### PR TITLE
AB#12800 - Remove the app part of path for logs in config

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.json
@@ -80,9 +80,9 @@
         "Name": "File",
         "Args": {
           "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] ({Properties}) {Message:lj}{NewLine}{Exception}",
-          "path": "app/logs/log.txt",
+          "path": "logs/log.txt",
           "rollingInterval": "Day",
-          "rollOnFileSizeLimit": true,          
+          "rollOnFileSizeLimit": true,
           "formatter": "Serilog.Formatting.Json.JsonFormatter, Serilog"
         }
       }


### PR DESCRIPTION
- setting this as to a version that works as expected locally in both visual studio and docker dev
- this writes to the current vs solution folder /logs as well as the /app/logs folder in the docker container
- still need to figure out why the pathing isn't working in openshift for this