### PR TITLE
Fix/AB#10661 connection string resolution

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/GrantManagerConsts.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/GrantManagerConsts.cs
@@ -11,4 +11,6 @@ public static class GrantManagerConsts
     public const string TenantDbSchema = null;
 
     public const string DefaultTenantName = "Default Grants Program";
+
+    public const string TenantConnectionStringName = "Tenant";
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/GrantManagerDefaultTenantSeederContributor.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/GrantManagerDefaultTenantSeederContributor.cs
@@ -45,7 +45,7 @@ namespace Unity.GrantManager
                     if (tenantConnectionString != null)
                     {
                         var newTenant = await _tenantManager.CreateAsync(GrantManagerConsts.DefaultTenantName);
-                        newTenant.ConnectionStrings.Add(new TenantConnectionString(newTenant.Id, "default", tenantConnectionString));
+                        newTenant.ConnectionStrings.Add(new TenantConnectionString(newTenant.Id, "Tenant", tenantConnectionString));
                         await _tenantRepository.InsertAsync(newTenant, true);
                     }
                 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/GrantManagerDefaultTenantSeederContributor.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/GrantManagerDefaultTenantSeederContributor.cs
@@ -41,11 +41,11 @@ namespace Unity.GrantManager
 
                 if (tenant == null)
                 {
-                    var tenantConnectionString = _configuration.GetConnectionString("Tenant");
+                    var tenantConnectionString = _configuration.GetConnectionString(GrantManagerConsts.TenantConnectionStringName);
                     if (tenantConnectionString != null)
                     {
                         var newTenant = await _tenantManager.CreateAsync(GrantManagerConsts.DefaultTenantName);
-                        newTenant.ConnectionStrings.Add(new TenantConnectionString(newTenant.Id, "Tenant", tenantConnectionString));
+                        newTenant.ConnectionStrings.Add(new TenantConnectionString(newTenant.Id, GrantManagerConsts.TenantConnectionStringName, tenantConnectionString));
                         await _tenantRepository.InsertAsync(newTenant, true);
                     }
                 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/EntityFrameworkCore/GrantTenantDbContext.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/EntityFrameworkCore/GrantTenantDbContext.cs
@@ -13,7 +13,7 @@ using Unity.GrantManager.Identity;
 
 namespace Unity.GrantManager.EntityFrameworkCore
 {
-    [ConnectionStringName("Tenant")]
+    [ConnectionStringName(GrantManagerConsts.TenantConnectionStringName)]
     public class GrantTenantDbContext : AbpDbContext<GrantTenantDbContext>
     {
         #region Domain Entities

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/EntityFrameworkCore/GrantTenantDbContextFactory.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/EntityFrameworkCore/GrantTenantDbContextFactory.cs
@@ -20,7 +20,7 @@ namespace Unity.GrantManager.EntityFrameworkCore
             var configuration = BuildConfiguration();
 
             var builder = new DbContextOptionsBuilder<GrantTenantDbContext>()
-                .UseNpgsql(configuration.GetConnectionString("Tenant"));
+                .UseNpgsql(configuration.GetConnectionString(GrantManagerConsts.TenantConnectionStringName));
 
             return new GrantTenantDbContext(builder.Options);
         }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Connection/ConnectionStringResolver.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Connection/ConnectionStringResolver.cs
@@ -32,7 +32,7 @@ namespace Unity.GrantManager.Web.Connection
 
         public override async Task<string> ResolveAsync(string? connectionStringName = null)
         {
-            if (connectionStringName == "Tenant"
+            if (connectionStringName == GrantManagerConsts.TenantConnectionStringName
                 && _currentUser.TenantId != null)
             {
                 _currentTenant.Change(_currentUser.TenantId);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Connection/ConnectionStringResolver.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Connection/ConnectionStringResolver.cs
@@ -1,0 +1,113 @@
+﻿using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+using System;
+using System.Threading.Tasks;
+using Volo.Abp.Data;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.MultiTenancy;
+using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp.Users;
+
+namespace Unity.GrantManager.Web.Connection
+{
+    [Dependency(ReplaceServices = true)]
+    public class MultiTenantConnectionStringResolver : DefaultConnectionStringResolver
+    {
+        private readonly ICurrentUser _currentUser;
+        private readonly ICurrentTenant _currentTenant;
+        private readonly IServiceProvider _serviceProvider;
+
+        public MultiTenantConnectionStringResolver(
+            IOptionsMonitor<AbpDbConnectionOptions> options,
+            ICurrentTenant currentTenant,
+            IServiceProvider serviceProvider,
+            ICurrentUser currentUser)
+
+            : base(options)
+        {
+            _currentTenant = currentTenant;
+            _serviceProvider = serviceProvider;
+            _currentUser = currentUser;
+        }
+
+        public override async Task<string> ResolveAsync(string? connectionStringName = null)
+        {
+            if (connectionStringName == "Tenant"
+                && _currentUser.TenantId != null)
+            {
+                _currentTenant.Change(_currentUser.TenantId);
+            }
+
+            if (_currentTenant.Id == null)
+            {
+                //No current tenant, fallback to default logic
+                return await base.ResolveAsync(connectionStringName);
+            }
+
+            var tenant = await FindTenantConfigurationAsync(_currentTenant.Id.Value);
+
+            if (tenant == null || tenant.ConnectionStrings.IsNullOrEmpty())
+            {
+                //Tenant has not defined any connection string, fallback to default logic
+                return await base.ResolveAsync(connectionStringName);
+            }
+
+            var tenantDefaultConnectionString = tenant.ConnectionStrings?.Default;
+
+            //Requesting default connection string...
+            if (connectionStringName == null ||
+                connectionStringName == ConnectionStrings.DefaultConnectionStringName)
+            {
+                //Return tenant's default or global default
+                return !tenantDefaultConnectionString.IsNullOrWhiteSpace()
+                    ? tenantDefaultConnectionString!
+                    : Options.ConnectionStrings.Default!;
+            }
+
+            //Requesting specific connection string...
+            var connString = tenant.ConnectionStrings?.GetOrDefault(connectionStringName);
+            if (!connString.IsNullOrWhiteSpace())
+            {
+                //Found for the tenant
+                return connString!;
+            }
+
+            //Fallback to the mapped database for the specific connection string
+            var database = Options.Databases.GetMappedDatabaseOrNull(connectionStringName);
+            if (database != null && database.IsUsedByTenants)
+            {
+                connString = tenant.ConnectionStrings?.GetOrDefault(database.DatabaseName);
+                if (!connString.IsNullOrWhiteSpace())
+                {
+                    //Found for the tenant
+                    return connString!;
+                }
+            }
+
+            //Fallback to tenant's default connection string if available
+            if (!tenantDefaultConnectionString.IsNullOrWhiteSpace())
+            {
+                return tenantDefaultConnectionString!;
+            }
+
+            return await base.ResolveAsync(connectionStringName);
+        }
+
+        [Obsolete("Use ResolveAsync method.")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Info Code Smell", "S1133:Deprecated code should be removed", Justification = "<Pending>")]
+        public override string Resolve(string? connectionStringName = null)
+        {
+            return ResolveAsync(connectionStringName).Result;
+        }
+
+        protected virtual async Task<TenantConfiguration?> FindTenantConfigurationAsync(Guid tenantId)
+        {
+            using var serviceScope = _serviceProvider.CreateScope();
+            var tenantStore = serviceScope
+                .ServiceProvider
+                .GetRequiredService<ITenantStore>();
+
+            return await tenantStore.FindAsync(tenantId);
+        }
+    }
+}


### PR DESCRIPTION
- Resolve the tenant database connection string by setting the tenant explicitly when required, this was falling back to the default and not actually using the one stored in the connection strings table for the tenant