### PR TITLE
feature/AB#8196-Redstopnull

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Applicants/ApplicantsService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Applicants/ApplicantsService.cs
@@ -56,6 +56,7 @@ public class ApplicantsService(IApplicantRepository applicantRepository,
             ApproxNumberOfEmployees = intakeMap.ApproxNumberOfEmployees,
             IndigenousOrgInd = intakeMap.IndigenousOrgInd ?? "N",
             OrgStatus = intakeMap.OrgStatus,
+            RedStop = false
         };
 
         return await applicantRepository.InsertAsync(applicant);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Migrations/TenantMigrations/20241212225049_Redstop.Designer.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Migrations/TenantMigrations/20241212225049_Redstop.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unity.GrantManager.EntityFrameworkCore;
@@ -12,9 +13,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace Unity.GrantManager.Migrations.TenantMigrations
 {
     [DbContext(typeof(GrantTenantDbContext))]
-    partial class GrantTenantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241212225049_Redstop")]
+    partial class Redstop
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Migrations/TenantMigrations/20241212225049_Redstop.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Migrations/TenantMigrations/20241212225049_Redstop.cs
@@ -10,19 +10,28 @@ namespace Unity.GrantManager.Migrations.TenantMigrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AddColumn<bool>(
+            migrationBuilder.AlterColumn<bool>(
                 name: "RedStop",
                 table: "Applicants",
                 type: "boolean",
-                nullable: true);
+                nullable: true,
+                defaultValue: false,
+                oldType: "boolean",
+                oldNullable: false);
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropColumn(
+            migrationBuilder.AlterColumn<bool>(
                 name: "RedStop",
-                table: "Applicants");
+                table: "Applicants",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false,
+                oldType: "boolean",
+                oldNullable: true);
         }
+
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Migrations/TenantMigrations/20241212225049_Redstop.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Migrations/TenantMigrations/20241212225049_Redstop.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unity.GrantManager.Migrations.TenantMigrations
+{
+    /// <inheritdoc />
+    public partial class Redstop : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "RedStop",
+                table: "Applicants",
+                type: "boolean",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RedStop",
+                table: "Applicants");
+        }
+    }
+}


### PR DESCRIPTION
Created a migration which picks up on the model change:

Ran: 

C:\Work\Economy\UnityOnGit\Unity\applications\Unity.GrantManager\src\Unity.GrantManager.EntityFrameworkCore>dotnet ef migrations  add Redstop --context GrantTenantDbContext