### PR TITLE
AB#27279 update other custom datagrids when needed

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/DataGridWidget/Default.js
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/DataGridWidget/Default.js
@@ -45,6 +45,17 @@ $(function () {
             .attr('data-wsi-id', response.responseText.worksheetInstanceId)
             .attr('data-ws-id', response.responseText.worksheetId)
             .attr('data-ws-anchor', response.responseText.uiAnchor);
+
+        // Find the form containing the row
+        let form = row.closest('form');
+
+        // Find other tables within the same form with class 'custom-dynamic-table'
+        let otherTables = form.find('table.custom-dynamic-table');
+
+        // Set the worksheet instance ID for these tables
+        otherTables.each(function () {
+            $(this).attr('data-wsi-id', response.responseText.worksheetInstanceId);
+        });
     }
 
     // Function to update an existing row


### PR DESCRIPTION
- in this edge case a duplicate worksheetinstance is created when a new worksheetinstance is created via another custom datagrid within the same instance and then subsequently another table also has data added without a page refresh
- the table responsible for creating the new instance is updated correctly, but any other custom datagrid tables within the same worksheet also need to reflect the newer worksheetinstance id, otherwise the result is a duplicate worksheetinstance