### PR TITLE
feature/AB#12783-Fix default mapping expecting string instead of JSON…

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Mapping.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Mapping.cshtml
@@ -109,7 +109,6 @@
                         </div>
                     </abp-column>
                 </abp-row>
-
             </form>
         </div>
     </div>
@@ -161,7 +160,6 @@
         </abp-modal-footer>
     </abp-modal>
 
-
     <div class="content-div">
         <div class="buttons">
             <div class="buttons-div">
@@ -202,5 +200,5 @@
             </div>
         </div>
     </div>
-    </div>
+  </div>
 </div>

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Mapping.css
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Mapping.css
@@ -1,8 +1,9 @@
 ﻿.main-content {
     background-color: #f9f7f7;
     border: 1px solid black;
-    height: 630px;
-    padding: 4px
+    height: 550px;
+    padding: 4px;
+    padding-top: 2px;
 }
 
 .mapping-container {
@@ -27,6 +28,7 @@
     width: calc(65% - (.5em + 6px));
     float: left;
     min-height: 400px;
+    max-height: 500px;
     padding-top: 6px;
 }
 
@@ -34,6 +36,7 @@
     width: calc(35% - (.5em + 6px));
     float: right;
     min-height: 400px;
+    max-height: 500px;
     margin-top: 5px;
 }
 
@@ -76,7 +79,7 @@
     padding-left: 6px;
     margin: 4px;
     text-align: center;
-    font-size: 18px;
+    font-size: 16px;
     cursor: grab;
     background-image: linear-gradient(135deg, #f9f9fb 10%, #38598A 900%);
 }
@@ -201,6 +204,18 @@ thead tr:first-child th {
 
 table.dataTable {
     margin-top: 29px !important;
+}
+
+table.dataTable thead th {
+    font-size: 18px;
+}
+
+table.dataTable thead td {
+    font-size: 14px;
+}
+
+table.dataTable td {
+    font-size: 15px;
 }
 
 #intake-map-available-fields-column {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Mapping.css
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Mapping.css
@@ -122,7 +122,7 @@ table.dataTable thead th {
     background-color: #859ab9;
     color: white;
     font-weight: 500;
-    font-size: 21px;
+    font-size: 18px;
 }
 
 table.dataTable td {
@@ -206,9 +206,6 @@ table.dataTable {
     margin-top: 29px !important;
 }
 
-table.dataTable thead th {
-    font-size: 18px;
-}
 
 table.dataTable thead td {
     font-size: 14px;
@@ -220,6 +217,7 @@ table.dataTable td {
 
 #intake-map-available-fields-column {
     margin-top: 55px;
+    width: 96%;
 }
 
 .intake-mapping-title {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Mapping.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Mapping.js
@@ -153,12 +153,19 @@
                 for (let key of keys) {
                     let intakeProperty = key;
                     let chefsMappingProperty = existingMapping[intakeProperty];
-                    let intakeMappingCard = document.getElementById(intakeProperty);
+                    let intakeMappingCard = document.getElementById("unity"+intakeProperty);
                     let chefsMappingDiv = document.getElementById(chefsMappingProperty);
-                    chefsMappingDiv.appendChild(intakeMappingCard);
+                    if (chefsMappingDiv != null) {
+                        chefsMappingDiv.appendChild(intakeMappingCard);
+                    } else {
+                        abp.notify.error(
+                            '',
+                            'Could not map existing: ' + chefsMappingProperty
+                        );
+                    }
                 }
             } catch (err) {
-                console.log('Existing Mapping error');
+                console.log(err);
             }
         }
     }
@@ -295,7 +302,7 @@
                 let intakeFieldJson = JSON.parse(intakeField);
                 if(!excludedIntakeMappings.includes(intakeFieldJson.Name)) {
                     let dragableDiv = document.createElement('div');
-                    dragableDiv.id = intakeFieldJson.Name;
+                    dragableDiv.id = 'unity'+intakeFieldJson.Name;
                     dragableDiv.className = 'card';
                     dragableDiv.setAttribute("draggable", "true");
                     dragableDiv.innerHTML = intakeFieldJson.Name;


### PR DESCRIPTION
… Raw - FIX JS

I am adding a fix on the page that blew up the mapping columns when using mapping for non-standard chefs fields like

length.census_subdivision

If the user clicks on save at this point it will remove all of the previously entered mappings that did not get loaded properly.
I am ok with this for now as data values coming in as ugly json does not realy make sense.

![image](https://github.com/bcgov/Unity/assets/39963238/69f5c2d0-ece7-4867-b4cc-8816b0f9d674)
