### PR TITLE
bugfix/AB#27077 - Settings Management Bugfixes

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Settings/GrantManagerSettingDefinitionProvider.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Settings/GrantManagerSettingDefinitionProvider.cs
@@ -27,7 +27,7 @@ public class GrantManagerSettingDefinitionProvider : SettingDefinitionProvider
             { SettingsConstants.UI.Tabs.Project, true },
             { SettingsConstants.UI.Tabs.Applicant, true },
             { SettingsConstants.UI.Tabs.Payments, true },
-            { SettingsConstants.UI.Tabs.FundingAgreement, false }
+            { SettingsConstants.UI.Tabs.FundingAgreement, true }
         };
 
         foreach (var setting in tabSettings)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Unity.GrantManager.Web.csproj
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Unity.GrantManager.Web.csproj
@@ -41,6 +41,12 @@
     <None Update="Views\Shared\**\*.css">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Components\**\*.js">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Components\**\*.css">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bugfix changes:
* [`applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Settings/GrantManagerSettingDefinitionProvider.cs`](diffhunk://#diff-047dd79f9598f9d4bd9ce1e0ae25318eeffffe7bf4e2b885d95afc1c06729eccL30-R30): Set the `FundingAgreement` tab default to be `true`.

* [`applications/Unity.GrantManager/src/Unity.GrantManager.Web/Unity.GrantManager.Web.csproj`](diffhunk://#diff-1d3e0a0f06da33c2285144d55079c2c8aeeac37b2313351928bd4dc859a4aaf4R44-R49): Changed the project file to ensure that JavaScript and CSS files in the `Components` directory are always copied to the output directory.