### PR TITLE
AB#27088 set ABP cli version to 8.1.4

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Dockerfile
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Dockerfile
@@ -38,7 +38,7 @@ RUN dotnet restore "src/Unity.GrantManager.Web/Unity.GrantManager.Web.csproj"
 COPY . .
 WORKDIR "/src/src/Unity.GrantManager.Web"
 
-RUN dotnet tool install -g Volo.Abp.Cli
+RUN dotnet tool install -g Volo.Abp.Cli --version 8.1.4
 ENV PATH="${PATH}:/root/.dotnet/tools"
 RUN dotnet dev-certs https --trust
 RUN abp install-libs


### PR DESCRIPTION
explicitly set the ABP cli version in the docker build to 8.1.4