### PR TITLE
Bugfix/ab#27402 GitHub actions open shift CLI

### DIFF
--- a/.github/workflows/docker-build-dev.yml
+++ b/.github/workflows/docker-build-dev.yml
@@ -115,7 +115,6 @@ jobs:
         echo "buildArgs UNITY_BUILD_VERSION: ${{env.UGM_BUILD_VERSION}}, UNITY_BUILD_REVISION: ${{env.UGM_BUILD_REVISION}}"
         docker build --build-arg UNITY_BUILD_VERSION=${{env.UGM_BUILD_VERSION}} --build-arg UNITY_BUILD_REVISION=${{env.UGM_BUILD_REVISION}} -t unity-grantmanager-web -f src/Unity.GrantManager.Web/Dockerfile .
         docker build -t unity-grantmanager-dbmigrator -f src/Unity.GrantManager.DbMigrator/Dockerfile .
-
       working-directory: ./applications/Unity.GrantManager
     - name: Connect to JFrog Artifactory non-interactive login using --password-stdin
       run: |
@@ -129,6 +128,13 @@ jobs:
     - name: Disconnect docker from JFrog Artifactory
       run: |
         docker logout
+    - name: Install OpenShift CLI
+      run: |
+          curl -LO https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
+          tar -xvf oc.tar.gz
+          sudo mv oc /usr/local/bin
+    - name: Verify OpenShift CLI installation
+      run: oc version
     - name: Connect to OpenShift API non-interactive login using current session token
       run: |
         oc login --token=$OC_AUTH_TOKEN --server=$OC_CLUSTER

--- a/.github/workflows/docker-build-main.yml
+++ b/.github/workflows/docker-build-main.yml
@@ -183,6 +183,13 @@ jobs:
     - name: Disconnect docker from JFrog Artifactory
       run: |
         docker logout
+    - name: Install OpenShift CLI
+      run: |
+          curl -LO https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
+          tar -xvf oc.tar.gz
+          sudo mv oc /usr/local/bin
+    - name: Verify OpenShift CLI installation
+      run: oc version
     - name: Connect to OpenShift API non-interactive login using current session token
       run: |
         oc login --token=$OC_AUTH_TOKEN --server=$OC_CLUSTER

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -51,7 +51,8 @@ jobs:
         env | sort
     - name: Get current date
       id: date_selector
-      run: echo "DATE=$(date +'%B %e, %Y')" >> $GITHUB_OUTPUT
+      run: |
+        echo "DATE=$(date +'%B %e, %Y')" >> $GITHUB_OUTPUT
     outputs:
       DATE: ${{steps.date_selector.outputs.DATE}}
   Branch:
@@ -160,6 +161,13 @@ jobs:
     - name: Disconnect docker from JFrog Artifactory
       run: |
         docker logout
+    - name: Install OpenShift CLI
+      run: |
+          curl -LO https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
+          tar -xvf oc.tar.gz
+          sudo mv oc /usr/local/bin
+    - name: Verify OpenShift CLI installation
+      run: oc version
     - name: Connect to OpenShift API non-interactive login using current session token
       run: |
         oc login --token=$OC_AUTH_TOKEN --server=$OC_CLUSTER

--- a/.github/workflows/manual-trigger.yml
+++ b/.github/workflows/manual-trigger.yml
@@ -116,7 +116,7 @@ jobs:
       run: |
         echo "$JFROG_PASSWORD" | docker login -u "$JFROG_USERNAME" --password-stdin $JFROG_SERVICE
     - name: Push application images to Artifactory container registry
-      run:  |
+      run: |
         docker tag unity-grantmanager-dbmigrator $JFROG_SERVICE/$JFROG_REPO_PATH/unity-grantmanager-dbmigrator
         # docker push $JFROG_SERVICE/$JFROG_REPO_PATH/unity-grantmanager-dbmigrator
         docker tag unity-grantmanager-web $JFROG_SERVICE/$JFROG_REPO_PATH/unity-grantmanager-web
@@ -124,13 +124,20 @@ jobs:
     - name: Disconnect docker from JFrog Artifactory
       run: |
         docker logout
+    - name: Install OpenShift CLI
+      run: |
+          curl -LO https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
+          tar -xvf oc.tar.gz
+          sudo mv oc /usr/local/bin
+    - name: Verify OpenShift CLI installation
+      run: oc version
     - name: Connect to OpenShift API non-interactive login using current session token
       run: |
         oc login --token=$OC_AUTH_TOKEN --server=$OC_CLUSTER
         oc registry login
         docker login -u unused -p $(oc whoami -t) $OC_REGISTRY
     - name: Push application images to OpenShift container registry
-      run:  |
+      run: |
         docker tag unity-grantmanager-dbmigrator $OC_REGISTRY/$OC_TARGET_PROJECT/unity-grantmanager-dbmigrator
         # docker push $OC_REGISTRY/$OC_TARGET_PROJECT/unity-grantmanager-dbmigrator
         docker tag unity-grantmanager-web $OC_REGISTRY/$OC_TARGET_PROJECT/unity-grantmanager-web


### PR DESCRIPTION
Fix for workflow runs GitHub Actions removed OpenShift CLI from latest Ubuntu release. Added steps to download and verify oc commands are available. 