### PR TITLE
AB#12761 - explicit set of version for the ABP cli install

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Dockerfile
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Dockerfile
@@ -38,7 +38,7 @@ RUN dotnet restore "src/Unity.GrantManager.Web/Unity.GrantManager.Web.csproj"
 COPY . .
 WORKDIR "/src/src/Unity.GrantManager.Web"
 
-RUN dotnet tool install -g Volo.Abp.Cli
+RUN dotnet tool install -g Volo.Abp.Cli --version 7.4.4
 ENV PATH="${PATH}:/root/.dotnet/tools"
 RUN dotnet dev-certs https --trust
 RUN abp install-libs


### PR DESCRIPTION
- explicit set of the ABP cli version in web dockerfile - the default install command is defaulting to the V8 version which is not compatible with .net 7
- have set explict to 7.4.4 which is the latest .net 7 cli version