### PR TITLE
Chore/ab#26401 more code cleanup

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/UserAccountsRepository.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/UserAccountsRepository.cs
@@ -24,7 +24,7 @@ namespace Unity.GrantManager.Repositories
         {
             var dbSet = await GetDbSetAsync();
             return await dbSet.AsQueryable()
-                .Where(u => EF.Functions.Like(EF.Property<string>(u, "OidcSub"), $"{oidcSub.ToSubjectWithoutIdp()}%"))
+                .Where(u => EF.Functions.ILike(EF.Property<string>(u, "OidcSub"), $"{oidcSub.ToSubjectWithoutIdp()}%"))
                 .ToListAsync();
         }
     }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/UserAccountsRepository.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/UserAccountsRepository.cs
@@ -22,10 +22,9 @@ namespace Unity.GrantManager.Repositories
 
         public async Task<IList<IdentityUser>> GetListByOidcSub(string oidcSub)
         {
-            var dbSet = await GetDbSetAsync();            
-            return await dbSet.AsQueryable().Where(u => EF.Property<string>(u, "OidcSub")
-                .ToUpper()
-                .StartsWith(oidcSub.ToSubjectWithoutIdp()))
+            var dbSet = await GetDbSetAsync();
+            return await dbSet.AsQueryable()
+                .Where(u => EF.Functions.Like(EF.Property<string>(u, "OidcSub"), $"{oidcSub.ToSubjectWithoutIdp()}%"))
                 .ToListAsync();
         }
     }


### PR DESCRIPTION
- Make changes based on sonarqube suggestion:
Prefer the string comparison method overload of 'string.StartsWith(string)' that takes a 'StringComparison' enum value to perform a case-insensitive comparison, but keep in mind that this might cause subtle changes in behavior, so make sure to conduct thorough testing after applying the suggestion, or if culturally sensitive comparison is not required, consider using 'StringComparison.OrdinalIgnoreCase'

- Cannot use this string comparison in and entity framework query like this as this throws an exception:
InvalidOperationException: The LINQ expression 'DbSet<IdentityUser>()
.Where(i => AbpEfCoreDataFilterDbFunctionMethods.SoftDeleteFilter(
isDeleted: ((ISoftDelete)i).IsDeleted,
boolParam: True) && AbpEfCoreDataFilterDbFunctionMethods.MultiTenantFilter(
tenantId: ((IMultiTenant)i).TenantId,
currentTenantId: __ef_filter__CurrentTenantId_0,
boolParam: True))
.Where(i => EF.Property<string>(i, "OidcSub").StartsWith(
value: __ToSubjectWithoutIdp_0,
comparisonType: CurrentCultureIgnoreCase))' could not be translated. Additional information: Translation of method 'string.StartsWith' failed. If this method can be mapped to your custom function, see https://go.microsoft.com/fwlink/?linkid=2132413 for more information. Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to 'AsEnumerable', 'AsAsyncEnumerable', 'ToList', or 'ToListAsync'. See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.

Instead have gone with EF functions to execute this: ILIKE
This is overall more efficient than the casing and startswith comparison too.