### PR TITLE
Bugfix/ab#27279 fix storedvalue datagrid formats

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Shared/ValueConverterHelper.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Shared/ValueConverterHelper.cs
@@ -17,6 +17,18 @@ namespace Unity.Flex
             return string.Empty;
         }
 
+        public static string ConvertDateTime(object? value)
+        {
+            if (value == null) return string.Empty;
+            var strVal = value.ToString();
+            if (strVal == null) return string.Empty;
+
+            var culture = new CultureInfo("en-CA");
+            var parseDate = DateTime.TryParse(strVal, culture, DateTimeStyles.None, out DateTime date);
+            if (parseDate) return date.ToString("yyyy-MM-dd HH:mm:ss");
+            return string.Empty;
+        }
+
         public static string ConvertDecimal(object? value)
         {
             var valid = decimal.TryParse(value?.ToString(), out decimal decimalValue);

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Pages/Components/DataGrid/DataGridReadService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Pages/Components/DataGrid/DataGridReadService.cs
@@ -30,7 +30,7 @@ namespace Unity.Flex.Web.Pages.Flex
                 var typeTuple = keyValueTypes.Find(kvt => kvt.Item1 == key);
                 if (typeTuple != null)
                 {
-                    var formattedValue = value.ApplyFormatting(typeTuple.Item3.ToString(), null);
+                    var formattedValue = value.ApplyPresentationFormatting(typeTuple.Item3.ToString(), null);
                     formattedKeyValuePairs.Add(key, formattedValue);
                 }
                 else

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Pages/Components/DataGrid/DataGridWriteService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Pages/Components/DataGrid/DataGridWriteService.cs
@@ -163,7 +163,7 @@ namespace Unity.Flex.Web.Pages.Flex
                 newCells.Add(new DataGridRowCell()
                 {
                     Key = value.Item1,
-                    Value = value.Item2.ApplyFormatting(value.Item3.ToString(), null)
+                    Value = value.Item2.ApplyStoreFormatting(value.Item3.ToString())
                 });
             }
 

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/DataGridWidget/DataGridWidget.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/DataGridWidget/DataGridWidget.cs
@@ -163,7 +163,7 @@ namespace Unity.Flex.Web.Views.Shared.Components.DataGridWidget
                         cells.Add(new DataGridViewModelCell()
                         {
                             Key = fieldMatch.Key,
-                            Value = fieldMatch.Value.ApplyFormatting(column.Type, column.Format)
+                            Value = fieldMatch.Value.ApplyPresentationFormatting(column.Type, column.Format)
                         });
                     }
                     else
@@ -360,7 +360,7 @@ namespace Unity.Flex.Web.Views.Shared.Components.DataGridWidget
                 summary.Fields.Add(new DataGridViewModelSummaryField()
                 {
                     Key = field.Key,
-                    Value = SumCells(field.Key, rows).ApplyFormatting(field.Type, null),
+                    Value = SumCells(field.Key, rows).ApplyPresentationFormatting(field.Type, null),
                     Label = $"{_summaryLabelprefix} {field.Name}",
                     Type = field.Type
                 });
@@ -416,7 +416,7 @@ namespace Unity.Flex.Web.Views.Shared.Components.DataGridWidget
 
     public static class DataGridExtensions
     {
-        public static string ApplyFormatting(this string value, string columnType, string? format)
+        public static string ApplyPresentationFormatting(this string value, string columnType, string? format)
         {
             if (value == null) return string.Empty;
 
@@ -431,11 +431,25 @@ namespace Unity.Flex.Web.Views.Shared.Components.DataGridWidget
             };
         }
 
+
+        public static string ApplyStoreFormatting(this string value, string columnType)
+        {
+            return columnType switch
+            {
+                var ct when IsDateColumn(ct) => ValueConverterHelpers.ConvertDate(value),
+                var ct when IsDateTimeColumn(ct) => ValueConverterHelpers.ConvertDateTime(value),
+                var ct when IsCurrencyColumn(ct) => ValueConverterHelpers.ConvertDecimal(value),
+                var ct when IsYesNoColumn(ct) => ValueConverterHelpers.ConvertYesNo(value),
+                var ct when IsCheckBoxColumn(ct) => ValueConverterHelpers.ConvertCheckbox(value),
+                _ => value
+            };
+        }
+
         private static bool TryParseDateTime(string value, string? format, out string formattedDateTime)
         {
             if (DateTime.TryParse(value, new CultureInfo("en-CA"), DateTimeStyles.None, out DateTime dateTime))
             {
-                var appliedFormat = !string.IsNullOrEmpty(format) ? format : "MM-dd-yyyy hh:mm:ss tt";
+                var appliedFormat = !string.IsNullOrEmpty(format) ? format : "yyyy-MM-dd hh:mm:ss tt";
                 formattedDateTime = dateTime.ToString(appliedFormat, CultureInfo.InvariantCulture);
                 return true;
             }
@@ -491,7 +505,7 @@ namespace Unity.Flex.Web.Views.Shared.Components.DataGridWidget
         {
             if (DateTime.TryParse(value, new CultureInfo("en-CA"), DateTimeStyles.None, out DateTime dateTime))
             {
-                var appliedFormat = !string.IsNullOrEmpty(format) ? format : "MM-dd-yyyy";
+                var appliedFormat = !string.IsNullOrEmpty(format) ? format : "yyyy-MM-dd";
                 formattedDate = dateTime.ToString(appliedFormat, CultureInfo.InvariantCulture);
                 return true;
             }

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/DataGridWidget/Default.js
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/DataGridWidget/Default.js
@@ -188,13 +188,15 @@ $(function () {
 
                 // Access the data attributes
                 let tableElement = $('#' + tableId);
-                let dataValueId = tableElement.data('value-id');
-                let dataFieldId = tableElement.data('field-id');
-                let dataWsId = tableElement.data('ws-id');
-                let dataWsiId = tableElement.data('wsi-id');
-                let dataUiAnchor = tableElement.data('ws-anchor');
+                let tableDataSet = tableElement[0].dataset;
 
-                openEditDatagridRowModal(dataValueId, dataFieldId, dataWsId, dataWsiId, 0, true, dataUiAnchor);
+                openEditDatagridRowModal(tableDataSet.valueId,
+                    tableDataSet.fieldId,
+                    tableDataSet.wsId,
+                    tableDataSet.wsiId,
+                    0,
+                    true,
+                    tableDataSet.wsAnchor);
             }
         },
         {
@@ -299,7 +301,7 @@ $(function () {
         let tableDataSet = table[0].dataset;
 
         openEditDatagridRowModal(tableDataSet.valueId,
-            tableDataSet.fieldId,            
+            tableDataSet.fieldId,
             tableDataSet.wsId,
             tableDataSet.wsiId,
             rowDataSet.rowNo,


### PR DESCRIPTION
- update the way the datagrid to worksheet formats are parsed for custom fields
- change from using JQuery.obj.data() to using the raw obj[0].dataset as there can be unexpected caching issues withe the JQuery.obj.data() vs the raw obj[0].dataset which was causing an issue with row adds