### PR TITLE
AB#27128 - Bugfix for Payment Info and Submissions Tab Settings

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/SettingManagement/ApplicationUiSettingsAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/SettingManagement/ApplicationUiSettingsAppService.cs
@@ -31,7 +31,7 @@ public class ApplicationUiSettingsAppService(
     {
         if (CurrentTenant.IsAvailable)
         {
-            await settingManager.SetForCurrentTenantAsync(SettingsConstants.UI.Tabs.Submission, input.Submission.ToString());
+            await settingManager.SetForCurrentTenantAsync(SettingsConstants.UI.Tabs.Submission, true.ToString());
             await settingManager.SetForCurrentTenantAsync(SettingsConstants.UI.Tabs.Assessment, input.Assessment.ToString());
             await settingManager.SetForCurrentTenantAsync(SettingsConstants.UI.Tabs.Project, input.Project.ToString());
             await settingManager.SetForCurrentTenantAsync(SettingsConstants.UI.Tabs.Applicant, input.Applicant.ToString());

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Components/ApplicationUiSettingGroup/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Components/ApplicationUiSettingGroup/Default.cshtml
@@ -13,7 +13,7 @@
         <form id="ApplicationTabsSettingsForm">
             <abp-row>
                 <abp-column size-md="_12" class="mx-2 fw-bold">
-                    <abp-input asp-for="@Model.Submission" role="switch" />
+                    <abp-input asp-for="@Model.Submission" role="switch" disabled="true" />
                     <abp-input asp-for="@Model.Assessment" role="switch" />
                     <abp-input asp-for="@Model.Project" role="switch" />
                     <abp-input asp-for="@Model.Applicant" role="switch" />

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.cshtml
@@ -163,7 +163,7 @@
                 @*-------- Funding Agreement Section END ---------*@
 
                 @*-------- Payments Section ---------*@
-                @if (await FeatureChecker.IsEnabledAsync("Unity.Payments"))
+                @if (await FeatureChecker.IsEnabledAsync("Unity.Payments") && await SettingProvider.IsTrueAsync(SettingsConstants.UI.Tabs.Payments))
                 {
                     <abp-tab name="nav-payment-info" title="Payment Info">
                         <div class="w-100 px-2" id="PaymentInfoWidget">


### PR DESCRIPTION
Small bugfix to ensure Submissions and Payment Info tab are displayed in the Application Details screen in accordance with settings. Submissions tab is always visible and the setting is visible but disabled.

Pulled payment info tab visibility from client-side to server side enforcement.