### PR TITLE
Feature/ab#26962 payment error identification

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application.Contracts/PaymentRequests/PaymentRequestDto.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application.Contracts/PaymentRequests/PaymentRequestDto.cs
@@ -29,6 +29,7 @@ namespace Unity.Payments.PaymentRequests
         public string BatchName { get; set; }
         public decimal BatchNumber { get; set; }
         public string ReferenceNumber { get;  set; } = string.Empty;
+        public string? ErrorSummary { get; set; }
 
 
         public  Collection<ExpenseApprovalDto> ExpenseApprovals { get;  set; }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/PaymentsApplicationAutoMapperProfile.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/PaymentsApplicationAutoMapperProfile.cs
@@ -12,7 +12,9 @@ public class PaymentsApplicationAutoMapperProfile : Profile
 {
     public PaymentsApplicationAutoMapperProfile()
     {
-        CreateMap<PaymentRequest, PaymentRequestDto>();
+        CreateMap<PaymentRequest, PaymentRequestDto>()
+            .ForMember(dest => dest.ErrorSummary, options => options.Ignore());
+
         CreateMap<PaymentRequest, PaymentDetailsDto>();
         CreateMap<ExpenseApproval, ExpenseApprovalDto>();
         CreateMap<Site, SiteDto>()

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.css
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.css
@@ -31,3 +31,7 @@
 .payment-status-transition-arrow {
     color: #42814A;
 }
+
+.error-icon {
+    color: #fa2828;
+}

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.css
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.css
@@ -32,6 +32,15 @@
     color: #42814A;
 }
 
-.error-icon {
-    color: #fa2828;
+#PaymentRequestListTable .error-icon {
+    color: var(--mp-alt-row-color);
+}
+
+#PaymentRequestListTable .error-icon-selected {
+    color: var(--mp-warning-color);
+}
+
+#PaymentRequestListTable .error-row td {
+    background-color: var(--mp-warning-color);
+    color: var(--mp-alt-row-color) !important;
 }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.css
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.css
@@ -33,14 +33,14 @@
 }
 
 #PaymentRequestListTable .error-icon {
-    color: var(--mp-alt-row-color);
+    color: #FF0909;
 }
 
 #PaymentRequestListTable .error-icon-selected {
-    color: var(--mp-warning-color);
+    color: #FF0909;
 }
 
 #PaymentRequestListTable .error-row td {
-    background-color: var(--mp-warning-color);
-    color: var(--mp-alt-row-color) !important;
+    background-color: #FEEAEA;
+    color: #FF0909 !important;
 }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.js
@@ -105,9 +105,16 @@ $(function () {
         defaultVisibleColumns,
         listColumns, 10, 9, unity.payments.paymentRequests.paymentRequest.getList, {}, responseCallback, actionButtons, 'dynamicButtonContainerId');
 
-    // Attach the draw event to the DataTable 
+    // Attach the draw event to add custom row coloring logic
     dataTable.on('draw', function () {
-        // Initialize tooltips 
+        dataTable.rows().every(function () {
+            let data = this.data();
+            if (data.errorSummary != null && data.errorSummary !== '') {
+                $(this.node()).addClass('error-row'); // Change to your desired color
+            }
+        });
+
+        // Initialize tooltips
         $('[data-toggle="tooltip"]').tooltip();
     });
 
@@ -138,6 +145,12 @@ $(function () {
                 if ($(".chkbox:checked").length == $(".chkbox").length) {
                     $(".select-all-payments").prop("checked", true);
                 }
+                let row = dataTable.row(index).node();
+                let data = dataTable.row(index).data();
+                if (data.errorSummary != null && data.errorSummary !== '') {
+                    $(row).removeClass('error-row');
+                    $(row).find('i.fa-flag').addClass('error-icon-selected');
+                }
                 selectApplication(type, index, 'select_batchpayment_application');
             });
         }
@@ -150,6 +163,12 @@ $(function () {
                 $("#row_" + index).prop("checked", false);
                 if ($(".chkbox:checked").length != $(".chkbox").length) {
                     $(".select-all-payments").prop("checked", false);
+                }
+                let row = dataTable.row(index).node();
+                let data = dataTable.row(index).data();
+                if (data.errorSummary != null && data.errorSummary !== '') {
+                    $(row).addClass('error-row');
+                    $(row).find('i.fa-flag').removeClass('error-icon-selected');
                 }
             });
         }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.js
@@ -105,6 +105,12 @@ $(function () {
         defaultVisibleColumns,
         listColumns, 10, 9, unity.payments.paymentRequests.paymentRequest.getList, {}, responseCallback, actionButtons, 'dynamicButtonContainerId');
 
+    // Attach the draw event to the DataTable 
+    dataTable.on('draw', function () {
+        // Initialize tooltips 
+        $('[data-toggle="tooltip"]').tooltip();
+    });
+
     let payment_approve_buttons = dataTable.buttons(['.payment-status']);
     let history_button = dataTable.buttons(['.history']);
 
@@ -233,15 +239,23 @@ $(function () {
             data: 'referenceNumber',
             className: 'data-table-header',
             index: 0,
+            render: function (data, _, row) {
+                if (row.errorSummary != null && row.errorSummary !== '') {
+                    return `${data} <i class="fa fa-flag error-icon" data-toggle="tooltip" title="${row.errorSummary}"></i>`;
+                } else {
+                    return data;
+                }
+            }
         };
     }
+
     function getApplicantNameColumn() {
         return {
             title: l('ApplicationPaymentListTable:ApplicantName'),
             name: 'applicantName',
             data: 'payeeName',
             className: 'data-table-header',
-            index: 1,
+            index: 1
         };
     }
 


### PR DESCRIPTION
- add the ability to highlight in red any payment records in an error state
- currently the only error summary logic looks at the casresponse, and if not empty and not SUCCEEDED then highlight the record and add the error to the tooltip of the error flag that has been added

![image](https://github.com/user-attachments/assets/e5f7bbdf-2ac2-4345-ac79-a12fa6dd62f4)
