### PR TITLE
Bugfix/AB#26415 mapped currency fields not handling no decimals provided correctly

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Shared/Worksheets/Values/ValueConverterHelper.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Shared/Worksheets/Values/ValueConverterHelper.cs
@@ -20,7 +20,7 @@ namespace Unity.Flex.Worksheets.Values
         internal static string ConvertDecimal(object? value)
         {
             var valid = decimal.TryParse(value?.ToString(), out decimal decimalValue);
-            if (valid) return decimalValue.ToString();
+            if (valid) return decimalValue.ToString("0.00");
             return string.Empty;
         }
 


### PR DESCRIPTION
- When no decimal value is provided from CHEFS for a mapped currency field, the decimal formatting routine for custom fields intake (map and save) was converting "1234" to "12.34".
- The raw value we receive from CHEFS is "1234" and not "1234.00" 
- A value of "1234.56" was parsed correctly as the precision was provided in the input
- I have explicitly set the string conversion helper to take that value and parse it with 2 decimals which fixes the rest of the formatting routine for the custom field currency intake map