### PR TITLE
Bugfix/ab#26480 and ab#26646 Keyvalue pair definition widget improvements

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/CheckboxGroupDefinitionWidget/CheckboxGroupDefinitionWidget.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/CheckboxGroupDefinitionWidget/CheckboxGroupDefinitionWidget.cs
@@ -1,17 +1,12 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 using Volo.Abp.AspNetCore.Mvc.UI.Widgets;
-using Volo.Abp.AspNetCore.Mvc;
 using Volo.Abp.AspNetCore.Mvc.UI.Bundling;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Unity.Flex.Worksheets.Definitions;
 using System.Text.Json;
-using Microsoft.Extensions.Primitives;
-using Volo.Abp;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System;
+using Unity.Flex.Web.Views.Shared.Components.Common;
 
 namespace Unity.Flex.Web.Views.Shared.Components.CheckboxGroupDefinitionWidget
 {
@@ -21,19 +16,14 @@ namespace Unity.Flex.Web.Views.Shared.Components.CheckboxGroupDefinitionWidget
         ScriptTypes = [typeof(CheckboxGroupDefinitionWidgetScriptBundleContributor)],
         StyleTypes = [typeof(CheckboxGroupDefinitionWidgetStyleBundleContributor)],
         AutoInitialize = true)]
-    public partial class CheckboxGroupDefinitionWidget : AbpViewComponent
+    public partial class CheckboxGroupDefinitionWidget : KeyValueComponentDefinition
     {
-        const string validInputPattern = @"^[ə̀ə̩ə̥ɛæə̌ə̂ə̧ə̕ə̓ᵒə̄ə̱·ʷəŧⱦʸʋɨⱡɫʔʕⱥɬθᶿɣɔɩłə̈ʼə̲ᶻꭓȼƛλŋƚə̨ə̣ə́ `1234567890-=qwertyuiop[]asdfghjkl;_'_\\zxcvbnm,.~!@#$%^&*()_+QWERTYUIOP{}ASDFGHJKL:""||ZXCVBNM<>?]+$";
-
-        [GeneratedRegex(validInputPattern)]
-        private static partial Regex MyRegex();
-
         internal static object? ParseFormValues(IFormCollection form)
         {
             var keys = form["CheckboxKeys"];
             var labels = form["CheckboxLabels"];
 
-            ValidateInput(keys, labels);
+            ValidateInput(keys, labels, KeyValueType.Labels);
 
             var checkboxGroupDefinition = new CheckboxGroupDefinition
             {
@@ -53,58 +43,8 @@ namespace Unity.Flex.Web.Views.Shared.Components.CheckboxGroupDefinitionWidget
             return checkboxGroupDefinition;
         }
 
-        private static void ValidateInput(StringValues keys, StringValues labels)
-        {
-            ValidateLabelsAdded(keys, labels);
-            ValidateKeysUnique(keys);
-            ValidateKeysFormat(keys);
-            ValidateLabelsFormat(labels);
-        }
 
-        private static void ValidateLabelsFormat(StringValues values)
-        {
-            foreach (var key in values)
-            {
-                if (!IsValidInput(key ?? string.Empty))
-                {
-                    throw new UserFriendlyException("The following characters are allowed for Values: " + validInputPattern);
-                }
-            }
-        }
-
-        private static void ValidateKeysFormat(StringValues keys)
-        {
-            foreach (var key in keys)
-            {
-                if (string.IsNullOrWhiteSpace(key))
-                {
-                    throw new UserFriendlyException("There are empty Keys captured which are required");
-                }
-
-                if (!IsValidInput(key))
-                {
-                    throw new UserFriendlyException("The following characters are allowed for Keys: " + validInputPattern);
-                }
-            }
-        }
-
-        private static void ValidateKeysUnique(StringValues keys)
-        {
-            if (keys.Distinct().Count() != keys.Count)
-            {
-                throw new UserFriendlyException("Checkbox keys must be unique");
-            }
-        }
-
-        private static void ValidateLabelsAdded(StringValues keys, StringValues labels)
-        {
-            if (keys.Count == 0 || labels.Count == 0)
-            {
-                throw new UserFriendlyException("Checkbox keys not provided");
-            }
-        }
-
-        public async Task<IViewComponentResult> InvokeAsync(string? definition)
+        public override async Task<IViewComponentResult> InvokeAsync(string? definition)
         {
             if (definition != null)
             {
@@ -122,12 +62,6 @@ namespace Unity.Flex.Web.Views.Shared.Components.CheckboxGroupDefinitionWidget
             }
 
             return View(await Task.FromResult(new CheckboxGroupDefinitionViewModel()));
-        }
-
-        public static bool IsValidInput(string input)
-        {
-            Regex regex = MyRegex();
-            return regex.IsMatch(input);
         }
     }
 

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/CheckboxGroupDefinitionWidget/Default.js
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/CheckboxGroupDefinitionWidget/Default.js
@@ -38,7 +38,7 @@ $(function () {
     }
 
     function getRowTemplate(key, label) {
-        return `<tr><td><input type="text" class="form-control key-input" name="CheckboxKeys" pattern="${checkKeyInputRegexBase}" value="${key}" minlength="1" maxlength="25" required id="new-chk-key-${key}" />
+        return `<tr><td><input type="text" class="form-control key-input" name="CheckboxKeys" value="${key}" minlength="1" maxlength="25" required id="new-chk-key-${key}" />
         </td><td><input type="text" class="form-control" name="CheckboxLabels" value="${label}" maxlength="25" required id="new-chk-label-${key}" />
         </td><td><button id="data-btn-${key}" class="delete-checkbox-option btn btn-danger" type="button" data-busy-text="Processing..." data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Delete" data-bs-original-title="Delete">
         <i class="fl fl-delete"></i></button></td></tr>`

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/Common/KeyValueComponentDefinition.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/Common/KeyValueComponentDefinition.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Volo.Abp;
+using Volo.Abp.AspNetCore.Mvc;
+
+namespace Unity.Flex.Web.Views.Shared.Components.Common
+{
+    public partial class KeyValueComponentDefinition : AbpViewComponent
+    {
+        const string validInputPattern = @"^[ə̀ə̩ə̥ɛæə̌ə̂ə̧ə̕ə̓ᵒə̄ə̱·ʷəŧⱦʸʋɨⱡɫʔʕⱥɬθᶿɣɔɩłə̈ʼə̲ᶻꭓȼƛλŋƚə̨ə̣ə́ `1234567890-=qwertyuiop[]asdfghjkl;_'_\\zxcvbnm,.~!@#$%^&*()_+QWERTYUIOP{}ASDFGHJKL:""||ZXCVBNM<>?]+$";
+
+        [GeneratedRegex(validInputPattern)]
+        protected static partial Regex InputRegex();
+
+
+        public virtual async Task<IViewComponentResult> InvokeAsync(string? definition)
+        {
+            await Task.CompletedTask;
+            return View();
+        }
+
+        protected enum KeyValueType
+        {
+            Values = 0,
+            Labels = 1
+        };
+
+        protected static void ValidateKeysFormat(StringValues keys)
+        {
+            foreach (var key in keys)
+            {
+                if (string.IsNullOrWhiteSpace(key))
+                {
+                    throw new UserFriendlyException("There are empty Keys captured which are required");
+                }
+
+                if (!IsValidInput(key))
+                {
+                    throw new UserFriendlyException("The following characters are allowed for Keys: " + validInputPattern);
+                }
+            }
+        }
+
+        protected static void ValidateKeysUnique(StringValues keys)
+        {
+            if (keys.Distinct().Count() != keys.Count)
+            {
+                throw new UserFriendlyException("Provided Keys must be unique");
+            }
+        }
+
+        protected static bool IsValidInput(string input)
+        {
+            Regex regex = InputRegex();
+            return regex.IsMatch(input);
+        }
+
+        protected static void ValidateInputCounts(StringValues keys, StringValues labels, KeyValueType type)
+        {
+            if (keys.Count == 0 || labels.Count == 0)
+            {
+                throw new UserFriendlyException($"Both Keys and {type} are required");
+            }
+        }
+
+        protected static void ValidateValuesFormat(StringValues values, KeyValueType type)
+        {
+            foreach (var key in values)
+            {
+                if (!IsValidInput(key ?? string.Empty))
+                {
+                    throw new UserFriendlyException($"The following characters are allowed for {type}: " + validInputPattern);
+                }
+            }
+        }
+
+        protected static void ValidateInput(StringValues keys, StringValues labels, KeyValueType type)
+        {
+            ValidateInputCounts(keys, labels, type);
+            ValidateKeysUnique(keys);
+            ValidateKeysFormat(keys);
+            ValidateValuesFormat(labels, type);
+        }
+    }
+}

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/Common/KeyValueComponents.js
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/Common/KeyValueComponents.js
@@ -12,8 +12,10 @@ function getNewInputRow(controlName) {
     let newRow = $('#' + controlName);
     let inputs = newRow.find('input');
     let row = {};
+
     row.key = inputs[0].value;
     row.label = inputs[1].value;
+
     return row;
 }
 
@@ -104,6 +106,7 @@ function bindInputChanges(keys, validityClass) {
 }
 
 function sanitizeInput(string) {
+    let jString = $("<p>").text(string).text();
     const map = {
         '&': '&amp;',
         '<': '&lt;',
@@ -113,5 +116,5 @@ function sanitizeInput(string) {
         "/": '&#x2F;',
     };
     const reg = /[&<>"'/]/ig;
-    return string.replace(reg, (match) => (map[match]));
+    return jString.replace(reg, (match) => (map[match]));
 }

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/SelectListDefinitionWidget/Default.js
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/SelectListDefinitionWidget/Default.js
@@ -25,10 +25,11 @@ $(function () {
                     return;
 
                 let santizedLabel = sanitizeInput(row.label);
+                let sanitizedKey = sanitizeInput(row.key);
 
                 // Add valid row to table
                 $('#selectlist-options-table').find('tbody')
-                    .append(getRowTemplate(row.key, santizedLabel));
+                    .append(getRowTemplate(sanitizedKey, santizedLabel));
 
                 cancelAddRow();
 

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/SelectListDefinitionWidget/SelectListDefinitionWidget.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/SelectListDefinitionWidget/SelectListDefinitionWidget.cs
@@ -1,17 +1,12 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 using Volo.Abp.AspNetCore.Mvc.UI.Widgets;
-using Volo.Abp.AspNetCore.Mvc;
 using Volo.Abp.AspNetCore.Mvc.UI.Bundling;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Unity.Flex.Worksheets.Definitions;
 using System.Text.Json;
-using Microsoft.Extensions.Primitives;
-using Volo.Abp;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System;
+using Unity.Flex.Web.Views.Shared.Components.Common;
 
 namespace Unity.Flex.Web.Views.Shared.Components.SelectListDefinitionWidget
 {
@@ -21,19 +16,14 @@ namespace Unity.Flex.Web.Views.Shared.Components.SelectListDefinitionWidget
         ScriptTypes = [typeof(SelectListDefinitionWidgetScriptBundleContributor)],
         StyleTypes = [typeof(SelectListDefinitionWidgetStyleBundleContributor)],
         AutoInitialize = true)]
-    public partial class SelectListDefinitionWidget : AbpViewComponent
+    public partial class SelectListDefinitionWidget : KeyValueComponentDefinition
     {
-        const string validInputPattern = @"^[ə̀ə̩ə̥ɛæə̌ə̂ə̧ə̕ə̓ᵒə̄ə̱·ʷəŧⱦʸʋɨⱡɫʔʕⱥɬθᶿɣɔɩłə̈ʼə̲ᶻꭓȼƛλŋƚə̨ə̣ə́ `1234567890-=qwertyuiop[]asdfghjkl;_'_\\zxcvbnm,.~!@#$%^&*()_+QWERTYUIOP{}ASDFGHJKL:""||ZXCVBNM<>?]+$";
-
-        [GeneratedRegex(validInputPattern)]
-        private static partial Regex MyRegex();
-
         internal static object? ParseFormValues(IFormCollection form)
         {
             var keys = form["SelectListKeys"];
             var values = form["SelectListValues"];
 
-            ValidateInput(keys, values);
+            ValidateInput(keys, values, KeyValueType.Values);
 
             var checkboxGroupDefinition = new SelectListDefinition
             {
@@ -55,58 +45,7 @@ namespace Unity.Flex.Web.Views.Shared.Components.SelectListDefinitionWidget
             return checkboxGroupDefinition;
         }
 
-        private static void ValidateInput(StringValues keys, StringValues values)
-        {
-            ValidateValuesAdded(keys, values);
-            ValidateKeysUnique(keys);
-            ValidateKeysFormat(keys);
-            ValidateValuesFormat(values);
-        }
-
-        private static void ValidateValuesFormat(StringValues values)
-        {
-            foreach (var key in values)
-            {
-                if (!IsValidInput(key ?? string.Empty))
-                {
-                    throw new UserFriendlyException("The following characters are allowed for Values: " + validInputPattern);
-                }
-            }
-        }
-
-        private static void ValidateKeysFormat(StringValues keys)
-        {
-            foreach (var key in keys)
-            {
-                if (string.IsNullOrWhiteSpace(key))
-                {
-                    throw new UserFriendlyException("There are empty Keys captured which are required");
-                }
-
-                if (!IsValidInput(key))
-                {
-                    throw new UserFriendlyException("The following characters are allowed for Keys: " + validInputPattern);
-                }
-            }
-        }
-
-        private static void ValidateKeysUnique(StringValues keys)
-        {
-            if (keys.Distinct().Count() != keys.Count)
-            {
-                throw new UserFriendlyException("Provided Keys must be unique");
-            }
-        }
-
-        private static void ValidateValuesAdded(StringValues keys, StringValues labels)
-        {
-            if (keys.Count == 0 || labels.Count == 0)
-            {
-                throw new UserFriendlyException("Both Keys and Values are required");
-            }
-        }
-
-        public async Task<IViewComponentResult> InvokeAsync(string? definition)
+        public override async Task<IViewComponentResult> InvokeAsync(string? definition)
         {
             if (definition != null)
             {
@@ -124,12 +63,6 @@ namespace Unity.Flex.Web.Views.Shared.Components.SelectListDefinitionWidget
             }
 
             return View(await Task.FromResult(new SelectListDefinitionViewModel()));
-        }
-
-        public static bool IsValidInput(string input)
-        {
-            Regex regex = MyRegex();
-            return regex.IsMatch(input);
         }
     }
 


### PR DESCRIPTION
- based initially on a codeQL scan to sanitize input fields for the key value pair worksheet widgets
  - Add more sanitization and validation in the javascript for the checkboxgroup and listvalue definition widget
  - Refactor the checkboxgroup and listvalue definition widgets to use common base class to reduce code duplication