### PR TITLE
Bugfix/AB#23461 - Set default max result counts to max available

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantManagerApplicationModule.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantManagerApplicationModule.cs
@@ -19,6 +19,7 @@ using Volo.Abp.Modularity;
 using Volo.Abp.PermissionManagement;
 using Volo.Abp.SettingManagement;
 using Volo.Abp.BackgroundWorkers.Quartz;
+using Volo.Abp.Application.Dtos;
 
 namespace Unity.GrantManager;
 
@@ -117,5 +118,9 @@ namespace Unity.GrantManager;
                     );
             }
         });
+
+        // Set the max defaults as max - we are using non serverside paging and this effect this
+        PagedAndSortedResultRequestDto.DefaultMaxResultCount = int.MaxValue;
+        PagedAndSortedResultRequestDto.MaxMaxResultCount = int.MaxValue;
     }
 }


### PR DESCRIPTION
- Set the default max page amounts for client side paging requests