### PR TITLE
feature/AB#12241 Fix default mapping

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Intakes/IntakeFormSubmissionMapper.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Intakes/IntakeFormSubmissionMapper.cs
@@ -245,8 +245,7 @@ namespace Unity.GrantManager.Intakes
         private static IntakeMapping ApplyDefaultConfigurationMapping(dynamic data, dynamic form)
         {
             return new IntakeMapping()
-            {                
-                ProjectName = form.name is string ? form.name : null,
+            {
                 ApplicantName = data.applicantName is string ? data.applicantName : null,
                 Sector = data.sector is string ? data.sector : null,
                 TotalProjectBudget = data.totalProjectBudget is string ? data.totalProjectBudget : null,


### PR DESCRIPTION
Remove the original defaulting of Project Name to Form Name. 
This was done initially when we did not understand the requirement of how this was going to be mapped. 

It would be good to optionally show the form name as it is already show form category.
It would be called form name and not project name.
