### PR TITLE
AB#8549 - comment timestamp

### DIFF
--- a/applications/Unity.GrantManager/modules/Volo.BasicTheme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/wwwroot/themes/basic/layout.js
+++ b/applications/Unity.GrantManager/modules/Volo.BasicTheme/src/Volo.Abp.AspNetCore.Mvc.UI.Theme.Basic/wwwroot/themes/basic/layout.js
@@ -12,5 +12,37 @@ $(function () {
         });
 
         return false;
-    });
+    });    
+
+    setTimezoneCookie();
 });
+
+function setTimezoneCookie() {
+    let timezone_cookie = "timezoneoffset";
+    let cookie = getCookie(timezone_cookie);
+    if (!cookie) {
+        setCookie(timezone_cookie, new Date().getTimezoneOffset(), 90);
+    }
+}
+
+function setCookie(cname, cvalue, exdays) {
+    const d = new Date();
+    d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000));
+    let expires = "expires=" + d.toUTCString();
+    document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+}
+
+function getCookie(cname) {
+    let name = cname + "=";
+    let ca = document.cookie.split(';');
+    for (const element of ca) {
+        let c = element;
+        while (c.charAt(0) == ' ') {
+            c = c.substring(1);
+        }
+        if (c.indexOf(name) == 0) {
+            return c.substring(name.length, c.length);
+        }
+    }
+    return "";
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/CommentsWidget/CommentsWidgetController.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/CommentsWidget/CommentsWidgetController.cs
@@ -12,7 +12,7 @@ namespace Unity.GrantManager.Web.Views.Shared.Components.CommentsWidget
         [HttpGet]
         [Route("RefreshComments")]
         public IActionResult Comments(Guid ownerId, CommentType commentType, Guid currentUserId)
-        {
+        { 
             return ViewComponent("CommentsWidget", new { ownerId, commentType, currentUserId });
         }
     }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/CommentsWidget/CommentsWidgetViewComponent.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/CommentsWidget/CommentsWidgetViewComponent.cs
@@ -37,8 +37,17 @@ namespace Unity.GrantManager.Web.Views.Shared.Components.CommentsWidget
             return View(model);
         }
 
-        private static IEnumerable<CommentViewModel> MapToCommentDisplay(IReadOnlyList<CommentDto> commentDtos)
+        private IEnumerable<CommentViewModel> MapToCommentDisplay(IReadOnlyList<CommentDto> commentDtos)
         {
+            // Hook in to the timezoneoffset cookie explicitly added, there surely must be a better way to do this 
+            var offsetValue = "0";
+            if (HttpContext.Request.Cookies.ContainsKey("timezoneoffset"))
+            {
+                _ = HttpContext.Request.Cookies.TryGetValue("timezoneoffset", out offsetValue);
+            }
+
+            _ = int.TryParse(offsetValue, out int offset);
+
             foreach (var item in commentDtos)
             {
                 yield return new CommentViewModel()
@@ -46,7 +55,7 @@ namespace Unity.GrantManager.Web.Views.Shared.Components.CommentsWidget
                     Badge = item.Commenter.GetUserBadge(),
                     Comment = item.Comment,
                     Commenter = item.Commenter,
-                    CreationTime = item.CreationTime,
+                    CreationTime = item.CreationTime.AddMinutes(-offset),
                     CreatorId = item.CreatorId,
                     Id = item.Id,
                     OwnerId = item.OwnerId

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/CommentsWidget/CommentsWidgetViewModel.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/CommentsWidget/CommentsWidgetViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Unity.GrantManager.Comments;
+using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Form.DatePicker;
 
 namespace Unity.GrantManager.Web.Views.Shared.Components.CommentsWidget
 {
@@ -18,7 +19,7 @@ namespace Unity.GrantManager.Web.Views.Shared.Components.CommentsWidget
     }
 
     public class CommentViewModel : CommentDto
-    {
+    {        
         public string Badge { get; set; } = string.Empty;
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/CommentsWidget/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/CommentsWidget/Default.cshtml
@@ -2,7 +2,6 @@
 @using Unity.GrantManager.Web.Views.Shared.Components.CommentsWidget;
 @using Volo.Abp.AspNetCore.Mvc.UI.Layout;
 @using Unity.GrantManager.Web.Pages.GrantApplications;
-
 @model CommentsWidgetViewModel
 @{
     Layout = null;
@@ -46,11 +45,10 @@
                     </div>
                     <div class="comment-lbl" data-id="@comment.Id">
                         <div>
-
-                         @comment.Comment
+                            @comment.Comment
                         </div>
                     </div>
-                    <div class="commented-time mt-3">@comment.CreationTime.ToLocalTime().ToString("yyyy-MM-dd h:mm tt")</div>
+                    <div class="commented-time mt-3">@comment.CreationTime.ToString("yyyy-MM-dd h:mm tt")</div>
                 </div>
 
                 <div class="single-comment edit-mode" data-id="@comment.Id"  style="display: none;">
@@ -64,4 +62,3 @@
         }
     }
 </div>
-

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/CommentsWidget/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/CommentsWidget/Default.js
@@ -73,7 +73,7 @@
                 .done(function () {
                     abp.notify.success(
                         'The comment has been created.'
-                    );
+                    );                    
                     PubSub.publish(commentType + '_refresh');
                 });
 
@@ -81,5 +81,5 @@
         catch (error) {
             console.log(error);
         }
-    }
+    }    
 });


### PR DESCRIPTION
- add a timestamp cookie to allow the server to determine client timezone offset
- so far only used in the comment widget where the time is displayed from the server side render