### PR TITLE
Feature/ab#24950 submission attach download all

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/Bundling/UnityThemeUX2GlobalScriptContributor.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/Bundling/UnityThemeUX2GlobalScriptContributor.cs
@@ -26,5 +26,6 @@ public class UnityThemeUX2GlobalScriptContributor : BundleContributor
 
         context.Files.AddIfNotContains("/libs/datatables.net-fixedheader-bs5/js/fixedHeader.bootstrap5.min.js");
         context.Files.AddIfNotContains("/libs/echarts/echarts.min.js");
+        context.Files.AddIfNotContains("/libs/jszip/jszip.min.js");
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.HttpApi/Controllers/AttachmentController.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.HttpApi/Controllers/AttachmentController.cs
@@ -25,6 +25,9 @@ namespace Unity.GrantManager.Controllers
         private readonly IConfiguration _configuration;
         private readonly ISubmissionAppService _submissionAppService;
         private ILogger logger => LazyServiceProvider.LazyGetService<ILogger>(provider => LoggerFactory?.CreateLogger(GetType().FullName!) ?? NullLogger.Instance);
+        private const string badRequestFileMsg = "File name must be provided.";
+        private const string NotFoundFileMsg = "File not found.";
+        private const string errorFileMsg = "An error occurred while downloading the file.";
 
         public AttachmentController(IFileAppService fileAppService, IConfiguration configuration, ISubmissionAppService submissionAppService)
         {
@@ -48,7 +51,7 @@ namespace Unity.GrantManager.Controllers
 
             if (string.IsNullOrWhiteSpace(fileName))
             {
-                return BadRequest("File name must be provided.");
+                return BadRequest(badRequestFileMsg);
             }
 
             var folder = _configuration["S3:ApplicationS3Folder"] ?? throw new AbpValidationException("Missing server configuration: S3:ApplicationS3Folder");
@@ -67,7 +70,7 @@ namespace Unity.GrantManager.Controllers
 
                 if (fileDto == null || fileDto.Content == null)
                 {
-                    return NotFound("File not found.");
+                    return NotFound(NotFoundFileMsg);
                 }
 
                 return File(fileDto.Content, fileDto.ContentType, fileDto.Name);
@@ -76,7 +79,7 @@ namespace Unity.GrantManager.Controllers
             {
                 string ExceptionMessage = ex.Message;
                 logger.LogError(ex, "AttachmentController->DownloadApplicationAttachment: {ExceptionMessage}", ExceptionMessage);
-                return StatusCode(500, "An error occurred while downloading the file.");
+                return StatusCode(500, errorFileMsg);
             }
         }
 
@@ -95,7 +98,7 @@ namespace Unity.GrantManager.Controllers
 
             if (string.IsNullOrWhiteSpace(fileName))
             {
-                return BadRequest("File name must be provided.");
+                return BadRequest(badRequestFileMsg);
             }
 
             var folder = _configuration["S3:AssessmentS3Folder"] ?? throw new AbpValidationException("Missing server configuration: S3:AssessmentS3Folder");
@@ -114,7 +117,7 @@ namespace Unity.GrantManager.Controllers
 
                 if (fileDto == null || fileDto.Content == null)
                 {
-                    return NotFound("File not found.");
+                    return NotFound(NotFoundFileMsg);
                 }
 
                 return File(fileDto.Content, fileDto.ContentType, fileDto.Name);
@@ -123,7 +126,7 @@ namespace Unity.GrantManager.Controllers
             {
                 string ExceptionMessage = ex.Message;
                 logger.LogError(ex, "AttachmentController->DownloadAssessmentAttachment: {ExceptionMessage}", ExceptionMessage);
-                return StatusCode(500, "An error occurred while downloading the file.");
+                return StatusCode(500, errorFileMsg);
             }
         }
 
@@ -137,7 +140,7 @@ namespace Unity.GrantManager.Controllers
 
             if (string.IsNullOrWhiteSpace(fileName))
             {
-                return BadRequest("File name must be provided.");
+                return BadRequest(badRequestFileMsg);
             }
 
             try
@@ -146,7 +149,7 @@ namespace Unity.GrantManager.Controllers
 
                 if (fileDto == null || fileDto.Content == null)
                 {
-                    return NotFound("File not found.");
+                    return NotFound(NotFoundFileMsg);
                 }
 
                 return File(fileDto.Content, fileDto.ContentType, fileDto.Name);
@@ -155,7 +158,7 @@ namespace Unity.GrantManager.Controllers
             {
                 string ExceptionMessage = ex.Message;
                 logger.LogError(ex, "AttachmentController->DownloadChefsAttachment: {ExceptionMessage}", ExceptionMessage);
-                return StatusCode(500, "An error occurred while downloading the file.");
+                return StatusCode(500, errorFileMsg);
             }
         }
 
@@ -174,16 +177,15 @@ namespace Unity.GrantManager.Controllers
             {
                 if (string.IsNullOrWhiteSpace(item.FileName))
                 {
-                    return BadRequest("File name must be provided.");
+                    return BadRequest(badRequestFileMsg);
                 }
 
                 try
                 {
                     var fileDto = await _submissionAppService.GetChefsFileAttachment(item.FormSubmissionId, item.ChefsFileId, item.FileName);
-                    var x = File(fileDto.Content, fileDto.ContentType, fileDto.Name);
                     if (fileDto.Name == null || fileDto.Content == null)
                     {
-                        return NotFound("File not found.");
+                        return NotFound(NotFoundFileMsg);
                     }
 
                     byte[] fileBytes = fileDto.Content;
@@ -199,7 +201,7 @@ namespace Unity.GrantManager.Controllers
                 {
                     string ExceptionMessage = ex.Message;
                     logger.LogError(ex, "AttachmentController->DownloadAllChefsAttachment: {ExceptionMessage}", ExceptionMessage);
-                    return StatusCode(500, "An error occurred while downloading the file.");
+                    return StatusCode(500, errorFileMsg);
                 }
             }
             return Ok(files);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.HttpApi/Models/Attachments.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.HttpApi/Models/Attachments.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace Unity.GrantManager.Models
 {
     public class AttachmentsDto
 	{
-        public Guid FormSubmissionId { get; set; }
-        public Guid ChefsFileId { get; set; }
+        public Guid? FormSubmissionId { get; set; }
+        public Guid? ChefsFileId { get; set; }
         public string? FileName { get; set; }
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.HttpApi/Models/Attachments.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.HttpApi/Models/Attachments.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Unity.GrantManager.Models
+{
+    public class AttachmentsDto
+	{
+        public Guid FormSubmissionId { get; set; }
+        public Guid ChefsFileId { get; set; }
+        public string? FileName { get; set; }
+    }
+}
+

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/ChefsAttachments.css
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/ChefsAttachments.css
@@ -20,3 +20,11 @@
 .sorting_disabled:after {
     content: "" !important;
 }
+
+.submission-title {
+    display: inline-block;
+}
+
+.submission-button-section {
+    display: flex;
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/ChefsAttachments.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/ChefsAttachments.js
@@ -9,7 +9,12 @@ $(function () {
             setTimeout(function () {
                 PubSub.publish('update_application_attachment_count', { chefs: result.length });
             }, 10);
+
+            if (result.length === 0) { 
+                $('#downloadAll').prop("disabled", true);
+            }
         }
+        
         return {
             data: result
         };
@@ -71,118 +76,72 @@ $(function () {
         }
     });
 
-    $('#attachments-tab').one('click', function () {
+    $('#attachments-tab').on('click', function () {
         dataTable.columns.adjust();
     });
 
-    function extractFileName(url) {
-        const path = new URL(url).pathname;
-        return path.split('/').pop();
-    }
-   
-    $('#downloadAll').click(function () {
-        /*const zip = new JSZip();*/
+    $('#downloadAll').on('click', function () {
+        const _this = $(this);
+        const existingHTML = _this.html();
+        const zip = new JSZip();
         const chefsAttactmentsTable = document.getElementById('ChefsAttachmentsTable');
         const anchorTags = chefsAttactmentsTable.querySelectorAll('a');
-        const hrefValues = [];
-        anchorTags.forEach(anchor => {
-            hrefValues.push(anchor.href);
-        });
+        const tempFiles = [];
 
-        try {
-            // Loop through all the file URLs
-            for (const fileUrl of hrefValues) {
-                const fileName = decodeURIComponent(extractFileName(fileUrl));  // Get the file name from the URL
-                fetch(fileUrl).then(response => {
-                    if (!response.ok) {
-                        throw new Error('Network response was not ok');
-                    }
-                    return response.blob();
-                })
+        if (anchorTags.length > 0) { 
+            anchorTags.forEach(item => {
+                if (item !== null) {
+                    let tempFileName = item.pathname.split('/').pop();
+                    let tempChefsFileId = item.pathname.split('/').slice(-2)[0];
+                    let tempFormSubmissionId = item.pathname.split('/').slice(-4)[0];
 
-                    //This downloads each file one by one
-                    .then(blob => {
-                        let url = window.URL.createObjectURL(blob);
-                        let a = document.createElement('a');
-                        a.style.display = 'none';
-                        a.href = url;
-                        a.download = fileName;
-                        document.body.appendChild(a);
-                        a.click();
-                        window.URL.revokeObjectURL(url);
-                    })
-                    .catch(error => {
-                        console.error('There was a problem with the fetch operation:', error);
+                    tempFiles.push({
+                        FormSubmissionId: tempFormSubmissionId,
+                        ChefsFileId: tempChefsFileId,
+                        Filename: tempFileName
+                    });
+                }
+            });
+        } 
+
+        ////Calls an endpoint
+        $.ajax({
+            url: "/api/app/attachment/chefs/download-all",
+            data: JSON.stringify(tempFiles),
+            contentType: "application/json",
+            type: "POST",
+            beforeSend: function () {
+                //Add loading spinner
+                $(_this).html('<div class="spinner-loading"><span class="spinner-border spinner-border-sm mr-2" role="status" aria-hidden="true"></span> Downloading...</div>').prop('disabled', true);
+            },
+            success: function (data) {
+                data.forEach(file => {
+                    zip.file(file.fileDownloadName, file.fileContents, { base64: true });
+                });
+
+                zip.generateAsync({ type: "blob" })
+                    .then(function (content) {
+                        const link = document.createElement('a');
+                        link.href = URL.createObjectURL(content);
+                        link.download = 'Submission_Files.zip';
+                        link.click();
                     });
 
-                // Add file to the zip
-               /* zip.file(fileName, blob); */
+                abp.notify.success(
+                    '',
+                    'The files have been downloaded successfully.'
+                );
+                //show original HTML and enable
+                $(_this).html(existingHTML).prop('disabled', false);
+            },
+            error: function () {
+                abp.notify.error(
+                    '',
+                    'Error downloading the files.'
+                );
+                $(_this).html(existingHTML).prop('disabled', false);
             }
-
-            // Once all files are added, generate the zip file
-            //zip.generateAsync({ type: 'blob' }).then(function (content) {
-            //    // Create a link to download the zip file
-            //    const link = document.createElement('a');
-            //    link.href = URL.createObjectURL(content);
-            //    link.download = 'files.zip'; // The name of the downloaded zip file
-
-            //    // Trigger the download
-            //    link.click();
-            //}).catch(error => {
-            //            console.error('Error generating ZIP:', error);
-            //    });
-        } catch (error) {
-            console.error('Error downloading files: ', error);
-        }
-
-
-
-        //zip.generateAsync({ type: "blob" })
-        //    .then(function (content) {
-        //        const link = document.createElement('a');
-        //        link.href = URL.createObjectURL(content);
-        //        link.download = 'submissionAttachments.zip';
-        //        link.click();
-        //    });
-
-
-
-        //const fileList = [
-        //    { filename: 'sample budget form.pdf', url: 'https://localhost:44342/api/app/attachment/chefs/a7969aa0-f780-4d0a-8cdc-2e243bb1f1ba/download/3f4b94db-6f03-4fe1-a816-b8319a2489d0/sample%20budget%20form.pdf', id: 123 },
-        //    { filename: 'Test Direct Deposit application form.pdf', url: 'https://localhost:44342/api/app/attachment/chefs/a7969aa0-f780-4d0a-8cdc-2e243bb1f1ba/download/b672745e-1450-4f68-8577-d5e2fd6e7dcd/Test%20Direct%20Deposit%20application%20form.pdf', id: 456 },
-        //    // ... more file objects
-        //];
-
-        //downloadFilesAsZip(filePaths, 'TestZip');
-        //worker.postMessage(filePaths);
-
-        //worker.onmessage = (event) => {
-        //    const { filename, blob } = event.data;
-        //    zip.file(filename, blob);
-        //};
-
-        //worker.onerror = (event) => {
-        //    console.error('Error fetching file:', event.data);
-        //};
-
-        //worker.onmessage = (event) => {
-        //    if (event.data === 'all_files_added') {
-        //        zip.generateAsync({ type: "blob" })
-        //            .then(function (content) {
-        //                const link = document.createElement('a');
-        //                link.href = URL.createObjectURL(content);
-        //                link.download = 'my_archive.zip';
-        //                link.click();
-        //            })
-        //            .catch(error => {
-        //                console.error('Error generating ZIP:', error);
-        //            });
-        //        }
-        //    };
-
-          
-
+        });
 
     });
-
 });

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/ChefsAttachments.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/ChefsAttachments.js
@@ -74,4 +74,115 @@ $(function () {
     $('#attachments-tab').one('click', function () {
         dataTable.columns.adjust();
     });
+
+    function extractFileName(url) {
+        const path = new URL(url).pathname;
+        return path.split('/').pop();
+    }
+   
+    $('#downloadAll').click(function () {
+        /*const zip = new JSZip();*/
+        const chefsAttactmentsTable = document.getElementById('ChefsAttachmentsTable');
+        const anchorTags = chefsAttactmentsTable.querySelectorAll('a');
+        const hrefValues = [];
+        anchorTags.forEach(anchor => {
+            hrefValues.push(anchor.href);
+        });
+
+        try {
+            // Loop through all the file URLs
+            for (const fileUrl of hrefValues) {
+                const fileName = decodeURIComponent(extractFileName(fileUrl));  // Get the file name from the URL
+                fetch(fileUrl).then(response => {
+                    if (!response.ok) {
+                        throw new Error('Network response was not ok');
+                    }
+                    return response.blob();
+                })
+
+                    //This downloads each file one by one
+                    .then(blob => {
+                        let url = window.URL.createObjectURL(blob);
+                        let a = document.createElement('a');
+                        a.style.display = 'none';
+                        a.href = url;
+                        a.download = fileName;
+                        document.body.appendChild(a);
+                        a.click();
+                        window.URL.revokeObjectURL(url);
+                    })
+                    .catch(error => {
+                        console.error('There was a problem with the fetch operation:', error);
+                    });
+
+                // Add file to the zip
+               /* zip.file(fileName, blob); */
+            }
+
+            // Once all files are added, generate the zip file
+            //zip.generateAsync({ type: 'blob' }).then(function (content) {
+            //    // Create a link to download the zip file
+            //    const link = document.createElement('a');
+            //    link.href = URL.createObjectURL(content);
+            //    link.download = 'files.zip'; // The name of the downloaded zip file
+
+            //    // Trigger the download
+            //    link.click();
+            //}).catch(error => {
+            //            console.error('Error generating ZIP:', error);
+            //    });
+        } catch (error) {
+            console.error('Error downloading files: ', error);
+        }
+
+
+
+        //zip.generateAsync({ type: "blob" })
+        //    .then(function (content) {
+        //        const link = document.createElement('a');
+        //        link.href = URL.createObjectURL(content);
+        //        link.download = 'submissionAttachments.zip';
+        //        link.click();
+        //    });
+
+
+
+        //const fileList = [
+        //    { filename: 'sample budget form.pdf', url: 'https://localhost:44342/api/app/attachment/chefs/a7969aa0-f780-4d0a-8cdc-2e243bb1f1ba/download/3f4b94db-6f03-4fe1-a816-b8319a2489d0/sample%20budget%20form.pdf', id: 123 },
+        //    { filename: 'Test Direct Deposit application form.pdf', url: 'https://localhost:44342/api/app/attachment/chefs/a7969aa0-f780-4d0a-8cdc-2e243bb1f1ba/download/b672745e-1450-4f68-8577-d5e2fd6e7dcd/Test%20Direct%20Deposit%20application%20form.pdf', id: 456 },
+        //    // ... more file objects
+        //];
+
+        //downloadFilesAsZip(filePaths, 'TestZip');
+        //worker.postMessage(filePaths);
+
+        //worker.onmessage = (event) => {
+        //    const { filename, blob } = event.data;
+        //    zip.file(filename, blob);
+        //};
+
+        //worker.onerror = (event) => {
+        //    console.error('Error fetching file:', event.data);
+        //};
+
+        //worker.onmessage = (event) => {
+        //    if (event.data === 'all_files_added') {
+        //        zip.generateAsync({ type: "blob" })
+        //            .then(function (content) {
+        //                const link = document.createElement('a');
+        //                link.href = URL.createObjectURL(content);
+        //                link.download = 'my_archive.zip';
+        //                link.click();
+        //            })
+        //            .catch(error => {
+        //                console.error('Error generating ZIP:', error);
+        //            });
+        //        }
+        //    };
+
+          
+
+
+    });
+
 });

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/Default.cshtml
@@ -3,16 +3,18 @@
 
 @inject IStringLocalizer<GrantManagerResource> L
 <div class="attachments__title-button-split">
-    <div style="display:inline-block">
+    <div class="submission-title">
         <h6 class="fw-bold px-3 pt-4 pb-2 m-0">Submission Attachments</h6>
     </div>
-    <div style="display:inline-block" class="me-3">
-            <abp-button id="resyncSubmissionAttachments"
+    <div class="submission-button-section me-3">
+    <button type="button" class="btn unt-btn-outline-primary btn-outline-primary me-2" id="downloadAll"><i class="unt-icon-sm fl fl-download"></i>Download All</button>
+        <button type="button" class="btn unt-btn-outline-primary btn-outline-primary me-2" id="resyncSubmissionAttachments" abp-tooltip="@L["ApplicationList:ResyncSubmissionAttachmentsButton"].Value"><i class="fl fl-synch"></i></button>
+        @* <abp-button id="resyncSubmissionAttachments"
                         icon-type="Other"
                         size="Large"
                         icon="fl fl-synch"
                         abp-tooltip="@L["ApplicationList:ResyncSubmissionAttachmentsButton"].Value"
-                        button-type="Light" />
+                        button-type="Light" /> *@
     </div>
 </div>
 <div class="px-3">

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/_Shared/Attachments.css
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/_Shared/Attachments.css
@@ -28,3 +28,7 @@
     display: block;
     text-align: left;
 }
+
+.spinner-loading {
+    color: #9f9d9c;
+}


### PR DESCRIPTION
Initial feature download all files for Submission attachments
- Add new service download-all for list of files to be downloaded
- Add JSZip library for creating and manipulating the zip archive in javascript and in-memory also helps to handle large files
- Add new button Download All 
- Add event handling to show success and error message
- Disable the 'Download All' button when the table list is empty to improve user experience
- Spinner indicator will show after the 'Download All' button is clicked, indicating that the download is in progress. 
