### PR TITLE
bugfix/AB#10462-Fix Datetime utc format p.m.

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Intakes/IntakeFormSubmissionManager.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Intakes/IntakeFormSubmissionManager.cs
@@ -44,7 +44,7 @@ namespace Unity.GrantManager.Intakes
         {
             IntakeMapping intakeMap = _intakeFormSubmissionMapper.MapFormSubmissionFields(applicationForm, formSubmission);
             intakeMap.SubmissionId = formSubmission.submission.id;
-            intakeMap.SubmissionDate = formSubmission.submission.date;
+            intakeMap.SubmissionDate = formSubmission.submission.createdAt;
             intakeMap.ConfirmationId = formSubmission.submission.confirmationId;
             using var uow = _unitOfWorkManager.Begin();
             var application = await CreateNewApplicationAsync(intakeMap, applicationForm);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Intakes/IntakeFormSubmissionManager.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Intakes/IntakeFormSubmissionManager.cs
@@ -76,7 +76,7 @@ namespace Unity.GrantManager.Intakes
                     ApplicationStatusId = submittedStatus.Id,
                     ReferenceNo = intakeMap.ConfirmationId ?? "{Confirmation ID}",
                     RequestedAmount = decimal.Parse(intakeMap.RequestedAmount ?? "0"),
-                    SubmissionDate = DateTime.Parse(intakeMap.SubmissionDate ?? DateTime.UtcNow.ToString(), CultureInfo.InvariantCulture),
+                    SubmissionDate = DateTime.Parse(intakeMap.SubmissionDate ?? DateTime.UtcNow.ToString("u"), CultureInfo.InvariantCulture),
                     City = intakeMap.PhysicalCity ?? "{City}", // To be determined from the applicant
                     EconomicRegion = intakeMap.EconomicRegion ?? "{Region}", // TBD how to calculate this - spacial lookup?
                     TotalProjectBudget = decimal.Parse(intakeMap.TotalProjectBudget ?? "0"),


### PR DESCRIPTION
In UAT the  DateTime.UtcNow.ToString()
seems to return the string '2023-11-15 6:40:23 p.m.' which does not parse
change to DateTime.UtcNow.ToString("u")
which should format the response to 2023-11-15 19:32:37Z

Locally I tested with the same form submission and it did return the DateTime as PM 
Not sure why on UAT it does this format
