### PR TITLE
Feature/ab#23923 ensure build no is visible

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/Themes/UX2/Components/Footer/Default.cshtml
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/Themes/UX2/Components/Footer/Default.cshtml
@@ -1,0 +1,12 @@
+﻿@using System.Reflection
+
+<footer class="bg-light text-center mt-auto">
+    <div class="text-muted container">
+        <p class="mb-0">
+            UGM @(Assembly
+             .GetEntryAssembly()
+             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+             .InformationalVersion)
+        </p>
+    </div>
+</footer>

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/Themes/UX2/Components/Footer/FooterViewComponent.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/Themes/UX2/Components/Footer/FooterViewComponent.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Volo.Abp.AspNetCore.Mvc;
+
+namespace Unity.AspNetCore.Mvc.UI.Theme.UX2.Themes.UX2.Components.Footer;
+
+public class FooterViewComponent : AbpViewComponent
+{
+    public virtual IViewComponentResult Invoke()
+    {
+        return View("~/Themes/UX2/Components/Footer/Default.cshtml");
+    }
+}

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/Themes/UX2/Layouts/Application.cshtml
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/Themes/UX2/Layouts/Application.cshtml
@@ -1,5 +1,7 @@
-﻿@using Unity.AspNetCore.Mvc.UI.Theme.UX2.Bundling;
+﻿@using System.Reflection
+@using Unity.AspNetCore.Mvc.UI.Theme.UX2.Bundling;
 @using Unity.AspNetCore.Mvc.UI.Theme.UX2.Themes.UX2.Components.ContentTitle;
+@using Unity.AspNetCore.Mvc.UI.Theme.UX2.Themes.UX2.Components.Footer
 @using Unity.AspNetCore.Mvc.UI.Theme.UX2.Themes.UX2.Components.MainNavbar;
 
 @using Volo.Abp.AspNetCore.Mvc.AntiForgery;
@@ -65,8 +67,6 @@
 <body class="abp-application-layout @rtl">
     @await Component.InvokeLayoutHookAsync(LayoutHooks.Body.First, StandardLayouts.Application)
 
-
-
     @if (@isHomePage)
     {
         @(await Component.InvokeAsync<HomeTopbarViewComponent>())        
@@ -92,11 +92,14 @@
                     </div>
                 </div>
 
-                @RenderBody()
+                @RenderBody()               
+
             </div>
         </div>
         @await Component.InvokeLayoutHookAsync(LayoutHooks.PageContent.Last, StandardLayouts.Application)
     </div>
+
+    @(await Component.InvokeAsync<FooterViewComponent>())
 
     <abp-script-bundle name="@UnityThemeUX2Bundles.Scripts.Global" />
 
@@ -109,5 +112,6 @@
     @await RenderSectionAsync("scripts", false)
 
     @await Component.InvokeLayoutHookAsync(LayoutHooks.Body.Last, StandardLayouts.Application)
+   
 </body>
 </html>

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.css
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.css
@@ -9,10 +9,6 @@ html, body {
     font-family: 'BCSans', var(--bs-font-sans-serif) !important;
 }
 
-body {
-    overflow: hidden;
-}
-
 
 .btn {
     --bs-btn-border-radius: 0.1875rem;
@@ -655,4 +651,9 @@ input[type=number]::-webkit-outer-spin-button {
 .div-btn-form
 {
     margin-right:2rem;
+}
+
+footer {
+    padding: 0.3rem 0; 
+    font-size: 0.65rem; 
 }

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.css
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.css
@@ -9,6 +9,12 @@ html, body {
     font-family: 'BCSans', var(--bs-font-sans-serif) !important;
 }
 
+/*This is the usual setting where page will have its own scrollbar when content overflows
+    If we set it to hidden, scrollbar goes away and so does the footer!
+*/
+body{
+    overflow:auto
+}
 
 .btn {
     --bs-btn-border-radius: 0.1875rem;


### PR DESCRIPTION
In uX1.0, the main body css used overflow hidden... probably because we did not want a scrollbar anywhere since the view components were themselves managing the scrolling. 

With that the footer won't be seen at any cost since it is hidden by the overflow. 

So currently keeping it to auto, footer is seen but this may have consequences.

Other option is to show build version in menu itself, let me know.