### PR TITLE
Bugfix/AB#12505 XSRF Lax

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/GrantManagerWebModule.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/GrantManagerWebModule.cs
@@ -120,7 +120,7 @@ public class GrantManagerWebModule : AbpModule
         {
             options.TokenCookie.Expiration = TimeSpan.FromDays(365);
             options.TokenCookie.SecurePolicy = CookieSecurePolicy.Always;
-            options.TokenCookie.SameSite = SameSiteMode.None;
+            options.TokenCookie.SameSite = SameSiteMode.Lax;
             options.TokenCookie.HttpOnly = false;
         });
         Configure<AbpClockOptions>(options =>
@@ -375,7 +375,10 @@ public class GrantManagerWebModule : AbpModule
                 OnAppendCookie = cookieContext =>
                 {
                     if (cookieContext.CookieName.Equals("XSRF-TOKEN"))
+                    {
                         cookieContext.CookieOptions.HttpOnly = false;
+                        cookieContext.CookieOptions.SameSite = SameSiteMode.Lax;
+                    }
                 }
             });
         }


### PR DESCRIPTION
- Set the XSRF to Lax - we are getting warnings about this cookie in its current mode for future deprecation, this is to try get ahead and not end up with unexpected breaking changes with updates versions of chrome in Q1 2024