### PR TITLE
AB#27395 - Bugfix - Add AssessmentStartDate on create first assessment

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/ApplicationManager.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/ApplicationManager.cs
@@ -185,7 +185,7 @@ public class ApplicationManager : DomainService, IApplicationManager
         application.ApplicationStatusId = statusChangedTo.Id;
         application.ApplicationStatus = statusChangedTo;
 
-        if (triggerAction == GrantApplicationAction.StartAssessment)
+        if (triggerAction == GrantApplicationAction.StartAssessment || triggerAction == GrantApplicationAction.Internal_StartAssessment)
         {
             application.AssessmentStartDate = DateTime.UtcNow;
         }


### PR DESCRIPTION
Bugfix to include populating AssessmentStartDate when `Internal_StartAssessment` is triggered.