### PR TITLE
AB#26870 - scoresheet validation 

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Application/Domain/Services/ScoresheetsManager.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Application/Domain/Services/ScoresheetsManager.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Unity.Flex.Domain.ScoresheetInstances;
 using Unity.Flex.Domain.Scoresheets;
@@ -52,8 +51,10 @@ namespace Unity.Flex.Domain.Services
         public static bool IsProvided(this Answer answer)
         {
             if (answer.Question == null) return false;
-            var currentValue = ValueConverter.Convert(answer.CurrentValue ?? string.Empty, answer.Question.Type);
-            return !currentValue.IsNullOrEmpty(); // Is provided, if the currentvalue is not null or empty
+            var currentValue = ValueResolver.Resolve(answer.CurrentValue ?? string.Empty, answer.Question.Type);
+            if (currentValue == null) return false;
+            if (string.IsNullOrEmpty(currentValue.ToString())) return false;
+            return true;
         }
     }
 }


### PR DESCRIPTION
Fix the isProvided method validation logic to determine if a field has an actual value.


Once a scoresheet is configured:

1. Change a dropdown value to a valid option and Save Changes:
2. Change the value back to the 'Please choose' option and Save Changes:
3. When trying to Complete The Assessment, this value is not rejected as a required field, and the Assessment is Completed.
-- This should reject completing the Scoresheet as there is no actual value saved