### PR TITLE
Feature/ab#26813 map description for payment to advice comments

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Integrations/Cas/InvoiceService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Integrations/Cas/InvoiceService.cs
@@ -84,6 +84,7 @@ namespace Unity.Payments.Integrations.Cas
                 casInvoice.GlDate = dateStringDayMonYear;
                 casInvoice.InvoiceAmount = paymentRequest.Amount;
                 casInvoice.InvoiceBatchName = paymentRequest.BatchName;
+                casInvoice.PaymentAdviceComments = paymentRequest.Description;
 
                 InvoiceLineDetail invoiceLineDetail = new InvoiceLineDetail();
                 invoiceLineDetail.InvoiceLineNumber = 1;

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/PaymentsModel.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/PaymentsModel.cs
@@ -12,6 +12,7 @@ namespace Unity.Payments.Web.Pages.Payments
         [Required]
         public decimal Amount { get; set; }
         [DisplayName("ApplicationPaymentRequest:Description")]
+        [MaxLength(40)]
         public string? Description { get; set; }
         [Required(ErrorMessage = "This field is required.")]
         [DisplayName("ApplicationPaymentRequest:InvoiceNumber")]


### PR DESCRIPTION
- Have mapped the payment advice comments to the value from the details field captured for payment

![image](https://github.com/user-attachments/assets/3cbfde50-2e66-48f3-a484-0418daf452a6)

![image](https://github.com/user-attachments/assets/3e62c9e5-d9b7-4309-a439-39b1b0116450)

James- the 40 limit was put in based on the Char Max/Format:
![image](https://github.com/user-attachments/assets/873e1b69-0935-4ab3-acd2-50518b231aca)

This can be found in the sharepoint.

We need to put a max on the description field also now
