### PR TITLE
AB#8546 - OpenShift Containerization Bugfixes

### DIFF
--- a/applications/Unity.GrantManager/.env.example
+++ b/applications/Unity.GrantManager/.env.example
@@ -1,3 +1,6 @@
+WEB_VERSION="v0.1.3"
+MIGRATOR_VERSION="v0.1.3"
+
 ASPNETCORE_ENVIRONMENT="Development"
 ASPNETCORE_URLS="https://+:443;http://+:80"
 

--- a/applications/Unity.GrantManager/docker-compose.yml
+++ b/applications/Unity.GrantManager/docker-compose.yml
@@ -4,7 +4,7 @@ name: unity_local
 
 services:
   unity-grantmanager-web:
-    image: 'image-registry.apps.silver.devops.gov.bc.ca/d18498-dev/unity-grantmanager-web:${TAG:-latest}'
+    image: 'image-registry.apps.silver.devops.gov.bc.ca/d18498-dev/unity-grantmanager-web:${WEB_VERSION:-latest}'
     build:
       context: .
       dockerfile: src/Unity.GrantManager.Web/Dockerfile
@@ -26,7 +26,7 @@ services:
       - common-network
 
   unity-data-dbmigrator:
-    image: 'image-registry.apps.silver.devops.gov.bc.ca/d18498-dev/unity-grantmanager-dbmigrator:${TAG:-latest}'
+    image: 'image-registry.apps.silver.devops.gov.bc.ca/d18498-dev/unity-grantmanager-dbmigrator:${MIGRATOR_VERSION:-latest}'
     build:
       context: .
       dockerfile: src/Unity.GrantManager.DbMigrator/Dockerfile

--- a/applications/Unity.GrantManager/modules/Volo.BasicTheme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Bundling/BasicThemeGlobalStyleContributor.cs
+++ b/applications/Unity.GrantManager/modules/Volo.BasicTheme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/Bundling/BasicThemeGlobalStyleContributor.cs
@@ -6,11 +6,40 @@ public class BasicThemeGlobalStyleContributor : BundleContributor
 {
     public override void ConfigureBundle(BundleConfigurationContext context)
     {
-        context.Files.Add("/themes/basic/fonts/*/*");
         context.Files.Add("/themes/basic/fluentui-icons.css");
         context.Files.Add("/themes/basic/fluenticons.min.css");
         context.Files.Add("/themes/basic/fonts.css");
         context.Files.Add("/themes/basic/layout.css");
         context.Files.Add("/themes/basic/unity-styles.css");
+
+        // Add assets for "/themes/basic/fonts/**/*"
+        context.Files.AddRange(new[] {
+            "/themes/basic/fonts/icons/Segoe-Fluent-Icons.ttf",
+            "/themes/basic/fonts/icons/Segoe-MDL2-Assets.ttf",
+            "/themes/basic/fonts/BCSans/BCSans-Bold.otf",
+            "/themes/basic/fonts/BCSans/BCSans-Bold.ttf",
+            "/themes/basic/fonts/BCSans/BCSans-Bold.woff",
+            "/themes/basic/fonts/BCSans/BCSans-Bold.woff2",
+            "/themes/basic/fonts/BCSans/BCSans-BoldItalic.otf",
+            "/themes/basic/fonts/BCSans/BCSans-BoldItalic.ttf",
+            "/themes/basic/fonts/BCSans/BCSans-BoldItalic.woff",
+            "/themes/basic/fonts/BCSans/BCSans-BoldItalic.woff2",
+            "/themes/basic/fonts/BCSans/BCSans-Italic.otf",
+            "/themes/basic/fonts/BCSans/BCSans-Italic.ttf",
+            "/themes/basic/fonts/BCSans/BCSans-Italic.woff",
+            "/themes/basic/fonts/BCSans/BCSans-Italic.woff2",
+            "/themes/basic/fonts/BCSans/BCSans-Light.otf",
+            "/themes/basic/fonts/BCSans/BCSans-Light.ttf",
+            "/themes/basic/fonts/BCSans/BCSans-Light.woff",
+            "/themes/basic/fonts/BCSans/BCSans-Light.woff2",
+            "/themes/basic/fonts/BCSans/BCSans-LightItalic.otf",
+            "/themes/basic/fonts/BCSans/BCSans-LightItalic.ttf",
+            "/themes/basic/fonts/BCSans/BCSans-LightItalic.woff",
+            "/themes/basic/fonts/BCSans/BCSans-LightItalic.woff2",
+            "/themes/basic/fonts/BCSans/BCSans-Regular.otf",
+            "/themes/basic/fonts/BCSans/BCSans-Regular.ttf",
+            "/themes/basic/fonts/BCSans/BCSans-Regular.woff",
+            "/themes/basic/fonts/BCSans/BCSans-Regular.woff2"
+        });
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Properties/launchSettings.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Properties/launchSettings.json
@@ -11,18 +11,20 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "Unity.GrantManager.Web": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:44342/",
+      "launchUrl": "https://localhost:44342/",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "ASPNETCORE_URLS": "http://+:8080;https://+:44342"
-      },
+      }
+    },
+    "Unity.GrantManager.Web": {
+        "commandName": "Project",
+        "launchBrowser": true,
+        "applicationUrl": "https://localhost:44342/",
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development",
+            "ASPNETCORE_URLS": "http://+:8080;https://+:44342"
+        },
     }
   }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Unity.GrantManager.Web.csproj
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Unity.GrantManager.Web.csproj
@@ -29,6 +29,12 @@
     <None Update="Pages\**\*.css">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Views\Shared\**\*.js">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Views\Shared\**\*.css">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.json
@@ -30,6 +30,6 @@
     "ClientSecret": "",
     "IdpHintKey": "kc_idp_hint",
     "IdpHint": "",
-    "UseHttpsRedirectLocally": false
+    "IsBehindTlsTerminationProxy": false
   }
 }


### PR DESCRIPTION
Added bugfixes that were causing errors in OpenShift and are now deployed in DEV:

1. Added direct references for font bundling. (Note: Bundling apparently doesn't support wildcard references)
2. Added references to the project file to include `Views/Shared/(*.js|*.css)` assets required for common widgets.
3. Simplified TLS Termination proxy switch logic for configuring application cookies and OIDC redirect URIs between local and OpenShift.