### PR TITLE
Feature/AB#26349 CSS for readonly fields

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Pages/ScoresheetConfiguration/ScoresheetModal.cshtml
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Pages/ScoresheetConfiguration/ScoresheetModal.cshtml
@@ -26,7 +26,7 @@
                     <abp-input asp-for="@Model.Scoresheet.Title" id="scoresheetTitle" onkeyup="updateScoresheetName('@Model.Scoresheet.ActionType')" />
                 </abp-column>
                 <abp-column size="_12" class="px-1">
-                    <abp-input asp-for="@Model.Scoresheet.Name" id="scoresheetName" readonly="true" />
+                    <abp-input asp-for="@Model.Scoresheet.Name" id="scoresheetName" readonly="true" class="disabled" />
                 </abp-column>
             </abp-row>
         </abp-modal-body>

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Pages/WorksheetConfiguration/UpsertWorksheetModal.cshtml
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Pages/WorksheetConfiguration/UpsertWorksheetModal.cshtml
@@ -26,7 +26,7 @@
                     <abp-input asp-for="@Model.Title" id="worksheetTitle" onkeyup="updateWorksheetName('@Model.UpsertAction.ToString()')" />
                 </abp-column>
                 <abp-column size="_12" class="px-1">
-                    <abp-input asp-for="@Model.Name" id="worksheetName" readonly="true" />
+                    <abp-input asp-for="@Model.Name" id="worksheetName" readonly="true" class="disabled" />
                 </abp-column>
             </abp-row>
         </abp-modal-body>

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.css
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.css
@@ -741,7 +741,14 @@ input[type=search]::-webkit-search-cancel-button {
     -webkit-appearance: button !important;
 }
 
-
+input.form-control.disabled:read-only, textarea.form-control.disabled:read-only, .form-select.disabled:read-only {
+    color: var(--bc-colors-grey-text-200);
+    pointer-events: none;
+    background-color: var(--bc-colors-grey-hover) !important;
+    opacity: var(--bs-btn-disabled-opacity);
+    background-blend-mode: difference;
+    border: none !important;
+}
 
 
 @media (max-height: 768px) {


### PR DESCRIPTION
- In scoresheets and worksheets the name is calculated as typed and is thus a read-only fields to keep it in the form post
- It is not clear that this field is read-only, so have added CSS that can be used specifically for a read-only input field by adding disabled class to it that styles the read-only field in the same way as a disabled field
- These read-only inputs are not styled as disabled by marking them as read-only and having the CSS class disabled