### PR TITLE
Feature/ab#27294 add dynamic fields to the edit modal for datagrid edit

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Shared/DataGridExtensions.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Shared/DataGridExtensions.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Globalization;
+using Unity.Flex.Worksheets;
+
+namespace Unity.Flex
+{
+    public static class DataGridExtensions
+    {
+        public static string ApplyPresentationFormatting(this string value, string columnType, string? format)
+        {
+            if (value == null) return string.Empty;
+
+            return columnType switch
+            {
+                var ct when IsDateColumn(ct) && TryParseDate(value, format, out string formattedDate) => formattedDate,
+                var ct when IsDateTimeColumn(ct) && TryParseDateTime(value, format, out string formattedDateTime) => formattedDateTime,
+                var ct when IsCurrencyColumn(ct) && TryParseCurrency(value, format, out string formattedCurrency) => formattedCurrency,
+                var ct when IsYesNoColumn(ct) && TryFormatYesNo(value, out string formattedYesNo) => formattedYesNo,
+                var ct when IsCheckBoxColumn(ct) && TryFormatCheckbox(value, out string formattedCheckbox) => formattedCheckbox,
+                _ => value
+            };
+        }
+
+
+        public static string ApplyStoreFormatting(this string value, string columnType)
+        {
+            return columnType switch
+            {
+                var ct when IsDateColumn(ct) => ValueConverterHelpers.ConvertDate(value),
+                var ct when IsDateTimeColumn(ct) => ValueConverterHelpers.ConvertDateTime(value),
+                var ct when IsCurrencyColumn(ct) => ValueConverterHelpers.ConvertDecimal(value),
+                var ct when IsYesNoColumn(ct) => ValueConverterHelpers.ConvertYesNo(value),
+                var ct when IsCheckBoxColumn(ct) => ValueConverterHelpers.ConvertCheckbox(value),
+                _ => value
+            };
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style",
+            "IDE0060:Remove unused parameter",
+            Justification = "We ignore the format provided from CHEFS for datetime as this does not display correctly")]
+        private static bool TryParseDateTime(string value, string? format, out string formattedDateTime)
+        {
+            const string fixedFormat = "yyyy-MM-dd hh:mm:ss tt";
+            if (DateTime.TryParse(value, new CultureInfo("en-CA"), DateTimeStyles.None, out DateTime dateTime))
+            {
+                // The format that CHEFS provides vs the provided value don't format correctly
+                format = fixedFormat;
+                var appliedFormat = !string.IsNullOrEmpty(format) ? format : fixedFormat;
+                formattedDateTime = dateTime.ToString(appliedFormat, CultureInfo.InvariantCulture);
+                return true;
+            }
+            formattedDateTime = string.Empty;
+            return false;
+        }
+
+        private static bool IsDateTimeColumn(string columnType)
+        {
+            return columnType == CustomFieldType.DateTime.ToString();
+        }
+
+        private static bool TryFormatCheckbox(string value, out string formattedCheckbox)
+        {
+            if (value.IsTruthy()) formattedCheckbox = "true";
+            else
+                formattedCheckbox = "false";
+            return true;
+        }
+
+        private static bool IsCheckBoxColumn(string columnType)
+        {
+            return columnType == CustomFieldType.Checkbox.ToString();
+        }
+
+        private static bool TryFormatYesNo(string value, out string formattedYesNo)
+        {
+            if (string.IsNullOrEmpty(value) || value == "Please choose...")
+            {
+                formattedYesNo = string.Empty;
+                return true;
+            }
+            formattedYesNo = value;
+            return false;
+        }
+
+        private static bool IsYesNoColumn(string columnType)
+        {
+            return columnType == CustomFieldType.YesNo.ToString();
+        }
+
+        private static bool IsDateColumn(string columnType)
+        {
+            return columnType == CustomFieldType.Date.ToString();
+        }
+
+        private static bool IsCurrencyColumn(string columnType)
+        {
+            return columnType == CustomFieldType.Currency.ToString();
+        }
+
+        private static bool TryParseDate(string value, string? format, out string formattedDate)
+        {
+            if (DateTime.TryParse(value, new CultureInfo("en-CA"), DateTimeStyles.None, out DateTime dateTime))
+            {
+                var appliedFormat = !string.IsNullOrEmpty(format) ? format : "yyyy-MM-dd";
+                formattedDate = dateTime.ToString(appliedFormat, CultureInfo.InvariantCulture);
+                return true;
+            }
+            formattedDate = string.Empty;
+            return false;
+        }
+
+        private static bool TryParseCurrency(string value, string? format, out string formattedCurrency)
+        {
+            if (decimal.TryParse(value, out decimal number))
+            {
+                var currencyCode = !string.IsNullOrEmpty(format) ? format : "CAD";
+                var culture = GetCultureInfoByCurrencyCode(currencyCode);
+                formattedCurrency = number.ToString("C", culture);
+                return true;
+            }
+            formattedCurrency = string.Empty;
+            return false;
+        }
+
+        private static CultureInfo GetCultureInfoByCurrencyCode(string currencyCode)
+        {
+            foreach (var culture in CultureInfo.GetCultures(CultureTypes.SpecificCultures))
+            {
+                var region = new RegionInfo(culture.Name);
+                if (region.ISOCurrencySymbol == currencyCode)
+                {
+                    return culture;
+                }
+            }
+
+            throw new ArgumentException("Invalid or unsupported currency code.");
+        }
+    }
+}

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Shared/Localization/Flex/en.json
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Shared/Localization/Flex/en.json
@@ -31,6 +31,8 @@
     "Worksheet:Configuration:AddCheckboxOptionText": "Add Option",
     "Worksheet:Configuration:ExportWorksheetButtonText": "Export Worksheet",
     "Worksheet:Configuration:AddSelectListOptionText": "Add Option",
-    "Worksheet:Configuration:AddColumnOptionText": "Add Column"
+    "Worksheet:Configuration:AddColumnOptionText": "Add Column",
+    "DataGrids:DynamicColumnsHeader": "Dynamic Columns",
+    "DataGrids:CustomColumnsHeader": "Custom Columns"
   }
 }

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Pages/Components/DataGrid/DataGridServiceUtils.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Pages/Components/DataGrid/DataGridServiceUtils.cs
@@ -10,7 +10,7 @@ namespace Unity.Flex.Web.Pages.Flex
 {
     public static class DataGridServiceUtils
     {
-        internal static List<WorksheetFieldViewModel> ConvertDataGridValue(DataGridValue? value,
+        internal static List<WorksheetFieldViewModel> ExtractCustomColumnsValues(DataGridValue? value,
             CustomFieldDto datagridDefinition,
             uint rowNumber,
             bool isNew)
@@ -123,6 +123,28 @@ namespace Unity.Flex.Web.Pages.Flex
                 });
             }
             return cells;
+        }
+
+        internal static KeyValuePair<string, string>[] ExtractDynamicColumnsPairs(DataGridValue? dataGridValue, uint rowNumber)
+        {
+            var keyValues = new List<KeyValuePair<string, string>>();
+            var gridValue = DeserializeDataGridValue(dataGridValue?.Value?.ToString());
+            if (gridValue == null) return [];
+            var gridRowsValue = DeserializeDataGridRowsValue(dataGridValue?.Value?.ToString());
+            if (gridRowsValue == null) return [];
+            var row = gridRowsValue.Rows[(int)rowNumber];
+
+            foreach (var column in dataGridValue?.Columns ?? [])
+            {
+                var cell = row.Cells.Find(s => s.Key == column.Key);
+
+                if (cell != null)
+                {
+                    keyValues.Add(new(column.Name, cell.Value.ApplyPresentationFormatting(column.Type, null)));
+                }
+            }
+
+            return [.. keyValues];
         }
     }
 

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Pages/Components/DataGrid/EditDataRowModal.cshtml
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Pages/Components/DataGrid/EditDataRowModal.cshtml
@@ -31,68 +31,88 @@
             <abp-input type="hidden" id="UiAnchor" asp-for="@Model.UiAnchor" />
             <abp-input type="hidden" id="IsNew" asp-for="@Model.IsNew" />
             <abp-input type="hidden" id="CheckboxKeys" asp-for="@Model.CheckboxKeys" />
-
-            @foreach (var field in Model.Properties ?? [])
-            {
-                <div class="edit_row_field unity-input-group">
-                    <label class="form-label" for="@field.Name">@field.Label</label>
-                    @try
-                    {
-                        @switch (field.Type)
+            <div class="custom-fields-split">
+                @if (Model.DynamicFields?.Length > 0)
+                {
+                    <div>
+                        <h6 class="customgrid-edit-row-header">@L["DataGrids:DynamicColumnsHeader"]:</h6>
+                        @foreach (var field in Model.DynamicFields ?? [])
                         {
-                            case CustomFieldType.Checkbox:
-                                {
-                                    @await Component.InvokeAsync(typeof(CheckboxWidget), new { fieldModel = field, modelName = field.Name })
-                                    break;
-                                }
-                            case CustomFieldType.Currency:
-                                {
-                                    @await Component.InvokeAsync(typeof(CurrencyWidget), new { fieldModel = field, modelName = field.Name })
-                                    break;
-                                }
-                            case CustomFieldType.Date:
-                                {
-                                    @await Component.InvokeAsync(typeof(DateWidget), new { fieldModel = field, modelName = field.Name })
-                                    break;
-                                }
-                            case CustomFieldType.DateTime:
-                                {
-                                    @await Component.InvokeAsync(typeof(DateWidget), new { fieldModel = field, modelName = field.Name })
-                                    break;
-                                }
-                            case CustomFieldType.TextArea:
-                                {
-                                    @await Component.InvokeAsync(typeof(TextAreaWidget), new { fieldModel = field, modelName = field.Name })
-                                    break;
-                                }
-                            case CustomFieldType.YesNo:
-                                {
-                                    @await Component.InvokeAsync(typeof(YesNoWidget), new { fieldModel = field, modelName = field.Name })
-                                    break;
-                                }
-                            default:
-                                {
-                                    <input type="@field.Type.ConvertInputType()"
-                                           label="@field.Label"
-                                           value="@field.CurrentValue?.ConvertInputValueOrNull(field.Type)"
-                                           class="@field.Type.ApplyCssClass()"
-                                           id="@($"{field.Name}.{field.Name}.{field.Id}")"
-                                           name="@($"{field.Name}.{field.Name}.{field.Id}")"
-                                           min="@field.Definition?.ConvertDefinition(field.Type)?.GetMinValueOrNull()"
-                                           max="@field.Definition?.ConvertDefinition(field.Type)?.GetMaxValueOrNull()"
-                                           minlength="@field.Definition?.ConvertDefinition(field.Type)?.GetMinLengthValueOrNull()"
-                                           maxlength="@field.Definition?.ConvertDefinition(field.Type)?.GetMaxLengthValueOrNull()" />
-                                    break;
-                                }
+                            <div class="edit_row_field unity-input-group">
+                                <label class="form-label" for="@field.Key">@field.Key</label>
+                                <input class="form-control customgrid-edit-dymanic-field" name="@field.Key" value="@field.Value" disabled />
+                            </div>
                         }
-                    }
-                    catch (Exception)
+                    </div>
+                }
+                <div>
+                    @if (Model.DynamicFields.Length > 0)
                     {
-                        <span class="control-render-error">Error rendering component!</span>
+                        <h6 class="customgrid-edit-row-header">@L["DataGrids:CustomColumnsHeader"]:</h6>
                     }
-                    <span class="text-danger field-validation-valid" data-valmsg-for="@($"{field?.Name}.{field?.Name}.{field?.Id}")" data-valmsg-replace="true"></span>
+                    @foreach (var field in Model.Properties ?? [])
+                    {
+                        <div class="edit_row_field unity-input-group">
+                            <label class="form-label" for="@field.Name">@field.Label</label>
+                            @try
+                            {
+                                @switch (field.Type)
+                                {
+                                    case CustomFieldType.Checkbox:
+                                        {
+                                            @await Component.InvokeAsync(typeof(CheckboxWidget), new { fieldModel = field, modelName = field.Name })
+                                            break;
+                                        }
+                                    case CustomFieldType.Currency:
+                                        {
+                                            @await Component.InvokeAsync(typeof(CurrencyWidget), new { fieldModel = field, modelName = field.Name })
+                                            break;
+                                        }
+                                    case CustomFieldType.Date:
+                                        {
+                                            @await Component.InvokeAsync(typeof(DateWidget), new { fieldModel = field, modelName = field.Name })
+                                            break;
+                                        }
+                                    case CustomFieldType.DateTime:
+                                        {
+                                            @await Component.InvokeAsync(typeof(DateWidget), new { fieldModel = field, modelName = field.Name })
+                                            break;
+                                        }
+                                    case CustomFieldType.TextArea:
+                                        {
+                                            @await Component.InvokeAsync(typeof(TextAreaWidget), new { fieldModel = field, modelName = field.Name })
+                                            break;
+                                        }
+                                    case CustomFieldType.YesNo:
+                                        {
+                                            @await Component.InvokeAsync(typeof(YesNoWidget), new { fieldModel = field, modelName = field.Name })
+                                            break;
+                                        }
+                                    default:
+                                        {
+                                            <input type="@field.Type.ConvertInputType()"
+                                                   label="@field.Label"
+                                                   value="@field.CurrentValue?.ConvertInputValueOrNull(field.Type)"
+                                                   class="@field.Type.ApplyCssClass()"
+                                                   id="@($"{field.Name}.{field.Name}.{field.Id}")"
+                                                   name="@($"{field.Name}.{field.Name}.{field.Id}")"
+                                                   min="@field.Definition?.ConvertDefinition(field.Type)?.GetMinValueOrNull()"
+                                                   max="@field.Definition?.ConvertDefinition(field.Type)?.GetMaxValueOrNull()"
+                                                   minlength="@field.Definition?.ConvertDefinition(field.Type)?.GetMinLengthValueOrNull()"
+                                                   maxlength="@field.Definition?.ConvertDefinition(field.Type)?.GetMaxLengthValueOrNull()" />
+                                            break;
+                                        }
+                                }
+                            }
+                            catch (Exception)
+                            {
+                                <span class="control-render-error">Error rendering component!</span>
+                            }
+                            <span class="text-danger field-validation-valid" data-valmsg-for="@($"{field?.Name}.{field?.Name}.{field?.Id}")" data-valmsg-replace="true"></span>
+                        </div>
+                    }
                 </div>
-            }
+            </div>
         </abp-modal-body>
         <abp-modal-footer>
             <button type="submit" class="btn btn-primary" id="saveRowValues-@Model.FieldId" name="saveRowValues-@Model.FieldId" value="save">@AbpModalButtons.Save</button>
@@ -121,7 +141,7 @@
         // Add a new 'change' event handler
         formElements.on('change', function () {
             let isValid = form.valid();
-            let hasInvalidCurrency = rowEditFormHasInvalidCurrencyCustomFields(formId);            
+            let hasInvalidCurrency = rowEditFormHasInvalidCurrencyCustomFields(formId);
             saveBtn.prop('disabled', !(isValid && !hasInvalidCurrency));
 
             if (!isValid) {
@@ -145,14 +165,14 @@
             icon.attr('class', '');
         });
 
-        function rowEditFormHasInvalidCurrencyCustomFields(formId) {            
+        function rowEditFormHasInvalidCurrencyCustomFields(formId) {
             let invalidFieldsFound = false;
             $("#" + formId + " input:visible").each(function (i, el) {
                 let $field = $(this);
-                if ($field.hasClass('custom-currency-input')) {                        
+                if ($field.hasClass('custom-currency-input')) {
                     if ($field.val() === '' || $field.val() === '0') {
                        $field.val('0.00');
-                    }                    
+                    }
                     if (!isValidCurrencyCustomField($field)) {
                         invalidFieldsFound = true;
                     }

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Pages/Components/DataGrid/EditDataRowModal.cshtml
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Pages/Components/DataGrid/EditDataRowModal.cshtml
@@ -46,7 +46,7 @@
                     </div>
                 }
                 <div>
-                    @if (Model.DynamicFields.Length > 0)
+                    @if (Model.DynamicFields?.Length > 0)
                     {
                         <h6 class="customgrid-edit-row-header">@L["DataGrids:CustomColumnsHeader"]:</h6>
                     }

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Pages/Components/DataGrid/EditDataRowModal.cshtml.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Pages/Components/DataGrid/EditDataRowModal.cshtml.cs
@@ -43,6 +43,9 @@ public class EditDataRowModalModel(DataGridWriteService dataGridWriteService,
     public List<WorksheetFieldViewModel>? Properties { get; set; }
 
     [BindProperty]
+    public KeyValuePair<string, string>[]? DynamicFields { get; set; }
+
+    [BindProperty]
     public string? CheckboxKeys { get; set; }
 
     public async Task OnGetAsync(Guid valueId,
@@ -78,7 +81,9 @@ public class EditDataRowModalModel(DataGridWriteService dataGridWriteService,
             UiAnchor = uiAnchor
         };
 
-        Properties = await dataGridReadService.GetPropertiesAsync(dataProps);
+        var (dynamicFields, customFields) = await dataGridReadService.GetPropertiesAsync(dataProps);
+        Properties = customFields;
+        DynamicFields = dynamicFields ?? [];
         CheckboxKeys = string.Join(',', Properties?.Where(s => s.Type == Worksheets.CustomFieldType.Checkbox).Select(s => s.Name) ?? []);
     }
 
@@ -93,7 +98,7 @@ public class EditDataRowModalModel(DataGridWriteService dataGridWriteService,
             {
                 keyValuePairs.TryAdd(key, "false");
             }
-        } 
+        }
 
         var dataProps = new RowInputData()
         {

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/DataGridWidget/DataGridWidget.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/DataGridWidget/DataGridWidget.cs
@@ -7,7 +7,6 @@ using Unity.Flex.Worksheets.Values;
 using System.Linq;
 using System.Collections.Generic;
 using Volo.Abp.AspNetCore.Mvc.UI.Bundling;
-using System.Globalization;
 using System;
 using Unity.Flex.Worksheets.Definitions;
 using Unity.Flex.Worksheets;
@@ -107,7 +106,7 @@ namespace Unity.Flex.Web.Views.Shared.Components.DataGridWidget
                 Name = modelName,
                 Columns = [.. columnNames],
                 Rows = [.. dataRows],
-                AllowEdit = true,
+                AllowEdit = AllowEdit(dataGridDefinition),
                 SummaryOption = ConvertSummaryOption(dataGridDefinition),
                 Summary = GenerateSummary([.. dataColumns], [.. dataRows]),
                 TableOptions = GenerateAvailableTableOptions(!dataGridDefinition.Dynamic),
@@ -117,6 +116,13 @@ namespace Unity.Flex.Web.Views.Shared.Components.DataGridWidget
             };
 
             return View(viewModel);
+        }
+
+        private static bool AllowEdit(DataGridDefinition dataGridDefinition)
+        {
+            if (dataGridDefinition.Columns.Count > 0) return true;
+
+            return false;
         }
 
         private static string GenerateAvailableTableOptions(bool allowAdd)
@@ -412,138 +418,5 @@ namespace Unity.Flex.Web.Views.Shared.Components.DataGridWidget
             context.Files
               .AddIfNotContains("/Views/Shared/Components/DataGridWidget/Default.css");
         }
-    }
-
-    public static class DataGridExtensions
-    {
-        public static string ApplyPresentationFormatting(this string value, string columnType, string? format)
-        {
-            if (value == null) return string.Empty;
-
-            return columnType switch
-            {
-                var ct when IsDateColumn(ct) && TryParseDate(value, format, out string formattedDate) => formattedDate,
-                var ct when IsDateTimeColumn(ct) && TryParseDateTime(value, format, out string formattedDateTime) => formattedDateTime,
-                var ct when IsCurrencyColumn(ct) && TryParseCurrency(value, format, out string formattedCurrency) => formattedCurrency,
-                var ct when IsYesNoColumn(ct) && TryFormatYesNo(value, out string formattedYesNo) => formattedYesNo,
-                var ct when IsCheckBoxColumn(ct) && TryFormatCheckbox(value, out string formattedCheckbox) => formattedCheckbox,
-                _ => value
-            };
-        }
-
-
-        public static string ApplyStoreFormatting(this string value, string columnType)
-        {
-            return columnType switch
-            {
-                var ct when IsDateColumn(ct) => ValueConverterHelpers.ConvertDate(value),
-                var ct when IsDateTimeColumn(ct) => ValueConverterHelpers.ConvertDateTime(value),
-                var ct when IsCurrencyColumn(ct) => ValueConverterHelpers.ConvertDecimal(value),
-                var ct when IsYesNoColumn(ct) => ValueConverterHelpers.ConvertYesNo(value),
-                var ct when IsCheckBoxColumn(ct) => ValueConverterHelpers.ConvertCheckbox(value),
-                _ => value
-            };
-        }
-
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style",
-            "IDE0060:Remove unused parameter",
-            Justification = "We ignore the format provided from CHEFS for datetime as this does not display correctly")]
-        private static bool TryParseDateTime(string value, string? format, out string formattedDateTime)
-        {
-            const string fixedFormat = "yyyy-MM-dd hh:mm:ss tt";
-            if (DateTime.TryParse(value, new CultureInfo("en-CA"), DateTimeStyles.None, out DateTime dateTime))
-            {
-                // The format that CHEFS provides vs the provided value don't format correctly
-                format = fixedFormat;
-                var appliedFormat = !string.IsNullOrEmpty(format) ? format : fixedFormat;
-                formattedDateTime = dateTime.ToString(appliedFormat, CultureInfo.InvariantCulture);
-                return true;
-            }
-            formattedDateTime = string.Empty;
-            return false;
-        }
-
-        private static bool IsDateTimeColumn(string columnType)
-        {
-            return columnType == CustomFieldType.DateTime.ToString();
-        }
-
-        private static bool TryFormatCheckbox(string value, out string formattedCheckbox)
-        {
-            if (value.IsTruthy()) formattedCheckbox = "true";
-            else
-                formattedCheckbox = "false";
-            return true;
-        }
-
-        private static bool IsCheckBoxColumn(string columnType)
-        {
-            return columnType == CustomFieldType.Checkbox.ToString();
-        }
-
-        private static bool TryFormatYesNo(string value, out string formattedYesNo)
-        {
-            if (string.IsNullOrEmpty(value) || value == "Please choose...")
-            {
-                formattedYesNo = string.Empty;
-                return true;
-            }
-            formattedYesNo = value;
-            return false;
-        }
-
-        private static bool IsYesNoColumn(string columnType)
-        {
-            return columnType == CustomFieldType.YesNo.ToString();
-        }
-
-        private static bool IsDateColumn(string columnType)
-        {
-            return columnType == CustomFieldType.Date.ToString();
-        }
-
-        private static bool IsCurrencyColumn(string columnType)
-        {
-            return columnType == CustomFieldType.Currency.ToString();
-        }
-
-        private static bool TryParseDate(string value, string? format, out string formattedDate)
-        {
-            if (DateTime.TryParse(value, new CultureInfo("en-CA"), DateTimeStyles.None, out DateTime dateTime))
-            {
-                var appliedFormat = !string.IsNullOrEmpty(format) ? format : "yyyy-MM-dd";
-                formattedDate = dateTime.ToString(appliedFormat, CultureInfo.InvariantCulture);
-                return true;
-            }
-            formattedDate = string.Empty;
-            return false;
-        }
-
-        private static bool TryParseCurrency(string value, string? format, out string formattedCurrency)
-        {
-            if (decimal.TryParse(value, out decimal number))
-            {
-                var currencyCode = !string.IsNullOrEmpty(format) ? format : "CAD";
-                var culture = GetCultureInfoByCurrencyCode(currencyCode);
-                formattedCurrency = number.ToString("C", culture);
-                return true;
-            }
-            formattedCurrency = string.Empty;
-            return false;
-        }
-
-        static CultureInfo GetCultureInfoByCurrencyCode(string currencyCode)
-        {
-            foreach (var culture in CultureInfo.GetCultures(CultureTypes.SpecificCultures))
-            {
-                var region = new RegionInfo(culture.Name);
-                if (region.ISOCurrencySymbol == currencyCode)
-                {
-                    return culture;
-                }
-            }
-
-            throw new ArgumentException("Invalid or unsupported currency code.");
-        }
-    }
+    }   
 }

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/DataGridWidget/Default.cshtml
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/DataGridWidget/Default.cshtml
@@ -29,13 +29,13 @@
                 <div id="btn-container-@Model.Field.Id" class="dynamic-buttons-div">
                 </div>
             </div>
-            <table data-value-id="@Model.Field.CurrentValueId" 
-                   data-field-id="@Model.Field.Id" 
+            <table data-value-id="@Model.Field.CurrentValueId"
+                   data-field-id="@Model.Field.Id"
                    data-wsi-id="@Model.WorksheetInstanceId"
                    data-ws-id="@Model.WorksheetId"
                    data-ws-anchor="@Model.UiAnchor"
-                   id="@Model.Field.Id" 
-                   class="display custom-dynamic-table @(Model.AllowEdit ? "custom-table-edit" : "")">
+                   id="@Model.Field.Id"
+                   class="display custom-dynamic-table custom-table-actions)">
                 <caption></caption>
                 <thead>
                     <tr>
@@ -43,10 +43,7 @@
                         {
                             <th>@column</th>
                         }
-                        @if (Model.AllowEdit)
-                        {
-                            <th></th>
-                        }
+                        <th class="custom-actions-header">Actions</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -59,11 +56,8 @@
                                     @cell.Value
                                 </td>
                             }
-                            @if (Model.AllowEdit)
-                            {
-                                <td>
-                                </td>
-                            }
+                            <td>
+                            </td>
                         </tr>
                     }
                 </tbody>

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/DataGridWidget/Default.css
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/DataGridWidget/Default.css
@@ -3,9 +3,9 @@
     justify-content: space-between;
 }
 
-.custom-dynamic-table.custom-table-edit th:last-child {
-    width: 20px !important;
-    max-width: 20px !important;
+.custom-dynamic-table.custom-table-actions th:last-child {
+    width: 75px !important;
+    max-width: 75px !important;
 }
 
 .dynamic-grid-summary {
@@ -40,4 +40,23 @@
 
 .edit_row_field {
     padding-bottom: 1rem;
+}
+
+.custom-fields-split {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+    align-items: flex-start;
+}
+
+.custom-fields-split > div {
+    width: 100%;
+}
+
+.customgrid-edit-row-header {
+    margin-bottom: 1rem;
+}
+
+.customgrid-edit-dymanic-field {
+    width: 90%;
 }

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/DataGridWidget/Default.js
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/DataGridWidget/Default.js
@@ -320,8 +320,7 @@ $(function () {
             tableDataSet.wsiId,
             rowDataSet.rowNo,
             false,
-            tableDataSet.uiAnchor,
-            ['field1', 'field2']);
+            tableDataSet.uiAnchor);
     }
 
     PubSub.subscribe(

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/DataGridWidget/Default.js
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/DataGridWidget/Default.js
@@ -170,6 +170,7 @@ $(function () {
         row,
         isNew,
         uiAnchor) {
+
         let formVersionId = $('#ApplicationFormVersionId').val();
         let applicationId = $('#DetailsViewApplicationId').val();
 
@@ -257,9 +258,11 @@ $(function () {
     function configureTable(table, fieldId) {
         table.buttons().container().prependTo(`#btn-container-${fieldId}`);
         let knownColumns = [];
+
         table.columns().header().to$().each(function (index) {
-            if ($(this).text() != '') {
-                knownColumns.push({ title: $(this).text(), visible: true, index: index + 1 });
+            let isActions = $(this).hasClass('custom-actions-header');
+            if ($(this).text() != '' && !isActions) {
+                knownColumns.push({ title: $(this).text(), visible: true, index: index + 1, isActions: isActions });
             }
         });
 
@@ -317,7 +320,8 @@ $(function () {
             tableDataSet.wsiId,
             rowDataSet.rowNo,
             false,
-            tableDataSet.uiAnchor);
+            tableDataSet.uiAnchor,
+            ['field1', 'field2']);
     }
 
     PubSub.subscribe(


### PR DESCRIPTION
- the edit datagrid edit button only appears when it is possible to edit the data (i.e. custom columns added), where before it would always appear but the modal would be blank if no fields were editable
- the readonly / dynamic fields that have come in from CHEFS now appear in the left hand side of the modal when editing the row if there are fields to show, otherwise the custom columns fields are centered and editable
- move the datagridextensions class to the shared flex project