### PR TITLE
AB#26781 update serilog file config to use shared mode

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.Development.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.Development.json
@@ -54,7 +54,8 @@
           "rollingInterval": "Day",
           "rollOnFileSizeLimit": true,
           "retainedFileCountLimit": 31,
-          "formatter": "Serilog.Formatting.Json.JsonFormatter, Serilog"
+          "formatter": "Serilog.Formatting.Json.JsonFormatter, Serilog",
+          "shared": true
         }
       }
     ],

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.json
@@ -131,7 +131,8 @@
           "path": "logs/log.txt",
           "rollingInterval": "Day",
           "rollOnFileSizeLimit": true,
-          "formatter": "Serilog.Formatting.Json.JsonFormatter, Serilog"
+          "formatter": "Serilog.Formatting.Json.JsonFormatter, Serilog",
+          "shared": true
         }
       }
     ],


### PR DESCRIPTION
When using multiple pods, we should set the file mode as shared for the log file(s)
Leaving the mode as shared by default, don't see any harm in making this the default

https://github.com/serilog/serilog-sinks-file?tab=readme-ov-file#shared-log-files
