### PR TITLE
bugfix/AB#27741 - checkboxgroup render error

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/PaymentInfo/Default.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/PaymentInfo/Default.js
@@ -32,8 +32,13 @@
 
         // Update checkboxes which are serialized if unchecked
         $(`#paymentInfoForm input:checkbox`).each(function () {
-            paymentInfoForm[this.name] = (this.checked).toString();
+            paymentInfoObj[this.name] = (this.checked).toString();
         });
+
+        // Make sure all the custom fields are set in the custom fields object
+        if (typeof Flex === 'function') {
+            Flex?.setCustomFields(paymentInfoObj);
+        }
 
         paymentInfoObj['correlationId'] = formVersionId;
         paymentInfoObj['worksheetId'] = worksheetId;

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
@@ -629,7 +629,7 @@ $(function () {
         $('table[data-resize-aware="true"]:visible').each(function () {
             const table = $(this).DataTable();
             try {
-                table.columns.adjust().draw();                
+                table.columns.adjust().draw();
             }
             catch {
                 console.error(`Adjust width failed for table ${$(this).id}:`, error);
@@ -745,6 +745,14 @@ const Flex = class {
         }
 
         formObject.CustomFields[input.name] = input.value;
+    }
+
+    static setCustomFields(customFieldsObj) {
+        for (const key in customFieldsObj) {
+            if (customFieldsObj.hasOwnProperty(key) && key.startsWith('custom_')) {
+                customFieldsObj.CustomFields[key] = customFieldsObj[key];
+            }
+        }
     }
 }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicantInfo/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicantInfo/Default.js
@@ -8,11 +8,11 @@
         let applicationId = document.getElementById('ApplicantInfoViewApplicationId').value;
         let formData = $("#ApplicantInfoForm").serializeArray();
         let ApplicantInfoObj = {};
-        let formVersionId = $("#ApplicationFormVersionId").val(); 
+        let formVersionId = $("#ApplicationFormVersionId").val();
         let worksheetId = $("#ApplicantInfo_WorksheetId").val();
 
-        $.each(formData, function (_, input) {            
-            if (typeof Flex === 'function' && Flex?.isCustomField(input)) {                
+        $.each(formData, function (_, input) {
+            if (typeof Flex === 'function' && Flex?.isCustomField(input)) {
                 Flex.includeCustomFieldObj(ApplicantInfoObj, input);
             }
             else {
@@ -23,7 +23,7 @@
                     ApplicantInfoObj[input.name.split(".")[1]] = null;
                 }
 
-            if (input.name == 'ApplicantId' || input.name == 'SupplierNumber' || input.name == 'OriginalSupplierNumber') {
+                if (input.name == 'ApplicantId' || input.name == 'SupplierNumber' || input.name == 'OriginalSupplierNumber') {
                     ApplicantInfoObj[input.name] = input.value;
                 }
             }
@@ -34,12 +34,15 @@
             ApplicantInfoObj[this.name] = (this.checked).toString();
         });
 
-        try {
+        // Make sure all the custom fields are set in the custom fields object
+        if (typeof Flex === 'function') {
+            Flex?.setCustomFields(ApplicantInfoObj);
+        }
 
-            if (ApplicantInfoObj["SupplierNumber"]+"" != "undefined" 
-             && ApplicantInfoObj["SupplierNumber"]+"" != ""
-             && ApplicantInfoObj["SupplierNumber"]+"" != ApplicantInfoObj["OriginalSupplierNumber"]+"")
-            {
+        try {
+            if (ApplicantInfoObj["SupplierNumber"] + "" != "undefined"
+                && ApplicantInfoObj["SupplierNumber"] + "" != ""
+                && ApplicantInfoObj["SupplierNumber"] + "" != ApplicantInfoObj["OriginalSupplierNumber"] + "") {
                 $('.cas-spinner').show();
             }
 
@@ -58,7 +61,7 @@
                 })
                 .then(function () {
                     $('.cas-spinner').hide();
-                }).catch(function(){
+                }).catch(function () {
                     $('.cas-spinner').hide();
                 });
         }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.js
@@ -37,6 +37,12 @@
             assessmentResultObj[this.name] = (this.checked).toString();
         });
 
+
+        // Make sure all the custom fields are set in the custom fields object
+        if (typeof Flex === 'function') {
+            Flex?.setCustomFields(assessmentResultObj);
+        }
+
         try {
             assessmentResultObj['correlationId'] = formVersionId;
             assessmentResultObj['worksheetId'] = worksheetId;

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ProjectInfo/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ProjectInfo/Default.js
@@ -30,6 +30,11 @@
             projectInfoObj[this.name] = (this.checked).toString();
         });
 
+        // Make sure all the custom fields are set in the custom fields object
+        if (typeof Flex === 'function') {
+            Flex?.setCustomFields(projectInfoObj);
+        }
+
         projectInfoObj['correlationId'] = formVersionId;
         projectInfoObj['worksheetId'] = worksheetId;
         updateProjectInfo(applicationId, projectInfoObj);


### PR DESCRIPTION
 - Make sure the empty checkboxes are serialized correctly to the custom fields object before being posted from the UI.
 - We set this explicitly for each Tab where we have embedded Custom Fields.