### PR TITLE
AB#27292 use explicit formatting for datagrid datetime column

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/DataGridWidget/DataGridWidget.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/DataGridWidget/DataGridWidget.cs
@@ -445,11 +445,17 @@ namespace Unity.Flex.Web.Views.Shared.Components.DataGridWidget
             };
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style",
+            "IDE0060:Remove unused parameter",
+            Justification = "We ignore the format provided from CHEFS for datetime as this does not display correctly")]
         private static bool TryParseDateTime(string value, string? format, out string formattedDateTime)
         {
+            const string fixedFormat = "yyyy-MM-dd hh:mm:ss tt";
             if (DateTime.TryParse(value, new CultureInfo("en-CA"), DateTimeStyles.None, out DateTime dateTime))
             {
-                var appliedFormat = !string.IsNullOrEmpty(format) ? format : "yyyy-MM-dd hh:mm:ss tt";
+                // The format that CHEFS provides vs the provided value don't format correctly
+                format = fixedFormat;
+                var appliedFormat = !string.IsNullOrEmpty(format) ? format : fixedFormat;
                 formattedDateTime = dateTime.ToString(appliedFormat, CultureInfo.InvariantCulture);
                 return true;
             }


### PR DESCRIPTION
- apply a fixed format for the datetime columns for the datagrid control - the format provided from chefs does not present correctly when used