### PR TITLE
AB#10685 Save empty decision date

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.cshtml
@@ -98,7 +98,7 @@
                     </abp-select>
                 </abp-column>
                 <abp-column size="_12" class="px-1">
-                    <abp-input type="date" asp-for="@Model.AssessmentResults.FinalDecisionDate" onchange="enableResultSaveBtn(this)" disabled="@(!Model.IsEditGranted)" abp-data-datepicker="false">
+                    <abp-input type="date" asp-for="@Model.AssessmentResults.FinalDecisionDate" onchange="document.getElementById('saveAssessmentResultBtn').disabled=false;" disabled="@(!Model.IsEditGranted)" abp-data-datepicker="false">
                     </abp-input>
                 </abp-column>
                 <abp-column size="_12" class="px-1 d-flex justify-content-end">

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.cshtml
@@ -98,7 +98,7 @@
                     </abp-select>
                 </abp-column>
                 <abp-column size="_12" class="px-1">
-                    <abp-input type="date" asp-for="@Model.AssessmentResults.FinalDecisionDate" onchange="document.getElementById('saveAssessmentResultBtn').disabled=false;" disabled="@(!Model.IsEditGranted)" abp-data-datepicker="false">
+                    <abp-input type="date" asp-for="@Model.AssessmentResults.FinalDecisionDate" onchange="enableResultSaveBtn({'value':'date'})" disabled="@(!Model.IsEditGranted)" abp-data-datepicker="false">
                     </abp-input>
                 </abp-column>
                 <abp-column size="_12" class="px-1 d-flex justify-content-end">


### PR DESCRIPTION
Fix for Bug:  Save button is not enabling when decision date is cleared.  Should be able to save empty decision date.