### PR TITLE
feature/AB#26535 - Render Notes Column on Applications List

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.css
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.css
@@ -777,3 +777,7 @@ input.form-control.disabled:read-only, textarea.form-control.disabled:read-only,
 .overflow-tooltip {
     text-overflow: ellipsis;
 }
+
+.multi-line {
+    white-space: pre-wrap !important;
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.js
@@ -932,6 +932,10 @@
             name: 'notes',
             data: 'notes',
             className: 'data-table-header multi-line',
+            width: "20rem",
+            createdCell: function (td) {
+                $(td).css('min-width', '20rem');
+            },
             render: function (data) {
                 return data ?? '';
             },

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.js
@@ -155,6 +155,7 @@
             getSigningAuthorityCellPhoneColumn(),
             getPlaceColumn(),
             getRiskRankingColumn(),
+            getNotesColumn(),
         ]
             .map((column) => ({ ...column, targets: [column.index], orderData: [column.index, 0] }));
     }
@@ -922,6 +923,19 @@
                 return titleCase(data ?? '') ?? '';
             },
             index: 55
+        }
+    }
+
+    function getNotesColumn() {
+        return {
+            title: 'Notes',
+            name: 'notes',
+            data: 'notes',
+            className: 'data-table-header multi-line',
+            render: function (data) {
+                return data ?? '';
+            },
+            index: 56
         }
     }
 


### PR DESCRIPTION
# Render Notes Column on Applications List
- The user can configure Notes as part of the column to be displayed in the Application List page
- The user can export the list along with the notes
- Notes cells support multi-line text and whitespace
- Notes column min-width set to 20rem~=300px