### PR TITLE
feature/AB#25071 - Authentication Session Expiration - Enforce User to Re-Login

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/GrantManagerWebModule.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/GrantManagerWebModule.cs
@@ -225,6 +225,8 @@ public class GrantManagerWebModule : AbpModule
         })
         .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme, options =>
         {
+            options.ExpireTimeSpan = TimeSpan.FromHours(8);
+            options.SlidingExpiration = false;
             options.Events.OnSigningOut = async e =>
             {
                 // revoke refresh token on sign-out
@@ -243,6 +245,7 @@ public class GrantManagerWebModule : AbpModule
 
             options.SaveTokens = true;
             options.GetClaimsFromUserInfoEndpoint = true;
+            options.MaxAge = TimeSpan.FromHours(8); 
 
             options.ClaimActions.MapClaimTypes();
             options.TokenValidationParameters = new TokenValidationParameters


### PR DESCRIPTION
We've set the following authentication properties on AddCookie and AddOpenIdConnect:

1. **ExpireTimeSpan in AddCookie:** Set to 8 hours. Determines how long the user's session is valid within the application.

2. **SlidingExpiration in AddCookie:** Set to false. The user's session expiration time will not be extended on new requests.

3. **MaxAge in AddOpenIdConnect:** Set to 8 hours. Controls the maximum allowable time since the last authentication with the OIDC provider, forcing re-authentication by the IDP.

**Note:** The Authentication Session ticket within the cookie will expire while the cookie will not and will be cleared on manual logout. This configuration triggers redirect to the OIDC IDP on expiry of the authentication session.