### PR TITLE
Bugfix/AB#25682 custom fields in assessment tab

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.cshtml
@@ -126,7 +126,7 @@
 
                 @*-------- Project Info Section ---------*@
                 <abp-tab name="nav-project-info" title="Project Info">
-                    <div class="w-100 px-2" id="assessmentResultWidget">
+                    <div class="w-100 px-2" id="projectInfoWidget">
                         @await Component.InvokeAsync("ProjectInfo", new { applicationId = Model.ApplicationId, applicationFormVersionId = Model.ApplicationFormVersionId })
                     </div>
                 </abp-tab>

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
@@ -278,26 +278,14 @@ $(function () {
         wrapper: '#assessmentResultWidget',
         filterCallback: function () {
             return {
-                'applicationId': $('#DetailsViewApplicationId').val()
+                'applicationId': $('#DetailsViewApplicationId').val(),
+                'applicationFormVersionId': $('#AssessmentResultViewApplicationFormVersionId').val()
             };
         }
     });
-    let assessmentResultCustomWidgetManager = new abp.WidgetManager({
-        wrapper: '#"assessmentResultsCustomWidget',
-        filterCallback: function () {
-            return {
-                'instanceCorrelationId': $('#DetailsViewApplicationId').val(),
-                'instanceCorrelationProvider': 'Application',
-                'sheetCorrelationId': $('#ApplicationFormVersionId').val(),
-                'sheetCorrelationProvider': 'FormVersion',
-                'uiAnchor': 'AssessmentInfo'
-            }
-        }
-    })
     PubSub.subscribe(
         'application_status_changed',
-        (msg, data) => {
-            console.log(msg, data);
+        (msg, data) => {            
             applicationBreadcrumbWidgetManager.refresh();
             applicationStatusWidgetManager.refresh();
             assessmentResultWidgetManager.refresh();            
@@ -305,8 +293,7 @@ $(function () {
     );
     PubSub.subscribe('application_assessment_results_saved',
         (msg, data) => {
-            assessmentResultWidgetManager.refresh();
-            assessmentResultCustomWidgetManager.refresh();
+            assessmentResultWidgetManager.refresh();        
         }
     );
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
@@ -282,18 +282,31 @@ $(function () {
             };
         }
     });
+    let assessmentResultCustomWidgetManager = new abp.WidgetManager({
+        wrapper: '#"assessmentResultsCustomWidget',
+        filterCallback: function () {
+            return {
+                'instanceCorrelationId': $('#DetailsViewApplicationId').val(),
+                'instanceCorrelationProvider': 'Application',
+                'sheetCorrelationId': $('#ApplicationFormVersionId').val(),
+                'sheetCorrelationProvider': 'FormVersion',
+                'uiAnchor': 'AssessmentInfo'
+            }
+        }
+    })
     PubSub.subscribe(
         'application_status_changed',
         (msg, data) => {
             console.log(msg, data);
             applicationBreadcrumbWidgetManager.refresh();
             applicationStatusWidgetManager.refresh();
-            assessmentResultWidgetManager.refresh();
+            assessmentResultWidgetManager.refresh();            
         }
     );
     PubSub.subscribe('application_assessment_results_saved',
         (msg, data) => {
             assessmentResultWidgetManager.refresh();
+            assessmentResultCustomWidgetManager.refresh();
         }
     );
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.cshtml
@@ -127,7 +127,8 @@
 
         @if (await FeatureChecker.IsEnabledAsync("Unity.Flex"))
         {
-            @await Component.InvokeAsync(typeof(WorksheetInstanceWidget),
+            <div id="assessmentResultsCustomWidget">
+             @await Component.InvokeAsync(typeof(WorksheetInstanceWidget),
                      new
                      {
                          instanceCorrelationId = Model.ApplicationId,
@@ -136,6 +137,7 @@
                          sheetCorrelationProvider = CorrelationConsts.FormVersion,
                          uiAnchor = FlexConsts.AssessmentInfoUiAnchor
                      })
+            </div>
         }
 
     </form>

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.cshtml
@@ -14,6 +14,7 @@
 @model AssessmentResultsPageModel
 
 <input type="hidden" id="AssessmentResultViewApplicationId" value="@Model.ApplicationId" />
+<input type="hidden" id="AssessmentResultViewApplicationFormVersionId" value="@Model.ApplicationFormVersionId" />
 
 <abp-row class="px-1 pb-2 mb-4 assessment-results-container">
     <abp-column size="_12" class="d-inline-flex justify-content-between pb-3 pt-2">

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.js
@@ -1,5 +1,4 @@
 ﻿$(function () {
-   
     $('body').on('click', '#saveAssessmentResultBtn', function () {
         let applicationId = document.getElementById('AssessmentResultViewApplicationId').value;
         let formData = $("#assessmentResultForm").serializeArray();
@@ -183,7 +182,24 @@ function flaggedFieldIsValid(flag, name) {
     return true;
 }
 
+function hasInvalidCustomFields() {        
+    let invalidFieldsFound = false;
+    $("input[id^='custom']:visible").each(function (i, el) {
+        let fieldValidity = document.getElementById(el.id).validity.valid;        
+        if (!fieldValidity) {
+            invalidFieldsFound = true;
+        }
+    });
+    
+    return invalidFieldsFound;
+}
+
 function enableResultSaveBtn() {
+    if (hasInvalidCustomFields()) {
+        $('#saveAssessmentResultBtn').prop('disabled', true);
+        return;
+    }
+
     if (hasInvalidExplicitValidations()) {
         $('#saveAssessmentResultBtn').prop('disabled', true);
         return;


### PR DESCRIPTION
Address issues with custom fields and the assessment results tab which has some custom logic and form validation

- Pressing the Save buttons causes the custom field section to disappear until refreshed
- There is an issue where validated fields still allow the save button which should be disabled