### PR TITLE
bugfix/AB#26253 Text Overflow Tooltip Viewer

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.css
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.css
@@ -772,3 +772,7 @@ input.form-control.disabled:read-only, textarea.form-control.disabled:read-only,
         max-height: calc(100vh - 30vh);
     }
 }
+
+.overflow-tooltip {
+    text-overflow: ellipsis;
+}

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.css
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.css
@@ -469,6 +469,7 @@ input.form-control, textarea.form-control, .form-select {
     color: var(--bc-colors-grey-text-500);
     border-radius: var(--bc-layout-margin-small) !important;
     border: 2px solid var(--bc-colors-blue-primary);
+    text-overflow: ellipsis;
 }
 
     input.form-control:hover, textarea.form-control:hover, .form-select:hover {

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.js
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.js
@@ -26,7 +26,7 @@ $(function () {
 
         const elementTitle = inputElement.value;
         if (elementTitle && isTextOverflowing(inputElement)) {
-            new bootstrap.Tooltip(tooltipTarget, {
+            bootstrap.Tooltip.getOrCreateInstance(tooltipTarget, {
                 title: elementTitle,
                 trigger: 'hover',
                 placement: 'top',
@@ -35,7 +35,7 @@ $(function () {
         }
     }
 
-    $(".overflow-tooltip").each(function () {
+    $('.overflow-tooltip, input.form-control[type="text"]:not(.exclude-tooltip)').each(function () {
         const $input = $(this);
 
         // Wrap element in tooltip wrapper to support input disabled/enabled transitions

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.js
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.js
@@ -29,7 +29,8 @@ $(function () {
             bootstrap.Tooltip.getOrCreateInstance(tooltipTarget, {
                 title: elementTitle,
                 trigger: 'hover',
-                placement: 'top',
+                placement: 'right',
+                fallbackPlacements: ['right', 'bottom', 'left', 'top'],
                 delay: { show: 500, hide: 100 }
             });
         }

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.js
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.js
@@ -13,6 +13,48 @@ $(function () {
 
         return false;
     });
+
+    function isTextOverflowing(element) {
+        return element.scrollWidth > element.clientWidth;
+    }
+
+    function createTooltipOnOverflow(inputElement, tooltipTarget) {
+        if (inputElement.tagName !== 'INPUT') {
+            console.warn('createTooltipOnOverflow: The provided inputElement is not an input element');
+            return;
+        }
+
+        const elementTitle = inputElement.value;
+        if (elementTitle && isTextOverflowing(inputElement)) {
+            new bootstrap.Tooltip(tooltipTarget, {
+                title: elementTitle,
+                trigger: 'hover',
+                placement: 'top',
+                delay: { show: 500, hide: 100 }
+            });
+        }
+    }
+
+    $(".overflow-tooltip").each(function () {
+        const $input = $(this);
+
+        // Wrap element in tooltip wrapper to support input disabled/enabled transitions
+        $input.wrap('<span class="tooltip-wrapper"></span>');
+        const tooltipTarget = $input.parent()[0];
+
+        // Create tooltip from value on initial load
+        createTooltipOnOverflow(this, tooltipTarget);
+
+        $input.on("input paste", function () {
+            const tooltipInstance = bootstrap.Tooltip.getInstance(tooltipTarget);
+            if (tooltipInstance) {
+                tooltipInstance.dispose();
+            }
+
+            // Update tooltip from value on input change
+            createTooltipOnOverflow(this, tooltipTarget);
+        });
+    });
 });
 
 window.addEventListener('DOMContentLoaded', (event) => {


### PR DESCRIPTION
This change allows more visibility into fields with overflowing text.
**On Load:**
![image](https://github.com/user-attachments/assets/0ba1a230-c3cd-4410-87f4-4605eb867b79)
**On Hover:**
![image](https://github.com/user-attachments/assets/c1f5ea31-4b73-4fd0-8e75-8be91dbe4540)

## Changes
1. Set text-overflow to ellipsis on `input.form-control`, `textarea.form-control`, `.form-select`, and `.overflow-tooltip` to make text overflows more clearly visible.
2. Set a Bootstrap Tooltip to load on any element that applies to the selector `.overflow-tooltip, input.form-control[type="text"]:not(.exclude-tooltip)`.
    - **Behavior:** The tooltip only displays on hover when `element.scrollWidth > element.clientWidth`, which indicates a text overflow within an input control.
    - **Note:** Any text form-control can opt-out of the overflow tooltip by using the `.exclude-tooltip` class.

## Considerations
This PR may require revisions, I'm requesting feedback on the following decisions if there are any concerns from the team:
1. To work on both enabled and disabled text input elements, the Bootstrap Tooltip object requires a wrapper around the input control as hover events aren't triggered on disabled elements. The script below wraps _every_ text input form-control element in an inline `span.tooltip-wrapper` element, which could be a front-end performance concern and break CSS or jQuery selectors that are based on the relative positioning of `input.form-control[type="text"]` elements. Tooltip wrapping selector: `.overflow-tooltip, input.form-control[type="text"]:not(.exclude-tooltip)`
2. Bootstrap Tooltip was selected over putting the input value in the element's `title` attribute to render as a browser based tooltip, since the `title` attribute has some descriptive use cases and may overlap with accessibility use cases.

#