### PR TITLE
AB#27634 bugfix - failing submissions

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/ApplicantAddress.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/ApplicantAddress.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 using Unity.GrantManager.GrantApplications;
 using Volo.Abp.Domain.Entities.Auditing;
 using Volo.Abp.MultiTenancy;
@@ -8,6 +9,8 @@ namespace Unity.GrantManager.Applications;
 public class ApplicantAddress : AuditedAggregateRoot<Guid>, IMultiTenant
 {
     public Guid? ApplicantId { get; set; }
+
+    [JsonIgnore]
     public virtual Applicant Applicant
     {
         set => _applicant = value;

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/ApplicationStatus.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/ApplicationStatus.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using Unity.GrantManager.GrantApplications;
 using Volo.Abp.Domain.Entities.Auditing;
 using Volo.Abp.MultiTenancy;
@@ -15,6 +16,7 @@ public class ApplicationStatus : AuditedAggregateRoot<Guid>, IMultiTenant
     public GrantApplicationState StatusCode { get; set; }
 
     // Navigation Property
+    [JsonIgnore]
     public virtual ICollection<Application>? Applications { get; set; }
 
     public Guid? TenantId { get; set; }


### PR DESCRIPTION
- We know that some submissions fail to come into Unity, and there are many errors around cyclic serialization in the ABP Audit system when these fail - so far the only way to reliably remove this error is to prevent the Navigation property from Serializing upwards with the IgnoreJson attribute - (other configuration options have not been successful) 
- Added the explicit IgnoreJson attribute to navigation properties to navigation properties that appear often in the logs with cyclic issues with the ABP Audit logging