### PR TITLE
Bugfix/ab#26354 error when cloning worksheet

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Application/Domain/Services/WorksheetsManager.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Application/Domain/Services/WorksheetsManager.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.Extensions.Logging;
+using NUglify.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
+using Unity.Flex.Domain.Utils;
 using Unity.Flex.Domain.WorksheetInstances;
 using Unity.Flex.Domain.WorksheetLinks;
 using Unity.Flex.Domain.Worksheets;
@@ -200,7 +202,7 @@ namespace Unity.Flex.Domain.Services
         public async Task<Worksheet> CloneWorksheetAsync(Guid id)
         {
             var worksheet = await worksheetRepository.GetAsync(id, true);
-            var versionSplit = worksheet.Name.Split('-');
+            var versionSplit = SheetParserFunctions.SplitSheetNameAndVersion(worksheet.Name);
             var worksheetVersions = await worksheetRepository.GetByNameStartsWithAsync($"{versionSplit[0]}-v", false);
             var highestVersion = worksheetVersions.Max(s => s.Version);
             var clonedWorksheet = new Worksheet(Guid.NewGuid(), $"{versionSplit[0]}-v{highestVersion + 1}", worksheet.Title);
@@ -218,7 +220,7 @@ namespace Unity.Flex.Domain.Services
 
             var result = await worksheetRepository.InsertAsync(clonedWorksheet);
             return result;
-        }
+        }       
 
         private static CustomField? FindCustomFieldByName(Worksheet? worksheet, string fieldName)
         {

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Application/Domain/Services/WorksheetsManager.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Application/Domain/Services/WorksheetsManager.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Logging;
-using NUglify.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Application/Domain/Utils/SheetParserFunctions.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Application/Domain/Utils/SheetParserFunctions.cs
@@ -1,0 +1,11 @@
+﻿namespace Unity.Flex.Domain.Utils
+{
+    public static class SheetParserFunctions
+    {
+        public static string[] SplitSheetNameAndVersion(string name)
+        {
+            var versionIndicator = name.LastIndexOf('-');
+            return [name[0..versionIndicator], name[versionIndicator..]];
+        }
+    }
+}

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Application/Scoresheets/ScoresheetAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Application/Scoresheets/ScoresheetAppService.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Unity.Flex.Domain.Scoresheets;
 using Unity.Flex.Domain.Settings;
+using Unity.Flex.Domain.Utils;
 using Volo.Abp;
 using Volo.Abp.Uow;
 using Volo.Abp.Validation;
@@ -100,7 +101,7 @@ namespace Unity.Flex.Scoresheets
             using var unitOfWork = _unitOfWorkManager.Begin();
 
             var originalScoresheet = await _scoresheetRepository.GetWithChildrenAsync(scoresheetIdToClone) ?? throw new AbpValidationException("Scoresheet not found.");
-            var versionSplit = originalScoresheet.Name.Split('-');
+            var versionSplit = SheetParserFunctions.SplitSheetNameAndVersion(originalScoresheet.Name);
             var clonedScoresheet = new Scoresheet(Guid.NewGuid(), originalScoresheet.Title, $"{versionSplit[0]}-v{originalScoresheet.Version + 1}")
             {
                 Version = originalScoresheet.Version + 1,


### PR DESCRIPTION
- There is a naming convention {name}-v{x} for worksheet and scoresheet names. These names are based on the title capture and auto generated. On cloning either a scoresheet or worksheet to determine the root name of the worksheet (without version) it was not correctly handling scenario's where the title include the '-' hyphen character as this is used as a suffix for version naming. 
- The code now looks at the last instance of the '-' hyphen to determine the name to version split allowing the titles/names of the worksheets/scoresheets to include a '-' hyphen.