### PR TITLE
Feature/ab#23663 synchronization part 3

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/ApplicationForms/IApplicationFormSycnronizationService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/ApplicationForms/IApplicationFormSycnronizationService.cs
@@ -14,7 +14,7 @@ namespace Unity.GrantManager.ApplicationForms
             CreateUpdateApplicationFormDto>
     {
         Task<IList<ApplicationFormDto>> GetConnectedApplicationFormsAsync();
-        Task<HashSet<string>> GetMissingSubmissions();
+        Task<HashSet<string>> GetMissingSubmissions(int numberOfDaysToCheck);
         Task<HashSet<string>> GetChefsSubmissions(ApplicationFormDto applicationFormDto, int numberOfDaysToCheck);
         HashSet<string> GetSubmissionsByForm(Guid applicationFormId);
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/ApplicationForms/IApplicationFormVersionService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/ApplicationForms/IApplicationFormVersionService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json.Linq;
+using System;
 using System.Threading.Tasks;
 using Unity.GrantManager.Forms;
 using Volo.Abp.Application.Dtos;
@@ -13,8 +14,10 @@ namespace Unity.GrantManager.ApplicationForms
             CreateUpdateApplicationFormVersionDto>
     {
         Task<bool> FormVersionExists(string chefsFormVersionId);
-        Task<bool> InitializePublishedFormVersion(dynamic chefsForm, Guid applicationFormId);                
+        Task<bool> InitializePublishedFormVersion(dynamic chefsForm, Guid applicationFormId, bool initializePublishedOnly);
         Task<string?> GetFormVersionSubmissionMapping(string chefsFormVersionId);
         Task<ApplicationFormVersionDto> UpdateOrCreateApplicationFormVersion(string chefsFormId, string chefsFormVersionId, Guid applicationFormId, dynamic chefsFormVersion);
+        Task<ApplicationFormVersionDto?> TryInitializeApplicationFormVersionWithToken(JToken token, Guid applicationFormId, string formVersionId, bool published);
+        Task<ApplicationFormVersionDto?> TryInitializeApplicationFormVersion(string? formId, int version, Guid applicationFormId, string formVersionId, bool published);
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Unity.GrantManager.Application.Contracts.csproj
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Unity.GrantManager.Application.Contracts.csproj
@@ -14,7 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
+	  <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
+  	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Volo.Abp.ObjectExtending" Version="7.4.0" />
     <PackageReference Include="Volo.Abp.Identity.Application.Contracts" Version="7.4.0" />
     <PackageReference Include="Volo.Abp.PermissionManagement.Application.Contracts" Version="7.4.0" />

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormAppService.cs
@@ -74,8 +74,8 @@ namespace Unity.GrantManager.ApplicationForms
                             input.ApplicationFormName = formName.ToString();
                             applicationFormDto = await base.UpdateAsync(id, input);
                         }
-
-                        await _applicationFormVersionAppService.InitializePublishedFormVersion(form, id);
+                        bool initializePublishedOnly = false;
+                        await _applicationFormVersionAppService.InitializePublishedFormVersion(form, id, initializePublishedOnly);
                     }
                 }
                 return applicationFormDto;

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormSycnronizationService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormSycnronizationService.cs
@@ -46,7 +46,7 @@ namespace Unity.GrantManager.ApplicationForms
         private List<Fact> _facts = new();
         private readonly RestClient _intakeClient;
         public List<ApplicationFormDto>? applicationFormDtoList { get; set; }
-        public HashSet<string> FormVersionsInitializedVersionHash { get; set; }
+        public HashSet<string> FormVersionsInitializedVersionHash { get; set; } = new HashSet<string>();
 
         public ApplicationFormSycnronizationService(
             ICurrentTenant currentTenant,

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormSycnronizationService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormSycnronizationService.cs
@@ -164,7 +164,7 @@ namespace Unity.GrantManager.ApplicationForms
                         AddFact("Application Form Name: ", applicationFormDto.ApplicationFormName);
                         AddFact("Missing Submissions Count: ", missingSubmissions.Count.ToString());
 
-                        if (missingSubmissions != null && missingSubmissions.Count > 0)
+                        if (missingSubmissions.Count > 0)
                         {
                             await SynchronizeFormSubmissions(missingSubmissions, applicationFormDto);
                         }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormSycnronizationService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormSycnronizationService.cs
@@ -44,7 +44,6 @@ namespace Unity.GrantManager.ApplicationForms
         private readonly ISubmissionsApiService _submissionsApiService;
         private readonly IIntakeFormSubmissionManager _intakeFormSubmissionManager;
         private List<Fact> _facts = new();
-        private HashSet<string> _formVersionsInitializedVersionHash = new HashSet<string>();
         private readonly RestClient _intakeClient;
         public List<ApplicationFormDto>? applicationFormDtoList { get; set; }
         public HashSet<string> FormVersionsInitializedVersionHash { get; set; }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormSycnronizationService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormSycnronizationService.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 using RestSharp;
 using RestSharp.Authenticators;
 using System;
@@ -12,11 +13,13 @@ using System.Threading.Tasks;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Forms;
 using Unity.GrantManager.Intakes;
+using Unity.GrantManager.Integration.Chefs;
 using Unity.GrantManager.TeamsNotifications;
 using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
+using Volo.Abp.MultiTenancy;
 using Volo.Abp.Security.Encryption;
 
 namespace Unity.GrantManager.ApplicationForms
@@ -34,105 +37,124 @@ namespace Unity.GrantManager.ApplicationForms
     {
         private readonly IStringEncryptionService _stringEncryptionService;
         private readonly IApplicationFormRepository _applicationFormRepository;
+        private readonly ICurrentTenant _currentTenant;
         private readonly IApplicationFormSubmissionRepository _applicationFormSubmissionRepository;
-        private readonly IChefsMissedSubmissionsRepository _chefsMissedSubmissionsRepository;
+        private readonly IApplicationFormVersionAppService _applicationFormVersionAppService;
         private readonly IConfiguration _configuration;
+        private readonly ISubmissionsApiService _submissionsApiService;
+        private readonly IIntakeFormSubmissionManager _intakeFormSubmissionManager;
+
+        private HashSet<string> _formVersionsInitializedVersionHash = new HashSet<string>();
+        private List<Fact> _facts = new ();
         private readonly RestClient _intakeClient;
-        private const int PREVIOS_DAY = -1;
+        public const int PREVIOS_DAY = -1;
+        public List<ApplicationFormDto>? applicationFormDtoList { get; set; }
 
-        public List<ApplicationFormDto>? ApplicationFormDtoList { get; set; }
-
-        public ApplicationFormSycnronizationService(IRepository<ApplicationForm,
+        public ApplicationFormSycnronizationService(
+            ICurrentTenant currentTenant,
+            IRepository<ApplicationForm,
             Guid> repository,
             RestClient restClient,
             IConfiguration configuration,
             IStringEncryptionService stringEncryptionService,
             IApplicationFormRepository applicationFormRepository,
             IApplicationFormSubmissionRepository applicationFormSubmissionRepository,
-            IChefsMissedSubmissionsRepository chefsMissedSubmissionsRepository)
+            IApplicationFormVersionAppService applicationFormVersionAppService,
+            IChefsMissedSubmissionsRepository chefsMissedSubmissionsRepository,
+            ISubmissionsApiService submissionsApiService,
+            IIntakeFormSubmissionManager intakeFormSubmissionManager,
+            IFormsApiService formsApiService)
             : base(repository)
         {
+            _currentTenant = currentTenant;
             _intakeClient = restClient;
             _configuration = configuration;
             _stringEncryptionService = stringEncryptionService;
             _applicationFormRepository = applicationFormRepository;
+            _submissionsApiService = submissionsApiService;
             _applicationFormSubmissionRepository = applicationFormSubmissionRepository;
-            _chefsMissedSubmissionsRepository = chefsMissedSubmissionsRepository;
+            _applicationFormVersionAppService = applicationFormVersionAppService;
+            _intakeFormSubmissionManager = intakeFormSubmissionManager;
         }
 
-        public async Task<HashSet<string>> GetMissingSubmissions()
+        private async Task SynchronizeFormSubmissions(HashSet<string> missingSubmissions, ApplicationFormDto applicationFormDto) {         
+            foreach (var submissionGuid in missingSubmissions)
+            {  
+                // Get the formVersionId from CHEFS by submissions id -> Submission Data
+                Guid.TryParse(applicationFormDto.ChefsApplicationFormGuid, out Guid chefsFormId);
+                Guid.TryParse(submissionGuid,out Guid chefsSubmissionId);
+
+                JObject? submissionData = await _submissionsApiService.GetSubmissionDataAsync(chefsFormId, chefsSubmissionId);
+                if (submissionData != null)
+                {
+                    JToken? tokenFormVersionId = submissionData.SelectToken("submission.formVersionId");
+
+                    if (tokenFormVersionId != null)
+                    {
+                        string formVersionId = tokenFormVersionId.ToString();
+                        if (_formVersionsInitializedVersionHash.Contains(formVersionId))
+                        {
+                            continue; // Continue to next if the form was initialized - no point in synching data if a new form version needs creating
+                        }
+                        
+                        JToken? tokenVersionVersion = submissionData.SelectToken("version.version");
+                        string tokenVersion = tokenVersionVersion != null ? tokenVersionVersion.ToString() : "0";
+                        int.TryParse(tokenVersion, out int version);                        
+                        bool formVersionExists = await _applicationFormVersionAppService.FormVersionExists(formVersionId);
+                        string formId = chefsFormId.ToString();
+                        if (!formVersionExists)
+                        {
+                            AddFact("Form Version did NOT exist in Unity: ", "" + version);
+                            AddFact("Version Created: ", "Please Fill in Mapping");
+                            Guid.TryParse(applicationFormDto.ChefsApplicationFormGuid, out Guid applicationFormIdGuid);
+                            await _applicationFormVersionAppService.TryInitializeApplicationFormVersion(formId, version, applicationFormIdGuid, formVersionId, false);
+                            _formVersionsInitializedVersionHash.Add(formVersionId);
+                        }
+                        else
+                        {
+                            ApplicationForm applicationForm = ObjectMapper.Map<ApplicationFormDto, ApplicationForm>(applicationFormDto);
+                            var result = await _intakeFormSubmissionManager.ProcessFormSubmissionAsync(applicationForm, submissionData);
+                            AddFact("Synchronizing Data - Form Version: ",  version + " Unity Submission ID: " + result);
+                        }
+                    }
+                }
+            }
+        }
+
+        public async Task<HashSet<string>> GetMissingSubmissions(int numberOfDaysToCheck = PREVIOS_DAY)
         {
+            _facts = new List<Fact>();
+
             HashSet<string> missingSubmissions = new HashSet<string>();
             // Get all forms with api keys
-            ApplicationFormDtoList = (List<ApplicationFormDto>?)await GetConnectedApplicationFormsAsync();
-            List<Fact> facts = new ();
+            applicationFormDtoList = (List<ApplicationFormDto>?)await GetConnectedApplicationFormsAsync();
 
-            if (ApplicationFormDtoList != null)
+            if (applicationFormDtoList != null)
             {
-                int numberOfDaysToCheck = PREVIOS_DAY;
-                Logger.LogInformation("Appform SYNC: Iterating Forms ");
-                foreach (ApplicationFormDto applicationFormDto in ApplicationFormDtoList)
+                AddFact("Forms Count: ",""+ applicationFormDtoList.Count);
+                foreach (ApplicationFormDto applicationFormDto in applicationFormDtoList)
                 {
                     try
                     {
                         HashSet<string> newChefsSubmissions = await GetChefsSubmissions(applicationFormDto, numberOfDaysToCheck);
                         HashSet<string> existingSubmissions = GetSubmissionsByForm(applicationFormDto.Id);
                         missingSubmissions = newChefsSubmissions.Except(existingSubmissions).ToHashSet();
-                        Logger.LogInformation("Appform SYNC: Looking up missing: " + missingSubmissions);
+
+                        AddFact("------------------------------------", "----------------------------------------");
+                        AddFact("Application Form Name: ", applicationFormDto.ApplicationFormName);
+                        AddFact("Missing Submissions Count: ", missingSubmissions.Count.ToString());
+
                         if (missingSubmissions != null && missingSubmissions.Count > 0)
                         {
-                            Logger.LogInformation("Appform SYNC: missingSubmissions: Count" + missingSubmissions.Count);
-                            await _chefsMissedSubmissionsRepository.InsertAsync(
-                                new ChefsMissedSubmission
-                                {
-                                    ChefsSubmissionGuids = string.Join(", ", missingSubmissions),
-                                    ChefsApplicationFormGuid = applicationFormDto.ChefsApplicationFormGuid,
-                                    TenantId = applicationFormDto.TenantId
-                                }
-                            );
-
-                            // Store the count of missing submissions and Application Form Name
-                            var fact = new Fact
-                            {
-                                Name = "Application Form Name: ",
-                                Value = applicationFormDto.ApplicationFormName
-                            };
-                            facts.Add(fact);
-
-                            fact = new Fact
-                            {
-                                Name = "Missing Submissions Count: ",
-                                Value = missingSubmissions.Count.ToString()
-                            };
-
-                            facts.Add(fact);
+                            await SynchronizeFormSubmissions(missingSubmissions, applicationFormDto);
                         }
-                    }
-                    catch (HttpRequestException hrex)
+                    } 
+                    catch (HttpRequestException hrex) 
                     {
                         string statusCode = hrex.StatusCode.ToString() ?? string.Empty;
-                        var fact = new Fact
-                        {
-                            Name = "Application Form ApiException: ",
-                            Value = applicationFormDto.ApplicationFormName
-                        };
-                        facts.Add(fact);
-
-                        fact = new Fact
-                        {
-                            Name = "Status Code: ",
-                            Value = statusCode
-                        };
-
-                        facts.Add(fact);
-
-                        fact = new Fact
-                        {
-                            Name = "Message: ",
-                            Value = hrex.Message
-                        };
-
-                        facts.Add(fact);
+                        AddFact("Application Form ApiException: ", applicationFormDto.ApplicationFormName);
+                        AddFact("Status Code: ", statusCode);
+                        AddFact("Message: ", hrex.Message);
                     }
                     catch (Exception ex)
                     {
@@ -141,12 +163,17 @@ namespace Unity.GrantManager.ApplicationForms
                 }
             }
 
+            string tenantName = "";
+            if (_currentTenant != null && !string.IsNullOrEmpty(_currentTenant.Name))
+            {
+                 tenantName = " -- Tenant: " + _currentTenant.Name;
+            }
+
             string? envInfo = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-            string activityTitle = "Review Missed Chefs Submissions";
+            string activityTitle = "Review Missed Chefs Submissions " + tenantName;
             string activitySubtitle = "Environment: " + envInfo;
             string teamsChannel = _configuration["Notifications:TeamsNotificationsWebhook"] ?? "";
-            Logger.LogInformation("Getting Teams Channel: " + teamsChannel + activitySubtitle);
-            await TeamsNotificationService.PostToTeamsAsync(teamsChannel, activityTitle, activitySubtitle, facts);
+            await TeamsNotificationService.PostToTeamsAsync(teamsChannel, activityTitle, activitySubtitle, _facts);
             return missingSubmissions ?? new HashSet<string>();
         }
 
@@ -170,7 +197,6 @@ namespace Unity.GrantManager.ApplicationForms
             string minDate = DateTime.Now.AddDays(numberOfDaysToCheck).ToString("yyyy-MM-dd");
             string maxDate = DateTime.Now.ToString("yyyy-MM-dd");
             string queryString = $"?createdAt[]={minDate}&createdAt[]={maxDate}";
-            Logger.LogInformation("ApplicationFormSynchronizationService queryString:  " + queryString);
             List<FormSubmissionSummaryDto>? pagedResult = await GetSubmissionsList(applicationFormDto, queryString);
             if (pagedResult != null && pagedResult.Count > 0)
             {
@@ -193,7 +219,6 @@ namespace Unity.GrantManager.ApplicationForms
             }
 
             string requestUrl = $"/forms/{applicationForm.ChefsApplicationFormGuid}/submissions";
-            Logger.LogInformation("ApplicationFormSynchronizationService calling requestUrl:  " + requestUrl);
             if (!string.IsNullOrEmpty(queryString))
             {
                 requestUrl += queryString;
@@ -231,8 +256,17 @@ namespace Unity.GrantManager.ApplicationForms
             };
 
             List<FormSubmissionSummaryDto>? jsonResponse = JsonSerializer.Deserialize<List<FormSubmissionSummaryDto>>(response.Content ?? string.Empty, submissionOptions);
-            Logger.LogInformation("ApplicationFormSynchronizationService jsonResponse:  " + jsonResponse);
             return jsonResponse;
+        }
+
+        private void AddFact(string Name, string Value)
+        {
+            var fact = new Fact
+            {
+                Name = Name,
+                Value = Value
+            };
+            _facts.Add(fact);
         }
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormSycnronizationService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormSycnronizationService.cs
@@ -46,8 +46,8 @@ namespace Unity.GrantManager.ApplicationForms
         private List<Fact> _facts = new();
         private HashSet<string> _formVersionsInitializedVersionHash = new HashSet<string>();
         private readonly RestClient _intakeClient;
-        public List<ApplicationFormDto>? applicationFormDtoList { get; set; }        
-        public HashSet<string> FormVersionsInitializedVersionHash { get => _formVersionsInitializedVersionHash; set => _formVersionsInitializedVersionHash = value; }
+        public List<ApplicationFormDto>? applicationFormDtoList { get; set; }
+        public HashSet<string> FormVersionsInitializedVersionHash { get; set; }
 
         public ApplicationFormSycnronizationService(
             ICurrentTenant currentTenant,

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormVersionAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormVersionAppService.cs
@@ -60,7 +60,7 @@ namespace Unity.GrantManager.ApplicationForms
             return dto;
         }
 
-        private JToken? GetFormVersionToken(dynamic chefsForm) {
+        private static JToken? GetFormVersionToken(dynamic chefsForm) {
             if (chefsForm == null) return null;
             JObject formObject = JObject.Parse(chefsForm.ToString());
             if (formObject == null) return null;
@@ -71,7 +71,7 @@ namespace Unity.GrantManager.ApplicationForms
 #pragma warning restore CS8600
         }
 
-        public async Task<bool> InitializePublishedFormVersion(dynamic chefsForm, Guid applicationFormId, bool initializePublishedOnly = true)
+        public async Task<bool> InitializePublishedFormVersion(dynamic chefsForm, Guid applicationFormId, bool initializePublishedOnly)
         {
             if (chefsForm == null) return false;
 
@@ -134,7 +134,7 @@ namespace Unity.GrantManager.ApplicationForms
             return null;
         }
 
-        public async Task<ApplicationFormVersionDto?> TryInitializeApplicationFormVersion(string? formId, int version, Guid applicationFormId, string formVersionId, bool published = true)
+        public async Task<ApplicationFormVersionDto?> TryInitializeApplicationFormVersion(string? formId, int version, Guid applicationFormId, string formVersionId, bool published)
         {
             try
             {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormVersionAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormVersionAppService.cs
@@ -11,6 +11,7 @@ using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Entities;
 using Volo.Abp.Domain.Repositories;
+using Volo.Abp.ObjectMapping;
 using Volo.Abp.Uow;
 
 namespace Unity.GrantManager.ApplicationForms
@@ -59,31 +60,41 @@ namespace Unity.GrantManager.ApplicationForms
             return dto;
         }
 
-        public async Task<bool> InitializePublishedFormVersion(dynamic chefsForm, Guid applicationFormId)
+        private JToken? GetFormVersionToken(dynamic chefsForm) {
+            if (chefsForm == null) return null;
+            JObject formObject = JObject.Parse(chefsForm.ToString());
+            if (formObject == null) return null;
+
+#pragma warning disable CS8600
+            JToken versionsToken = formObject["versions"];
+            return versionsToken; 
+#pragma warning restore CS8600
+        }
+
+        public async Task<bool> InitializePublishedFormVersion(dynamic chefsForm, Guid applicationFormId, bool initializePublishedOnly = true)
         {
             if (chefsForm == null) return false;
 
             try
             {
-                JObject formObject = JObject.Parse(chefsForm.ToString());
-                if (formObject == null) return false;
-#pragma warning disable CS8600
-                JToken versionsToken = formObject["versions"];
-#pragma warning restore CS8600
-                if (versionsToken == null) return false;
+                JToken versionsToken = GetFormVersionToken(chefsForm);
 
                 foreach (JToken childToken in versionsToken.Children().Where(t => t.Type == JTokenType.Object))
                 {
-                    if (TryParsePublished(childToken, out var formVersionId, out var published) && 
-                        published && (formVersionId != null && await FormVersionDoesNotExist(formVersionId)))
+                    if (TryParsePublished(childToken, out var formVersionId, out var published) 
+                            && formVersionId != null 
+                            && await FormVersionDoesNotExist(formVersionId))
                     {
-                        ApplicationFormVersion? applicationFormVersion = await TryInitializeApplicationFormVersion(childToken, applicationFormId, formVersionId);
+                        ApplicationFormVersionDto? applicationFormVersion = new ApplicationFormVersionDto();
+                        if ((initializePublishedOnly && published) || !initializePublishedOnly) {
+                            applicationFormVersion = await TryInitializeApplicationFormVersionWithToken(childToken, applicationFormId, formVersionId, published);
+                        }
+
                         if (applicationFormVersion != null)
                         {
                             await InsertApplicationFormVersion(applicationFormVersion);
                             return true;
                         }
-    
                     }
                 }
             }
@@ -107,28 +118,40 @@ namespace Unity.GrantManager.ApplicationForms
             return applicationFormVersion == null;
         }
 
-        private async Task<ApplicationFormVersion?> TryInitializeApplicationFormVersion(JToken token, Guid applicationFormId, string formVersionId)
+        public async Task<ApplicationFormVersionDto?> TryInitializeApplicationFormVersionWithToken(JToken token, Guid applicationFormId, string formVersionId, bool published)
         {
             try
             {
                 string? formId = token.Value<string>("formId");
+                int version = token.Value<int>("version");
+                return await TryInitializeApplicationFormVersion(formId, version, applicationFormId,formVersionId, published);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Initialization Exception: {ex.Message}", ex.Message);
+            }
+
+            return null;
+        }
+
+        public async Task<ApplicationFormVersionDto?> TryInitializeApplicationFormVersion(string? formId, int version, Guid applicationFormId, string formVersionId, bool published = true)
+        {
+            try
+            {
                 if (formId != null)
                 {
-                    int version = token.Value<int>("version");
-
                     var applicationFormVersion = new ApplicationFormVersion
                     {
                         ApplicationFormId = applicationFormId,
                         ChefsApplicationFormGuid = formId,
                         Version = version,
-                        Published = true,
+                        Published = published,
                         ChefsFormVersionGuid = formVersionId
                     };
 
                     var formVersion = await _formApiService.GetFormDataAsync(formId, formVersionId);
                     applicationFormVersion.AvailableChefsFields = _intakeFormSubmissionMapper.InitializeAvailableFormFields(formVersion);
-
-                    return applicationFormVersion;
+                    return ObjectMapper.Map<ApplicationFormVersion, ApplicationFormVersionDto>(applicationFormVersion);
                 }
             }
             catch (Exception ex)
@@ -139,8 +162,9 @@ namespace Unity.GrantManager.ApplicationForms
             return null;
         }
 
-        private async Task InsertApplicationFormVersion(ApplicationFormVersion applicationFormVersion)
+        private async Task InsertApplicationFormVersion(ApplicationFormVersionDto applicationFormVersionDto)
         {
+            ApplicationFormVersion applicationFormVersion = ObjectMapper.Map<ApplicationFormVersionDto, ApplicationFormVersion>(applicationFormVersionDto);
             await _applicationFormVersionRepository.InsertAsync(applicationFormVersion);
         }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormVersionAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormVersionAppService.cs
@@ -65,10 +65,8 @@ namespace Unity.GrantManager.ApplicationForms
             JObject formObject = JObject.Parse(chefsForm.ToString());
             if (formObject == null) return null;
 
-#pragma warning disable CS8600
-            JToken versionsToken = formObject["versions"];
-            return versionsToken; 
-#pragma warning restore CS8600
+            JToken? versionsToken = formObject["versions"];
+            return versionsToken;
         }
 
         public async Task<bool> InitializePublishedFormVersion(dynamic chefsForm, Guid applicationFormId, bool initializePublishedOnly)
@@ -77,8 +75,9 @@ namespace Unity.GrantManager.ApplicationForms
 
             try
             {
-                JToken versionsToken = GetFormVersionToken(chefsForm);
-
+                JToken? versionsToken = GetFormVersionToken(chefsForm);
+                if (versionsToken == null) return false;
+                
                 foreach (JToken childToken in versionsToken.Children().Where(t => t.Type == JTokenType.Object))
                 {
                     if (TryParsePublished(childToken, out var formVersionId, out var published) 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantManagerApplicationModule.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantManagerApplicationModule.cs
@@ -76,7 +76,8 @@ namespace Unity.GrantManager;
         {
             options.IsJobExecutionEnabled = configuration.GetValue<bool>("BackgroundJobs:IsJobExecutionEnabled");
             options.Quartz.IsAutoRegisterEnabled = configuration.GetValue<bool>("BackgroundJobs:Quartz:IsAutoRegisterEnabled");
-            options.IntakeResync.Expression = configuration.GetValue<string>("BackgroundJobs:IntakeResync:Expression") ?? "";            
+            options.IntakeResync.Expression = configuration.GetValue<string>("BackgroundJobs:IntakeResync:Expression") ?? "";
+            options.IntakeResync.NumDaysToCheck = configuration.GetValue<string>("BackgroundJobs:IntakeResync:NumDaysToCheck") ?? "-2";
         });
 
         context.Services.Configure<CssApiOptions>(

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/BackgroundWorkers/BackgroundJobsOptions.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/BackgroundWorkers/BackgroundJobsOptions.cs
@@ -14,5 +14,6 @@
     public class IntakeResyncOptions
     {
         public string Expression { get; set; } = string.Empty;
+        public string NumDaysToCheck { get; set; } = string.Empty;
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/BackgroundWorkers/IntakeSyncWorker.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/BackgroundWorkers/IntakeSyncWorker.cs
@@ -39,7 +39,12 @@ namespace Unity.GrantManager.Intakes.BackgroundWorkers
             Logger.LogInformation("Executing IntakeSyncWorker...");
 
             var tenants = await _tenantRepository.GetListAsync();
-            var numberDaysBack = -2;
+
+            if(!int.TryParse(_backgroundJobsOptions.Value.IntakeResync.NumDaysToCheck, out int numberDaysBack)) {
+                Logger.LogInformation("IntakeSyncWorker - Could not parse number of Days...");
+                return;
+            }
+
             foreach (var tenant in tenants)
             {
                 using (_currentTenant.Change(tenant.Id))

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/BackgroundWorkers/IntakeSyncWorker.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/BackgroundWorkers/IntakeSyncWorker.cs
@@ -39,12 +39,12 @@ namespace Unity.GrantManager.Intakes.BackgroundWorkers
             Logger.LogInformation("Executing IntakeSyncWorker...");
 
             var tenants = await _tenantRepository.GetListAsync();
-
+            var numberDaysBack = -2;
             foreach (var tenant in tenants)
             {
                 using (_currentTenant.Change(tenant.Id))
                 {
-                    await _applicationFormSynchronizationService.GetMissingSubmissions();
+                    await _applicationFormSynchronizationService.GetMissingSubmissions(numberDaysBack);
                 }
             }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.Development.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.Development.json
@@ -14,8 +14,9 @@
     "Quartz": {
       "IsAutoRegisterEnabled": false
     },
-    "IntakeResync": {      
-      "Expression": "0 0/1 * * * ?"
+    "IntakeResync": {
+      "Expression": "0 0/1 * * * ?",
+      "NumDaysToCheck": "-2"
     }
   },
   "Notifications": {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.json
@@ -15,7 +15,8 @@
       "IsAutoRegisterEnabled": true
     },
     "IntakeResync": {
-      "Expression": "0 0 1 * * ?"
+      "Expression": "0 0 1 * * ?",
+      "NumDaysToCheck": "-2"
     }
   },
   "Notifications": {


### PR DESCRIPTION
The synchronize now performs a get request to chefs for 2 days of missing requests.
The get method/sycnh does not care if the submission button was not named correctly.

This method hypothetically could be called more often but hopefully it is not needed if we can get past chefs issues of not posting when the submit button is not named correctly.

This synchronization will check to see if the version of the form mapping exists. 
If it does not it will try to create  the default mapping and then will inform the notifications channel that the version was initialized and that the custom mapping needs doing.

The next day that this is run and the default version mapping exists it will do the synchronization which I don't know if it is the best approach.

Discussed with Stephan, for now we are ok with pushing through submissions with default mapping.
Because of our due dilligence on verifying that for every submision has a mapping right now this is not an issue.
It will become an issue when we have multiple onboards and we can not control the flow

