### PR TITLE
AB#15465 Update github checkout to latest version

### DIFF
--- a/.github/workflows/docker-build-dev.yml
+++ b/.github/workflows/docker-build-dev.yml
@@ -29,7 +29,7 @@ jobs:
     outputs: 
       PROJECT: ${{steps.project.outputs.TARGET_PROJECT}}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Get BuildId
       id: commit
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -86,7 +86,7 @@ jobs:
     outputs: 
       PROJECT: ${{steps.project.outputs.TARGET_PROJECT}}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Get BuildId
       id: commit
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fix for failed merge to Dev branch, GitHub "Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3." update to checkout v4.