### PR TITLE
AB#12800 - Update logging configuration

### DIFF
--- a/applications/Unity.GrantManager/.env.example
+++ b/applications/Unity.GrantManager/.env.example
@@ -23,6 +23,7 @@ UNITY_WEB_PORT_EXT_HTTPS="44342"
 UNITY_WEB_PORT_INT_HTTPS="443"
 App__SelfUrl="http://localhost:8082"
 ConnectionStrings__Default="Host=${UNITY_DB_HOST};port=${UNITY_DB_PORT};Database=${UNITY_POSTGRES_DB};Username=${UNITY_POSTGRES_USER};Password=${UNITY_POSTGRES_PASSWORD}"
+ConnectionStrings__Tenant="Host=${UNITY_DB_HOST};port=${UNITY_DB_PORT};Database=${UNITY_POSTGRES_TENANT_DB};Username=${UNITY_POSTGRES_TENANT_USER};Password=UNITY_POSTGRES_TENANT_PASSWORD}"
 StringEncryption__DefaultPassPhrase="********"
 
 ## DB MIGRATOR REVIEW

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.Development.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.Development.json
@@ -8,5 +8,36 @@
   },
   "StringEncryption": {
     "DefaultPassPhrase": "g2IuZx7PwXDvCmlW"
+  },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Information",
+        "Microsoft.EntityFrameworkCore": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] ({Properties}) {Message:lj}{NewLine}{Exception}"
+        }
+      },
+      {
+        "Name": "File",
+        "Args": {
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] ({Properties}) {Message:lj}{NewLine}{Exception}",
+          "path": "logs/log.txt",
+          "rollingInterval": "Day",
+          "rollOnFileSizeLimit": true,
+          "retainedFileCountLimit": 31,
+          "formatter": "Serilog.Formatting.Json.JsonFormatter, Serilog"
+        }
+      }
+    ],
+    "Enrich": [
+      "FromLogContext"
+    ]
   }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.json
@@ -80,10 +80,9 @@
         "Name": "File",
         "Args": {
           "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] ({Properties}) {Message:lj}{NewLine}{Exception}",
-          "path": "logs/log.txt",
+          "path": "app/logs/log.txt",
           "rollingInterval": "Day",
-          "rollOnFileSizeLimit": true,
-          "retainedFileCountLimit": 31,
+          "rollOnFileSizeLimit": true,          
           "formatter": "Serilog.Formatting.Json.JsonFormatter, Serilog"
         }
       }


### PR DESCRIPTION
- update serilog logging configuration, the path should now work and allow the logging to happen in the container, we can then set a volume to that app/logs folder to persist the logs
- there is a separate config for development with a 31 day limit and root folder
- also added a reference connection string for the tenant db in the sample env file for local docker dev