### PR TITLE
feature/AB#27014 and AB#27016 - Add External Assessor Permissions Restrictions

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Permissions/GrantApplications/GrantApplicationPermissionDefinitionProvider.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Permissions/GrantApplications/GrantApplicationPermissionDefinitionProvider.cs
@@ -43,8 +43,13 @@ namespace Unity.GrantManager.Permissions.GrantApplications
 
             // Assessment Results
             var assessmentResultPermissions = grantApplicationPermissionsGroup.AddPermission(GrantApplicationPermissions.AssessmentResults.Default, L("Permission:GrantApplicationPermissions.AssessmentResults.Default"));
-            var assessmentResultUpdatePermissions = assessmentResultPermissions.AddChild(GrantApplicationPermissions.AssessmentResults.Edit, L("Permission:GrantApplicationPermissions.AssessmentResults.Edit"));
-            assessmentResultUpdatePermissions.AddChild(GrantApplicationPermissions.AssessmentResults.EditFinalStateFields, L("Permission:GrantApplicationPermissions.AssessmentResults.EditFinalStateFields"));
+            var updateAssessmentResultPermissions = assessmentResultPermissions.AddChild(GrantApplicationPermissions.AssessmentResults.Edit, L("Permission:GrantApplicationPermissions.AssessmentResults.Edit"));
+            updateAssessmentResultPermissions.AddChild(GrantApplicationPermissions.AssessmentResults.EditFinalStateFields, L("Permission:GrantApplicationPermissions.AssessmentResults.EditFinalStateFields"));
+
+            // Project Info
+            var projectInfoPermissions = grantApplicationPermissionsGroup.AddPermission(GrantApplicationPermissions.ProjectInfo.Default, L("Permission:GrantApplicationManagement.ProjectInfo"));
+            var updateProjectInfoPermissions = projectInfoPermissions.AddChild(GrantApplicationPermissions.ProjectInfo.Update, L("Permission:GrantApplicationManagement.ProjectInfo.Update"));
+            updateProjectInfoPermissions.AddChild(GrantApplicationPermissions.ProjectInfo.UpdateFinalStateFields, L("Permission:GrantApplicationManagement.ProjectInfo.Update.UpdateFinalStateFields"));
 
             var settingManagement = context.GetGroup(SettingManagementPermissions.GroupName);
             settingManagement.AddPermission(UnitySettingManagementPermissions.UserInterface, L("Permission:UnitySettingManagementPermissions.UserInterface"));

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Permissions/GrantApplications/GrantApplicationPermissionDefinitionProvider.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Permissions/GrantApplications/GrantApplicationPermissionDefinitionProvider.cs
@@ -43,8 +43,8 @@ namespace Unity.GrantManager.Permissions.GrantApplications
 
             // Assessment Results
             var assessmentResultPermissions = grantApplicationPermissionsGroup.AddPermission(GrantApplicationPermissions.AssessmentResults.Default, L("Permission:GrantApplicationPermissions.AssessmentResults.Default"));
-            assessmentResultPermissions.AddChild(GrantApplicationPermissions.AssessmentResults.Edit, L("Permission:GrantApplicationPermissions.AssessmentResults.Edit"));
-            assessmentResultPermissions.AddChild(GrantApplicationPermissions.AssessmentResults.EditFinalStateFields, L("Permission:GrantApplicationPermissions.AssessmentResults.EditFinalStateFields"));
+            var assessmentResultUpdatePermissions = assessmentResultPermissions.AddChild(GrantApplicationPermissions.AssessmentResults.Edit, L("Permission:GrantApplicationPermissions.AssessmentResults.Edit"));
+            assessmentResultUpdatePermissions.AddChild(GrantApplicationPermissions.AssessmentResults.EditFinalStateFields, L("Permission:GrantApplicationPermissions.AssessmentResults.EditFinalStateFields"));
 
             var settingManagement = context.GetGroup(SettingManagementPermissions.GroupName);
             settingManagement.AddPermission(UnitySettingManagementPermissions.UserInterface, L("Permission:UnitySettingManagementPermissions.UserInterface"));

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/GrantApplicationAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/GrantApplicationAppService.cs
@@ -260,6 +260,7 @@ public class GrantApplicationAppService : GrantManagerAppService, IGrantApplicat
 
     }
 
+    [Authorize(GrantApplicationPermissions.AssessmentResults.Edit)]
     public async Task<GrantApplicationDto> UpdateAssessmentResultsAsync(Guid id, CreateUpdateAssessmentResultsDto input)
     {
         var application = await _applicationRepository.GetAsync(id);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/GrantApplicationAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/GrantApplicationAppService.cs
@@ -318,6 +318,7 @@ public class GrantApplicationAppService : GrantManagerAppService, IGrantApplicat
         return await AuthorizationService.IsGrantedAsync(GrantApplicationPermissions.AssessmentResults.EditFinalStateFields);
     }
 
+    [Authorize(GrantApplicationPermissions.ProjectInfo.Update)]
     public async Task<GrantApplicationDto> UpdateProjectInfoAsync(Guid id, CreateUpdateProjectInfoDto input)
     {
         var application = await _applicationRepository.GetAsync(id);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain.Shared/Identity/UnityRoles.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain.Shared/Identity/UnityRoles.cs
@@ -9,6 +9,7 @@ public static class UnityRoles
     public const string Assessor = "assessor";
     public const string TeamLead = "team_lead";
     public const string Approver = "approver";
+    public const string ExternalAssessor = "external_assessor";
     public const string SystemAdmin = "system_admin";
     public const string FinancialAnalyst = "financial_analyst";
     public const string L1Approver = "l1_approver";
@@ -16,5 +17,5 @@ public static class UnityRoles
     public const string L3Approver = "l3_approver";
 
     public static readonly IReadOnlyList<string> DefinedRoles =
-            new List<string>() { ProgramManager, Reviewer, Assessor, TeamLead, Approver, SystemAdmin, FinancialAnalyst, L1Approver, L2Approver, L3Approver };        
+            new List<string>() { ProgramManager, Reviewer, Assessor, TeamLead, Approver, SystemAdmin, FinancialAnalyst, L1Approver, L2Approver, L3Approver, ExternalAssessor };
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain.Shared/Localization/GrantManager/en.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain.Shared/Localization/GrantManager/en.json
@@ -161,6 +161,10 @@
     "Permission:GrantApplicationPermissions.AssessmentResults.Edit": "Assessment Results Update",
     "Permission:GrantApplicationPermissions.AssessmentResults.EditFinalStateFields": "Edit Fields After Approval",
 
+    "Permission:GrantApplicationManagement.ProjectInfo": "Project Info",
+    "Permission:GrantApplicationManagement.ProjectInfo.Update": "Project Info Update",
+    "Permission:GrantApplicationManagement.ProjectInfo.Update.UpdateFinalStateFields": "Edit Project Info Fields After Approval",
+
     "GrantManager:AssessmentUserAssignmentAlreadyExists": "Business Exception: You cannot create two assessments on an application for the same user.",
     "GrantManager:CantCreateAssessmentForFinalStateApplication": "Business Exception: You cannot create an assessment for an application in final state.",
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain.Shared/Permissions/GrantApplicationPermissions.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain.Shared/Permissions/GrantApplicationPermissions.cs
@@ -57,6 +57,13 @@ namespace Unity.GrantManager.Permissions
             public const string EditFinalStateFields = Default + ".EditFinalStateFields";
         }
 
+        public static class ProjectInfo
+        {
+            public const string Default = GroupName + ".ProjectInfo";
+            public const string Update = Default + ".Update";
+            public const string UpdateFinalStateFields = Update + ".UpdateFinalStateFields";
+        }
+
         public static string[] GetAll()
         {
             return ReflectionHelper.GetPublicConstantsRecursively(typeof(GrantApplicationPermissions));

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Permissions/PermissionGrantsDataSeeder.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Permissions/PermissionGrantsDataSeeder.cs
@@ -46,7 +46,12 @@ namespace Unity.GrantManager.Permissions
                     IdentitySeedPermissions.Roles.Delete,
                     IdentitySeedPermissions.Roles.ManagePermissions,
                     GrantManagerPermissions.Intakes.Default,
-                    GrantManagerPermissions.ApplicationForms.Default
+                    GrantManagerPermissions.ApplicationForms.Default,
+
+                    GrantApplicationPermissions.AssessmentResults.Default,
+                    GrantApplicationPermissions.AssessmentResults.Edit,
+                    GrantApplicationPermissions.ProjectInfo.Default,
+                    GrantApplicationPermissions.ProjectInfo.Update,
                 }, context.TenantId);
 
             // - Reviewer
@@ -65,6 +70,9 @@ namespace Unity.GrantManager.Permissions
                     GrantApplicationPermissions.Assessments.Confirm,
 
                     GrantApplicationPermissions.AssessmentResults.Default,
+                    GrantApplicationPermissions.AssessmentResults.Edit,
+                    GrantApplicationPermissions.ProjectInfo.Default,
+                    GrantApplicationPermissions.ProjectInfo.Update,
                 }, context.TenantId);
 
             // - Assessor
@@ -84,6 +92,8 @@ namespace Unity.GrantManager.Permissions
 
                     GrantApplicationPermissions.AssessmentResults.Default,
                     GrantApplicationPermissions.AssessmentResults.Edit,
+                    GrantApplicationPermissions.ProjectInfo.Default,
+                    GrantApplicationPermissions.ProjectInfo.Update,
                 }, context.TenantId);
 
             // - TeamLead
@@ -107,6 +117,8 @@ namespace Unity.GrantManager.Permissions
 
                     GrantApplicationPermissions.AssessmentResults.Default,
                     GrantApplicationPermissions.AssessmentResults.Edit,
+                    GrantApplicationPermissions.ProjectInfo.Default,
+                    GrantApplicationPermissions.ProjectInfo.Update,
                 }, context.TenantId);
 
             // - Approver
@@ -121,6 +133,9 @@ namespace Unity.GrantManager.Permissions
                     GrantApplicationPermissions.AssessmentResults.Default,
                     GrantApplicationPermissions.AssessmentResults.Edit,
                     GrantApplicationPermissions.AssessmentResults.EditFinalStateFields,
+                    GrantApplicationPermissions.ProjectInfo.Default,
+                    GrantApplicationPermissions.ProjectInfo.Update,
+                    GrantApplicationPermissions.ProjectInfo.UpdateFinalStateFields,
                 }, context.TenantId);
 
             // - SystemAdmin
@@ -139,7 +154,12 @@ namespace Unity.GrantManager.Permissions
                     GrantApplicationPermissions.Assessments.Default,
                     GrantApplicationPermissions.Assessments.Create,
                     GrantApplicationPermissions.Assessments.SendBack,
-                    GrantApplicationPermissions.Assessments.Confirm
+                    GrantApplicationPermissions.Assessments.Confirm,
+
+                    GrantApplicationPermissions.AssessmentResults.Default,
+                    GrantApplicationPermissions.AssessmentResults.Edit,
+                    GrantApplicationPermissions.ProjectInfo.Default,
+                    GrantApplicationPermissions.ProjectInfo.Update,
                 }, context.TenantId);
 
 
@@ -150,7 +170,12 @@ namespace Unity.GrantManager.Permissions
                     GrantManagerPermissions.Default,
                     GrantApplicationPermissions.Applications.Default,
                     PaymentsPermissions.Payments.Default,
-                    PaymentsPermissions.Payments.L1ApproveOrDecline
+                    PaymentsPermissions.Payments.L1ApproveOrDecline,
+
+                    GrantApplicationPermissions.AssessmentResults.Default,
+                    GrantApplicationPermissions.AssessmentResults.Edit,
+                    GrantApplicationPermissions.ProjectInfo.Default,
+                    GrantApplicationPermissions.ProjectInfo.Update,
 
                 }, context.TenantId);
 
@@ -161,8 +186,12 @@ namespace Unity.GrantManager.Permissions
                     GrantManagerPermissions.Default,
                     GrantApplicationPermissions.Applications.Default,
                     PaymentsPermissions.Payments.Default,
-                    PaymentsPermissions.Payments.L2ApproveOrDecline
+                    PaymentsPermissions.Payments.L2ApproveOrDecline,
 
+                    GrantApplicationPermissions.AssessmentResults.Default,
+                    GrantApplicationPermissions.AssessmentResults.Edit,
+                    GrantApplicationPermissions.ProjectInfo.Default,
+                    GrantApplicationPermissions.ProjectInfo.Update,
                 }, context.TenantId);
 
             // -L3 Approver
@@ -172,9 +201,26 @@ namespace Unity.GrantManager.Permissions
                     GrantManagerPermissions.Default,
                     GrantApplicationPermissions.Applications.Default,
                     PaymentsPermissions.Payments.Default,
-                    PaymentsPermissions.Payments.L3ApproveOrDecline
+                    PaymentsPermissions.Payments.L3ApproveOrDecline,
 
+                    GrantApplicationPermissions.AssessmentResults.Default,
+                    GrantApplicationPermissions.AssessmentResults.Edit,
+                    GrantApplicationPermissions.ProjectInfo.Default,
+                    GrantApplicationPermissions.ProjectInfo.Update,
                 }, context.TenantId);
+
+            // -External Assessor
+            await _permissionDataSeeder.SeedAsync(RolePermissionValueProvider.ProviderName, UnityRoles.ExternalAssessor,
+                new List<string>
+                {
+                    GrantManagerPermissions.Default,
+                    GrantApplicationPermissions.Applications.Default,
+                    PaymentsPermissions.Payments.Default,
+
+                    GrantApplicationPermissions.AssessmentResults.Default,
+                    GrantApplicationPermissions.ProjectInfo.Default,
+                }, context.TenantId);
+
         }
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/AssessmentResults.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/AssessmentResults.cs
@@ -34,7 +34,8 @@ namespace Unity.GrantManager.Web.Views.Shared.Components.AssessmentResults
         {
             GrantApplicationDto application = await _grantApplicationAppService.GetAsync(applicationId);
             bool finalDecisionState = GrantApplicationStateGroups.FinalDecisionStates.Contains(application.StatusCode);
-            bool isEditGranted = await _authorizationService.IsGrantedAsync(GrantApplicationPermissions.AssessmentResults.Edit) && !finalDecisionState;
+            bool isFormEditGranted = await _authorizationService.IsGrantedAsync(GrantApplicationPermissions.AssessmentResults.Edit);
+            bool isEditGranted = isFormEditGranted && !finalDecisionState;
             bool isPostEditFieldsAllowed = isEditGranted || (await _authorizationService.IsGrantedAsync(GrantApplicationPermissions.AssessmentResults.EditFinalStateFields) && finalDecisionState);
 
             AssessmentResultsPageModel model = new()
@@ -42,6 +43,7 @@ namespace Unity.GrantManager.Web.Views.Shared.Components.AssessmentResults
                 ApplicationId = applicationId,
                 ApplicationFormId = application.ApplicationForm.Id,
                 ApplicationFormVersionId = applicationFormVersionId,
+                IsFormEditGranted = isFormEditGranted,
                 IsEditGranted = isEditGranted,
                 IsPostEditFieldsAllowed = isPostEditFieldsAllowed,
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/AssessmentResultsViewModel.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/AssessmentResultsViewModel.cs
@@ -22,6 +22,7 @@ namespace Unity.GrantManager.Web.Views.Shared.Components.AssessmentResults
         public Guid ApplicationFormVersionId { get; set; }
 
         public AssessmentResultsModel AssessmentResults { get; set; } = new();
+        public bool IsFormEditGranted { get; set; }
         public bool IsEditGranted { get; set; }
         public bool IsPostEditFieldsAllowed { get; set; }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.cshtml
@@ -25,6 +25,7 @@
     </abp-column>
     <form id="assessmentResultForm">
         <fieldset name="assessmentResults" @(!Model.IsFormEditGranted ? "disabled" : "")>
+            <legend class="d-none">@L["AssessmentResultsView:AssessmentResultsTitle"].Value</legend>
         <abp-row class="m-0 assessment-result-form">
             <abp-column size="_12" class="px-0">
                 <abp-row class="m-0">

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.cshtml
@@ -24,6 +24,7 @@
                     icon-type="Other" icon="fl fl-save" button-type="Primary" disabled="true" />
     </abp-column>
     <form id="assessmentResultForm">
+        <fieldset name="assessmentResults" @(!Model.IsFormEditGranted ? "disabled" : "")>
         <abp-row class="m-0 assessment-result-form">
             <abp-column size="_12" class="px-0">
                 <abp-row class="m-0">
@@ -139,7 +140,7 @@
                      })
             </div>
         }
-
+        </fieldset>
     </form>
 </abp-row>
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.js
@@ -219,7 +219,9 @@ function enableAssessmentResultsSaveBtn() {
         return;
     }
 
-    $('#saveAssessmentResultBtn').prop('disabled', false);
+    if (abp.auth.isGranted('GrantApplicationManagement.AssessmentResults.Update')) {
+        $('#saveAssessmentResultBtn').prop('disabled', false);
+    }
 }
 
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ProjectInfo/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ProjectInfo/Default.cshtml
@@ -34,6 +34,8 @@
                     icon="fl fl-save" button-type="Primary" disabled="true" />
     </abp-column>
     <form id="projectInfoForm">
+        <fieldset name="projectInfo" @(!Model.IsFormEditGranted ? "disabled" : "")>
+            <legend class="d-none">@L["ProjectInfoView:ProjectInfoTitle"].Value</legend>
         <abp-row class="m-0 project-info-form">
             <abp-row class="m-0 p-0">
                 <abp-column size="_6" class="px-1">
@@ -164,7 +166,7 @@
                          uiAnchor = FlexConsts.ProjectInfoUiAnchor                   
                      })
         }
-
+        </fieldset>
     </form>
 </abp-row>
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ProjectInfo/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ProjectInfo/Default.js
@@ -190,7 +190,9 @@ function enableProjectInfoSaveBtn(inputText) {
         return;
     }
 
-    $('#saveProjectInfoBtn').prop('disabled', false);
+    if (abp.auth.isGranted('GrantApplicationManagement.ProjectInfo.Update')) {
+        $('#saveProjectInfoBtn').prop('disabled', false);
+    }
 }
 
 function calculatePercentage() {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ProjectInfo/ProjectInfoViewModel.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ProjectInfo/ProjectInfoViewModel.cs
@@ -42,6 +42,7 @@ namespace Unity.GrantManager.Web.Views.Shared.Components.ProjectInfo
         public List<SelectListItem> CommunityList { get; set; } = new List<SelectListItem>();
         public List<CommunityDto> Communities { get; set; } = new List<CommunityDto>();
         public List<SelectListItem> RegionalDistrictList { get; set; } = new List<SelectListItem>();
+        public bool IsFormEditGranted { get; set; }
         public bool IsEditGranted { get; set; }
         public bool IsPostEditFieldsAllowed { get; set; }
 


### PR DESCRIPTION
Add External Assessor Role and Permissions Restrictions for Application Assessment Results and Project Info forms to make them read-only.

AB#27014 and AB#27016 were combined into one PR due to the shared dependency on `external_assessor`.

- Add `external_assessor` Role
- Modify default permissions for all roles around Assessment Results and Project Info
- Add Project Info Permission Group
- Modify Assessment Results permission hierarchy
  - `Edit Fields After Approval` is a child of `Assessment Results Update` in the permissions interface as update permissions are required for allowing updates given a state.
- Modify `AssessmentResults` and `ProjectInfo` widgets to adhere to new read-only permissions for `external_assessor`.