### PR TITLE
Feature/ab#24088 payment cas response modal

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application.Contracts/PaymentRequests/PaymentDetailsDto.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application.Contracts/PaymentRequests/PaymentDetailsDto.cs
@@ -22,6 +22,7 @@ namespace Unity.Payments.PaymentRequests
         public string ContractNumber { get; set; } = string.Empty;
         public string SupplierNumber { get; set; } = string.Empty;
         public string CorrelationProvider { get; set; } = string.Empty;
+        public string? CasResponse { get; set; }
 
         public Collection<ExpenseApprovalDto> ExpenseApprovals { get; set; } = [];
     }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application.Contracts/PaymentRequests/PaymentRequestDto.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application.Contracts/PaymentRequests/PaymentRequestDto.cs
@@ -25,6 +25,7 @@ namespace Unity.Payments.PaymentRequests
         public string ContractNumber { get; set; }
         public string SupplierNumber { get; set; }
         public  string CorrelationProvider { get;  set; } = string.Empty;
+        public string? CasResponse { get; set; }
 
         public  Collection<ExpenseApprovalDto> ExpenseApprovals { get;  set; }
 

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/EntityFrameworkCore/Repositories/PaymentRequestRepository.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/EntityFrameworkCore/Repositories/PaymentRequestRepository.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Linq.Dynamic.Core;
 using System.Threading.Tasks;
 using Unity.Payments.Domain.PaymentRequests;
 using Unity.Payments.EntityFrameworkCore;

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/EntityFrameworkCore/Repositories/PaymentRequestRepository.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/EntityFrameworkCore/Repositories/PaymentRequestRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Linq.Dynamic.Core;
 using System.Threading.Tasks;
 using Unity.Payments.Domain.PaymentRequests;
 using Unity.Payments.EntityFrameworkCore;
@@ -29,7 +30,7 @@ namespace Unity.Payments.Repositories
               // Don't include declined - right now we don't know how to set status
               .GroupBy(p => p.CorrelationId)
               .Select(p => p.Sum(q => q.Amount))
-              .First();
+              .FirstOrDefault();
 
             return applicationPaymentRequestsTotal;
         }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CasPaymentRequestResponse.cshtml
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CasPaymentRequestResponse.cshtml
@@ -1,7 +1,6 @@
 ﻿@page
 @using Microsoft.Extensions.Localization
 @using Unity.Payments.Localization;
-@using Volo.Abp.AspNetCore.Mvc.UI.Layout;
 @using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Modal;
 @model Unity.Payments.Web.Pages.Payments.DisplayCasPaymentRequestResponseModel
 @inject IStringLocalizer<PaymentsResource> L

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CasPaymentRequestResponse.cshtml
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CasPaymentRequestResponse.cshtml
@@ -1,0 +1,27 @@
+﻿@page
+@using Microsoft.Extensions.Localization
+@using Unity.Payments.Localization;
+@using Volo.Abp.AspNetCore.Mvc.UI.Layout;
+@using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Modal;
+@model Unity.Payments.Web.Pages.Payments.DisplayCasPaymentRequestResponseModel
+@inject IStringLocalizer<PaymentsResource> L
+
+@{
+    Layout = null;
+}
+<form method="post" asp-page-handler="OnPostAsync" id="paymentform">
+    <abp-modal size="ExtraLarge" id="cas-payment-response-modal">
+        <abp-modal-header class="payment-modal-header" title="CAS Payment Request Response"></abp-modal-header>
+        <abp-modal-body>
+            <abp-card>
+                <abp-card-body class="payment-card">
+                    @Html.Raw(Model.CasPaymentResponse)
+                </abp-card-body>
+            </abp-card>
+        </abp-modal-body>
+        <abp-modal-footer>
+            <button class="btn btn-secondary" data-bs-dismiss="modal" type="button">Close</button>
+        </abp-modal-footer>
+    </abp-modal>
+</form>
+

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CasPaymentRequestResponse.cshtml.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CasPaymentRequestResponse.cshtml.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Volo.Abp.AspNetCore.Mvc.UI.RazorPages;
+
+
+namespace Unity.Payments.Web.Pages.Payments
+{
+    public class DisplayCasPaymentRequestResponseModel : AbpPageModel
+    {
+
+        [BindProperty]
+        public string CasPaymentResponse { get; set; }
+
+        public DisplayCasPaymentRequestResponseModel()
+        {
+        }
+
+        public async Task OnGetAsync(string casResponse)
+        {
+            string pattern = ";";
+            string replace = "<br>";
+
+            string formattedResponse = Regex.Replace(casResponse,
+                            pattern,
+                            replace,
+                            RegexOptions.None);
+            CasPaymentResponse = formattedResponse;
+        }
+    }
+}

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CasPaymentRequestResponse.cshtml.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CasPaymentRequestResponse.cshtml.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Volo.Abp.AspNetCore.Mvc.UI.RazorPages;
+using System;
 
 
 namespace Unity.Payments.Web.Pages.Payments
@@ -10,15 +11,10 @@ namespace Unity.Payments.Web.Pages.Payments
     {
 
         [BindProperty]
-        public string CasPaymentResponse { get; set; }
+        public string CasPaymentResponse { get; set; } = string.Empty;
         private static int OneMinuteMilliseconds = 60000;
-        
-        public DisplayCasPaymentRequestResponseModel()
-        {
-        }
 
-
-        public async Task OnGetAsync(string casResponse)
+        public ActionResult OnGet(string casResponse)
         {
             string pattern = ";";
             string replace = "<br>";
@@ -29,6 +25,7 @@ namespace Unity.Payments.Web.Pages.Payments
                             RegexOptions.None,
                             TimeSpan.FromMilliseconds(OneMinuteMilliseconds));
             CasPaymentResponse = formattedResponse;
+            return Page();
         }
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CasPaymentRequestResponse.cshtml.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CasPaymentRequestResponse.cshtml.cs
@@ -11,10 +11,12 @@ namespace Unity.Payments.Web.Pages.Payments
 
         [BindProperty]
         public string CasPaymentResponse { get; set; }
-
+        private static int OneMinuteMilliseconds = 60000;
+        
         public DisplayCasPaymentRequestResponseModel()
         {
         }
+
 
         public async Task OnGetAsync(string casResponse)
         {
@@ -24,7 +26,8 @@ namespace Unity.Payments.Web.Pages.Payments
             string formattedResponse = Regex.Replace(casResponse,
                             pattern,
                             replace,
-                            RegexOptions.None);
+                            RegexOptions.None,
+                            TimeSpan.FromMilliseconds(OneMinuteMilliseconds));
             CasPaymentResponse = formattedResponse;
         }
     }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.css
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.css
@@ -16,3 +16,9 @@
     border: var(--bs-border-width) solid;
     border-color: var(--bs-border-color);
 }
+
+.info-btn {
+    font-size: 13pt;
+    font-family: BCSans, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    font-weight: 100;
+}

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.js
@@ -346,6 +346,7 @@ $(function () {
         };
     }
     function getCASResponseColumn() {
+        // Add button to view response modal
         return {
             title: l('ApplicationPaymentListTable:CASResponse'),
             name: 'CASResponse',
@@ -353,7 +354,10 @@ $(function () {
             className: 'data-table-header',
             index: 14,
             render: function (data) {
-                return formatDate(data);
+                if(data+"" !== "undefined" && data.length > 0) {
+                    return '<button class="btn btn-light" type="button" onclick="openCasResponseModal(\'' + data + '\');"><i class="fl fl-search"></i></button>';
+                }
+                return  '{Not Available}';
             }
         };
     }
@@ -431,3 +435,14 @@ $(function () {
         selectedPaymentIds = [];
     });
 });
+
+
+let casPaymentResponseModal = new abp.ModalManager({
+    viewUrl: '../PaymentRequests/CasPaymentRequestResponse'
+});
+
+function openCasResponseModal(casResponse) {
+    casPaymentResponseModal.open({
+        casResponse: casResponse
+    });
+}

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.js
@@ -355,7 +355,7 @@ $(function () {
             index: 14,
             render: function (data) {
                 if(data+"" !== "undefined" && data.length > 0) {
-                    return '<button class="btn btn-light" type="button" onclick="openCasResponseModal(\'' + data + '\');"><i class="fl fl-search"></i></button>';
+                    return '<button class="btn btn-light info-btn" type="button" onclick="openCasResponseModal(\'' + data + '\');">View Response<i class="fl fl-mapinfo"></i></button>';
                 }
                 return  '{Not Available}';
             }

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/fluentui-icons.css
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/fluentui-icons.css
@@ -185,6 +185,10 @@
     content: '\E721';
 }
 
+.fl-mapinfo:before {
+    content: '\E816';
+}
+
 .fl-add-to:before {
     content: '\ECC8';
 }


### PR DESCRIPTION
This pull request also fixes an issue in the payment creation where there are no payments. 
Was causing a no items on the sum of the query when creating a payment.

Simple dispaly of cas response:
![image](https://github.com/bcgov/Unity/assets/39963238/dd857dc8-5cfc-4162-ac39-8d3e148f9197)
![image](https://github.com/bcgov/Unity/assets/39963238/df242bf9-2e4d-463e-be03-dfb7b497b8f3)
