### PR TITLE
bugfix/AB#26200 - Add Reset Button to Assessment Recommendation Dropdown

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.cshtml
@@ -250,7 +250,12 @@
                         </div>
 
                         <div class="m-3">
-                            <h6 class="fw-bold py-2 m-0">Recommendation</h6>
+                            <div class="d-flex flex-row">
+                                <h6 class="fw-bold py-2 m-0 flex-grow-1">Recommendation</h6>
+                                <div class="p-2 cursor-disabled">
+                                    <button id="clearBtn" class="btn btn-outline-secondary btn-sm m-0 px-2 py-0 fw-bold" type="button" aria-label="Reset selection">RESET</button>
+                                </div>
+                            </div>
                             <abp-select id="recommendation_select" name="recommendation_select" asp-for="SelectedAction" suppress-label="true" asp-items="@Model.ActionList" class="">
                                 <option value="null" disabled>Please choose...</option>
                             </abp-select>

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.cshtml
@@ -250,10 +250,10 @@
                         </div>
 
                         <div class="m-3">
-                            <div class="d-flex flex-row">
+                            <div class="d-flex flex-row align-items-center">
                                 <h6 class="fw-bold py-2 m-0 flex-grow-1">Recommendation</h6>
-                                <div class="p-2 cursor-disabled">
-                                    <button id="clearBtn" class="btn btn-outline-secondary btn-sm m-0 px-2 py-0 fw-bold" type="button" aria-label="Reset selection">RESET</button>
+                                <div class="p-0 recommendation_reset_wrapper">
+                                    <button id="recommendation_reset_btn" class="btn btn-outline-danger recom-reset-button px-2 py-0 fw-bold" type="button" aria-label="Reset selection">RESET</button>
                                 </div>
                             </div>
                             <abp-select id="recommendation_select" name="recommendation_select" asp-for="SelectedAction" suppress-label="true" asp-items="@Model.ActionList" class="">

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.css
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.css
@@ -166,6 +166,17 @@
         color: #333;
     }
 
+.recom-reset-button {
+    font-size: 0.8rem;
+    color: var(--bc-colors-blue-text-links);
+    border: 2px solid var(--bc-colors-blue-text-links);
+    min-height: 1.4rem;
+}
+
+.recom-reset-button:hover {
+    border-color: var(--bs-btn-color);
+}
+
 .back-button-container {
     justify-content: left;
     align-items: start;

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
@@ -137,9 +137,6 @@ $(function () {
         updateRecommendation(value, selectedReviewDetails.id);
     });
 
-    // Set reset button state on load
-    $recommendationResetBtn.prop('disabled', !$recommendationSelect.prop('disabled') || !$recommendationSelect.val());
-
     function disableRecommendationControls(state) {
         $recommendationSelect.prop('disabled', state)
         $recommendationResetBtn.prop('disabled', state ? true : !$recommendationSelect.val());
@@ -601,10 +598,13 @@ const checkCurrentUser = function (data) {
     if (getCurrentUser() == data.assessorId && data.status == "IN_PROGRESS") {
         $('#recommendation_select').prop('disabled', false);
         $('#assessment_upload_btn').prop('disabled', false);
+        // Review state class transitions between hide and show
+        $('#recommendation_reset_btn').prop('disabled', !$('#recommendation_select').val()).show();
     }
     else {
         $('#recommendation_select').prop('disabled', 'disabled');
         $('#assessment_upload_btn').prop('disabled', 'disabled');
+        $('#recommendation_reset_btn').prop('disabled', 'disabled').hide();
     }
 };
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
@@ -138,8 +138,10 @@ $(function () {
     });
 
     function disableRecommendationControls(state) {
-        $recommendationSelect.prop('disabled', state)
-        $recommendationResetBtn.prop('disabled', state ? true : !$recommendationSelect.val());
+        $recommendationSelect.prop('disabled', state);
+        $recommendationResetBtn
+            .prop('disabled', state ? true : !$recommendationSelect.val())
+            .toggleClass('d-none', state ? true : !$recommendationSelect.val());
     }
 
     function updateRecommendation(value, id) {
@@ -598,13 +600,14 @@ const checkCurrentUser = function (data) {
     if (getCurrentUser() == data.assessorId && data.status == "IN_PROGRESS") {
         $('#recommendation_select').prop('disabled', false);
         $('#assessment_upload_btn').prop('disabled', false);
-        // Review state class transitions between hide and show
-        $('#recommendation_reset_btn').prop('disabled', !$('#recommendation_select').val()).show();
+        $('#recommendation_reset_btn')
+            .prop('disabled', !$('#recommendation_select').val())
+            .toggleClass('d-none', !$('#recommendation_select').val());
     }
     else {
         $('#recommendation_select').prop('disabled', 'disabled');
         $('#assessment_upload_btn').prop('disabled', 'disabled');
-        $('#recommendation_reset_btn').prop('disabled', 'disabled').hide();
+        $('#recommendation_reset_btn').prop('disabled', 'disabled').toggleClass('d-none', true);
     }
 };
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
@@ -137,19 +137,18 @@ $(function () {
         updateRecommendation(value, selectedReviewDetails.id);
     });
 
-    function updateResetButtonState() {
-        // The reset button is only enabled if a recommendation has been selected
-        $recommendationResetBtn.prop('disabled', !$recommendationSelect.val());
-    }
+    // Set reset button state on load
+    $recommendationResetBtn.prop('disabled', !$recommendationSelect.prop('disabled') || !$recommendationSelect.val());
 
-    // Set button state on load
-    updateResetButtonState();
+    function disableRecommendationControls(state) {
+        $recommendationSelect.prop('disabled', state)
+        $recommendationResetBtn.prop('disabled', state ? true : !$recommendationSelect.val());
+    }
 
     function updateRecommendation(value, id) {
         try {
             // Disable the select and reset button during update
-            $recommendationSelect.prop('disabled', true);
-            $recommendationResetBtn.prop('disabled', true);
+            disableRecommendationControls(true);
 
             let data = { "approvalRecommended": value, "assessmentId": id }
             unity.grantManager.assessments.assessment.updateAssessmentRecommendation(data)
@@ -161,16 +160,14 @@ $(function () {
                 })
                 .always(function () {
                     // Re-enable the select and reset button
-                    $recommendationSelect.prop('disabled', false);
-                    updateResetButtonState();
+                    disableRecommendationControls(false);
                 });
 
         }
         catch (error) {
             console.log(error);
             // Re-enable the select and reset button in case of error
-            $recommendationSelect.prop('disabled', false);
-            updateResetButtonState();
+            disableRecommendationControls(false);
         }
     }
 


### PR DESCRIPTION
Added a button to reset the assessment recommendation dropdown selection that is conditionally visible based on user and assessment status.

![image](https://github.com/user-attachments/assets/bdf568af-6537-4b4f-a6bd-c4cf861146f8)

On hover before click:
![image](https://github.com/user-attachments/assets/3cf8c9a4-cc19-4014-98f8-9c0375c30c9e)
