### PR TITLE
bugfix/AB#23845 - Add arrow keys to allowed chars for scores widget

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentScoresWidget/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentScoresWidget/Default.js
@@ -45,8 +45,11 @@ function updateSum() {
     $('#subTotal').val(sum);
 }
 
-function positiveIntegersOnly(e) {
-    if (e.keyCode === 9 || e.keyCode === 8) {
+function positiveIntegersOnly(e) {    
+    if (e.keyCode === 9
+        || e.keyCode === 8
+        || e.keyCode === 37
+        || e.keyCode === 39) {
         return true;
     }
     if(e.target?.value?.length >= 2 ) {


### PR DESCRIPTION
- allow the left and right arrow keys as valid input in the assessment scores widget