### PR TITLE
AB#12550 set default docker build parameters to v0.0.0+0000000

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Dockerfile
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Dockerfile
@@ -46,7 +46,7 @@ RUN abp install-libs
 FROM build AS publish
 ARG UNITY_BUILD_VERSION
 ARG UNITY_BUILD_REVISION
-RUN dotnet publish "Unity.GrantManager.Web.csproj" -c Release -p:Version=${UNITY_BUILD_VERSION:-1.0.0} -p:SourceRevisionId=${UNITY_BUILD_REVISION:-ee369fd} -p:UseAppHost=false -o /app/publish 
+RUN dotnet publish "Unity.GrantManager.Web.csproj" -c Release -p:Version=${UNITY_BUILD_VERSION:-0.0.0} -p:SourceRevisionId=${UNITY_BUILD_REVISION:-0000000} -p:UseAppHost=false -o /app/publish 
 
 FROM base AS final
 WORKDIR /app


### PR DESCRIPTION
Update the default docker build Version and SourceRevisionId to all zeros this will display in the application only if no parameter is passed during the docker build steps. 