### PR TITLE
AB#27279 Field Worksheet Update First

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Pages/Components/DataGrid/DataGridWriteService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Pages/Components/DataGrid/DataGridWriteService.cs
@@ -20,6 +20,8 @@ namespace Unity.Flex.Web.Pages.Flex
     {
         internal async Task<WriteDataRowResponse> WriteRowAsync(RowInputData rowInputData)
         {
+            rowInputData.WorksheetInstanceId = await ValidateWorksheetInstanceId(rowInputData);
+
             if (IsAddFirstRow(rowInputData))
             {
                 return await AddFirstRowAsync(rowInputData);
@@ -32,6 +34,24 @@ namespace Unity.Flex.Web.Pages.Flex
             {
                 return await UpdateRowAsync(rowInputData);
             }
+        }
+
+        private async Task<Guid> ValidateWorksheetInstanceId(RowInputData rowInputData)
+        {
+            if (rowInputData.WorksheetInstanceId == Guid.Empty)
+            {
+                // Make sure we dont have an existing instance via another field within the same form
+
+                var worksheetInstance = await worksheetInstanceAppService
+                    .GetByCorrelationAnchorAsync(rowInputData.ApplicationId, CorrelationConsts.Application, rowInputData.WorksheetId, rowInputData.UiAnchor);
+
+                if (worksheetInstance != null)
+                {
+                    rowInputData.WorksheetInstanceId = worksheetInstance.Id;
+                }
+            }
+            
+            return rowInputData.WorksheetInstanceId;
         }
 
         private static bool IsAddFirstRow(RowInputData rowInputData)


### PR DESCRIPTION
- Edge case where a field on the worksheet generates a new worksheet first and then the datagrid is used for edit before a page refresh occurs