### PR TITLE
bugfix/AB#25296 Refresh Summary Details Pane on Project Info Save

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ProjectInfo/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ProjectInfo/Default.js
@@ -59,6 +59,7 @@
                     );
                     $('#saveProjectInfoBtn').prop('disabled', true);
                     PubSub.publish('project_info_saved', projectInfoObj);
+                    PubSub.publish('refresh_detail_panel_summary');
                 });
         }
         catch (error) {


### PR DESCRIPTION
Fix to refresh the summary detail pane when a save is successfully completed in the Project Info tab.