### PR TITLE
AB#26747 codeQL fix

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/BCAddressWidget/BCAddressWidgetController.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/BCAddressWidget/BCAddressWidgetController.cs
@@ -16,7 +16,7 @@ namespace Unity.Flex.Web.Views.Shared.Components.BCAddressWidget
         {
             if (!ModelState.IsValid)
             {
-                Logger.LogWarning("Invalid model state for Refresh: {ModelName}, {FieldModel}", modelName.SanitizeField(), fieldModel);
+                Logger.LogWarning("Invalid model state for Refresh: {ModelName}, {FieldModel}", modelName.SanitizeField(), fieldModel?.Id.ToString());
                 return ViewComponent(typeof(BCAddressWidget));
             }
             return ViewComponent(typeof(BCAddressWidget), new { fieldModel, modelName });


### PR DESCRIPTION
- address codeql warning 
- we are logging the whole object here when in an invalid state
- logging just the id if available and the modelname if invalid