### PR TITLE
bugfix/AB#25952 - Skip CHEFS form initialization on Application Form update if not required

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormAppService.cs
@@ -54,8 +54,21 @@ namespace Unity.GrantManager.ApplicationForms
 
         public override async Task<ApplicationFormDto> UpdateAsync(Guid id, CreateUpdateApplicationFormDto input)
         {
+            var existingEntity = await Repository.GetAsync(id);
             input.ApiKey = _stringEncryptionService.Encrypt(input.ApiKey);
-            return await InitializeFormVersion(id, input); 
+
+            bool hasFormGuidChanged = existingEntity.ChefsApplicationFormGuid != input.ChefsApplicationFormGuid;
+            bool hasFormApiKeyChanged = existingEntity.ApiKey != input.ApiKey;
+
+            // Only initialize form version if changes are made to form connection details
+            if (hasFormGuidChanged || hasFormApiKeyChanged)
+            {
+                return await InitializeFormVersion(id, input);
+            }
+            else
+            {
+                return await base.UpdateAsync(id, input);
+            }
         }
 
         private async Task<ApplicationFormDto> InitializeFormVersion(Guid id, CreateUpdateApplicationFormDto input)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormAppService.cs
@@ -54,11 +54,11 @@ namespace Unity.GrantManager.ApplicationForms
 
         public override async Task<ApplicationFormDto> UpdateAsync(Guid id, CreateUpdateApplicationFormDto input)
         {
-            var existingEntity = await Repository.GetAsync(id);
+            var existingForm = await Repository.GetAsync(id);
             input.ApiKey = _stringEncryptionService.Encrypt(input.ApiKey);
 
-            bool hasFormGuidChanged = existingEntity.ChefsApplicationFormGuid != input.ChefsApplicationFormGuid;
-            bool hasFormApiKeyChanged = existingEntity.ApiKey != input.ApiKey;
+            bool hasFormGuidChanged = existingForm.ChefsApplicationFormGuid != input.ChefsApplicationFormGuid;
+            bool hasFormApiKeyChanged = existingForm.ApiKey != input.ApiKey;
 
             // Only initialize form version if changes are made to form connection details
             if (hasFormGuidChanged || hasFormApiKeyChanged)


### PR DESCRIPTION
Changed the `ApplicationFormAppService.UpdateAsync()` method to only trigger `InitializeFormVersion()` when the CHEFS Form ID or API Key GUID fields change. On no change, the `ApplicationForm` updates as usual.

Tried writing unit tests for this method but had challenges mocking the `FormsApiService` used in `InitializeFormVersion()`. Should address unit testing of this during technical debt sprint. 