### PR TITLE
bugfix/AB#25349 - Event Submission Validation

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Notifications/src/Unity.Notifications.Application/TeamsNotifications/TeamsNotificationService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Notifications/src/Unity.Notifications.Application/TeamsNotifications/TeamsNotificationService.cs
@@ -12,7 +12,17 @@ namespace Unity.Notifications.TeamsNotifications
 {
     public class TeamsNotificationService
     {
-        protected TeamsNotificationService() : base() { }
+        public TeamsNotificationService() : base() { }
+        private List<Fact> _facts = new List<Fact>();
+
+        public async Task PostFactsToTeamsAsync(string teamsChannel, string activityTitle, string activitySubtitle)
+        {
+            if (!teamsChannel.IsNullOrEmpty())
+            {
+                string messageCard = InitializeMessageCard(activityTitle, activitySubtitle, _facts);
+                await PostToTeamsChannelAsync(teamsChannel, messageCard);
+            }
+        }
 
         public static async Task PostToTeamsAsync(string teamsChannel, string activityTitle, string activitySubtitle, List<Fact> facts)
         {
@@ -20,6 +30,18 @@ namespace Unity.Notifications.TeamsNotifications
                 string messageCard = InitializeMessageCard(activityTitle, activitySubtitle, facts);
                 await PostToTeamsChannelAsync(teamsChannel, messageCard);
             }
+        }
+
+        public List<Fact> AddFact(string Name, string Value)
+        {
+            var fact = new Fact
+            {
+                Name = Name,
+                Value = Value
+            };
+
+            _facts.Add(fact);
+            return _facts;
         }
 
         private static class ChefsEventTypesConsts

--- a/applications/Unity.GrantManager/modules/Unity.Notifications/src/Unity.Notifications.Application/TeamsNotifications/TeamsNotificationService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Notifications/src/Unity.Notifications.Application/TeamsNotifications/TeamsNotificationService.cs
@@ -13,7 +13,7 @@ namespace Unity.Notifications.TeamsNotifications
     public class TeamsNotificationService
     {
         public TeamsNotificationService() : base() { }
-        private List<Fact> _facts = new List<Fact>();
+        private readonly List<Fact> _facts = new List<Fact>();
 
         public async Task PostFactsToTeamsAsync(string teamsChannel, string activityTitle, string activitySubtitle)
         {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Events/EventSubscriptionConfirmationDto.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Events/EventSubscriptionConfirmationDto.cs
@@ -4,6 +4,7 @@ namespace Unity.GrantManager.Events
 {
     public record EventSubscriptionConfirmationDto
 	{
-        public Guid ConfirmationId { get; set; }
+        public Guid? ConfirmationId { get; set; }
+        public string? ExceptionMessage { get; set; }
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/IntakeSubmissionAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/IntakeSubmissionAppService.cs
@@ -1,14 +1,18 @@
-﻿using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Linq;
+using System.Security.Policy;
 using System.Threading.Tasks;
 using Unity.GrantManager.ApplicationForms;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Events;
 using Unity.GrantManager.Exceptions;
+using Unity.GrantManager.Identity;
 using Unity.GrantManager.Intake;
 using Unity.GrantManager.Integration.Chefs;
+using Unity.Notifications.TeamsNotifications;
 using Volo.Abp;
 
 namespace Unity.GrantManager.Intakes
@@ -22,13 +26,15 @@ namespace Unity.GrantManager.Intakes
         private readonly ISubmissionsApiService _submissionsIntService;
         private readonly IApplicationFormVersionAppService _applicationFormVersionAppService;
         private readonly IOptions<IntakeClientOptions> _intakeClientOptions;
+        private readonly IConfiguration _configuration;
 
         public IntakeSubmissionAppService(IIntakeFormSubmissionManager intakeFormSubmissionManager,
             IFormsApiService formsApiService,
             ISubmissionsApiService submissionsIntService,
             IApplicationFormRepository applicationFormRepository,
             IApplicationFormVersionAppService applicationFormVersionAppService,
-            IOptions<IntakeClientOptions> intakeClientOptions)
+            IOptions<IntakeClientOptions> intakeClientOptions,
+            IConfiguration configuration)
         {
             _intakeFormSubmissionManager = intakeFormSubmissionManager;
             _submissionsIntService = submissionsIntService;
@@ -36,6 +42,7 @@ namespace Unity.GrantManager.Intakes
             _formsApiService = formsApiService;
             _applicationFormVersionAppService = applicationFormVersionAppService;
             _intakeClientOptions = intakeClientOptions;
+            _configuration = configuration;
         }
 
         public async Task<EventSubscriptionConfirmationDto> CreateIntakeSubmissionAsync(EventSubscriptionDto eventSubscriptionDto)
@@ -48,23 +55,11 @@ namespace Unity.GrantManager.Intakes
 
             JObject submissionData = await _submissionsIntService.GetSubmissionDataAsync(eventSubscriptionDto.FormId, eventSubscriptionDto.SubmissionId) ?? throw new InvalidFormDataSubmissionException();
 
-            // If there are no mappings initialize the available
-            bool formVersionExists = await _applicationFormVersionAppService.FormVersionExists(eventSubscriptionDto.FormVersion.ToString());
-
-            dynamic? formVersion = null;
-
-            if (!formVersionExists)
-            {
-                formVersion = await _formsApiService.GetFormDataAsync(eventSubscriptionDto.FormId.ToString(),
-                    eventSubscriptionDto.FormVersion.ToString())
-                    ?? throw new ApplicationFormSetupException("Application Form Version Not Registered - Unknown Version");
-            }
-
-            if (!formVersionExists && !_intakeClientOptions.Value.AllowUnregisteredVersions)
-            {
-                ThrowVersionNotRegisteredExceptionIfRequired(formVersion);
-            }
-
+            bool validSubmission = await ValidateSubmission(eventSubscriptionDto, submissionData);
+            if (!validSubmission) {
+                return new EventSubscriptionConfirmationDto() { ExceptionMessage = "An Error Occured Validating the Chefs Submission" };
+            } 
+            
             JToken? token = submissionData.SelectToken("submission.formVersionId");
             if (token != null)
             {
@@ -75,11 +70,61 @@ namespace Unity.GrantManager.Intakes
             return new EventSubscriptionConfirmationDto() { ConfirmationId = result };
         }
 
-        private static void ThrowVersionNotRegisteredExceptionIfRequired(dynamic? formVersion)
+        private async Task<bool> ValidateSubmission(EventSubscriptionDto eventSubscriptionDto, JObject submissionData)
         {
-            var version = ((JObject)formVersion!).SelectToken("version");
-            var published = ((JObject)formVersion!).SelectToken("published");
-            throw new ApplicationFormSetupException($"Application Form Version Not Registerd - Version: {version} Published: {published}");
+            JToken? tokenDraft = submissionData.SelectToken("submission.draft");
+            
+            if (tokenDraft != null && tokenDraft.ToString() == "True") {
+                string factName = "A draft submission was submitted and should not have been";
+                string factValue = $"FormId: {eventSubscriptionDto.FormId} SubmissionID: {eventSubscriptionDto.SubmissionId}";
+                SendTeamsNotification(factName, factValue);
+                return false;
+            }
+
+            JToken? tokenDeleted = submissionData.SelectToken("submission.deleted");
+            if (tokenDeleted != null && tokenDeleted.ToString() == "True") {
+                string factName = "A deleted submission was submitted - user navigated back and got a success message from chefs";
+                string factValue = $"FormId: {eventSubscriptionDto.FormId} SubmissionID: {eventSubscriptionDto.SubmissionId}";
+                SendTeamsNotification(factName, factValue);
+            }
+
+            // If there are no mappings initialize the available
+            bool formVersionExists = await _applicationFormVersionAppService.FormVersionExists(eventSubscriptionDto.FormVersion.ToString());
+            dynamic? formVersion = null;
+
+            if (!formVersionExists)
+            {
+                formVersion = await _formsApiService.GetFormDataAsync(eventSubscriptionDto.FormId.ToString(),
+                    eventSubscriptionDto.FormVersion.ToString());
+
+                if(formVersion == null)
+                {
+                    string factName = "Application Form Version Not Registered - Unknown Version";
+                    string factValue = $"FormId: {eventSubscriptionDto.FormId} FormVersion: {eventSubscriptionDto.FormVersion}";
+                    SendTeamsNotification(factName, factValue);
+                    return false;
+                } else if(!_intakeClientOptions.Value.AllowUnregisteredVersions)
+                {
+                    var version = ((JObject)formVersion!).SelectToken("version");
+                    var published = ((JObject)formVersion!).SelectToken("published");
+                    string factName = "Application Form Version Not Registered - Unknown Version";
+                    string factValue = $"Application Form Version Not Registerd - Version: {version} Published: {published}";
+                    SendTeamsNotification(factName, factValue);
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private async void SendTeamsNotification(string factName, string factValue)
+        {
+            string? envInfo = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+            string activityTitle = "Chefs Submission Event Validation Error";
+            string activitySubtitle = "Environment: " + envInfo;
+            string teamsChannel = _configuration["Notifications:TeamsNotificationsWebhook"] ?? "";
+            TeamsNotificationService teamsNotificationService = new TeamsNotificationService();
+            teamsNotificationService.AddFact(factName, factValue);
+            await teamsNotificationService.PostFactsToTeamsAsync(teamsChannel, activityTitle, activitySubtitle);
         }
 
         private async Task StoreChefsFieldMappingAsync(EventSubscriptionDto eventSubscriptionDto, ApplicationForm applicationForm, JToken token)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
@@ -38,10 +38,10 @@ $(function () {
             ).then(function (form) {
                 // Set Example Submission Object
                 form.submission = submissionData.submission.submission;
-                addEventListeners();
                 form.resetValue();
                 form.refresh();
                 form.on('render', function() {
+                    addEventListeners();
                     storeRenderedHtml();
                 });
             });
@@ -177,7 +177,6 @@ $(function () {
                 PubSub.publish('AssessmentComment_refresh', { review: selectedReviewDetails });
                 assessmentUserDetailsWidgetManager.refresh();
                 assessmentScoresWidgetManager.refresh();
-                updateSubtotal()
                 checkCurrentUser(data);
             }
             else {


### PR DESCRIPTION
Fixes the timing of the expand/collapse on the Form Details page when the page has not rendered before
Prevents the Submission of Drafts
Notifies the Teams Channel when Deleted or Draft is submitted or if the Form Version does not exist

![image](https://github.com/bcgov/Unity/assets/39963238/b88dfc57-e327-49ba-b99f-05d07cd3c58b)
