### PR TITLE
AB#27461 - cater for null / hidden checkbox group from CHEFS

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Intakes/Transformers/CheckboxGroupTransformer.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Intakes/Transformers/CheckboxGroupTransformer.cs
@@ -9,7 +9,8 @@ namespace Unity.GrantManager.Intakes
         public CheckboxGroupValue Transform(JToken value)
         {
             // Post from CHEFS checkboxgroup value                                                       
-            var checkboxValues = new List<CheckboxGroupValueOption>();            
+            var checkboxValues = new List<CheckboxGroupValueOption>();
+            if (value == null) return new CheckboxGroupValue(checkboxValues);
             JObject obj = JObject.FromObject(value);
             foreach (var prop in obj.Properties())
             {


### PR DESCRIPTION
- When a checkboxgroup is optional a NULL value is received for the component and causes the intake to break.
- Cater for this with a simple null check

below scenarios now come is correctly - a select list with options to show / hide 2 underlying group checkboxes through conditional logic.

None shown: 
![image](https://github.com/user-attachments/assets/7a49f545-e78e-406d-a382-075b3d199d4c)

One shown with no values:
![image](https://github.com/user-attachments/assets/d9d4e38e-abc9-4a7c-b98e-3d59f5113fbd)

One shown with values:
![image](https://github.com/user-attachments/assets/17d95d0e-4d1d-4dd2-8737-49a8aa83290a)

