### PR TITLE
bugfix/AB#27589 - Display Reference No on Payments Request Modal

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentApprovals/PaymentsApprovalModel.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentApprovals/PaymentsApprovalModel.cs
@@ -8,9 +8,13 @@ namespace Unity.Payments.Web.Pages.PaymentApprovals
 {
     public class PaymentsApprovalModel
     {
-        [DisplayName("ApplicationPaymentStatusRequest:Id")]
         [Required]
         public Guid Id { get; set; }
+
+        [DisplayName("ApplicationPaymentStatusRequest:Id")]
+        [Required]
+        public string ReferenceNumber { get; set; } = string.Empty;
+
         [DisplayName("ApplicationPaymentStatusRequest:Amount")]
         [Required]
         public decimal Amount { get; set; }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentApprovals/UpdatePaymentRequestStatus.cshtml
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentApprovals/UpdatePaymentRequestStatus.cshtml
@@ -47,6 +47,7 @@
                                 {
                                     <div id="@($"{@Model.PaymentGroupings[k].Items[i].Id}_container")" class="single-payment">
                                         <input type="hidden" asp-for="@Model.PaymentGroupings[k].Items[i].Id" />
+                                        <input type="hidden" asp-for="@Model.PaymentGroupings[k].Items[i].ReferenceNumber" />
                                         <input type="hidden" asp-for="@Model.PaymentGroupings[k].Items[i].Amount" />
                                         <input type="hidden" asp-for="@Model.PaymentGroupings[k].Items[i].Description" />
                                         <input type="hidden" asp-for="@Model.PaymentGroupings[k].Items[i].InvoiceNumber" />
@@ -64,7 +65,7 @@
                                         <input type="hidden" asp-for="@Model.IsApproval" />
                                         <abp-row class="m-0 p-3">
                                             <abp-column size="_4" class="px-1">
-                                                <abp-input asp-for="@Model.PaymentGroupings[k].Items[i].Id" disabled />
+                                                <abp-input asp-for="@Model.PaymentGroupings[k].Items[i].ReferenceNumber" disabled />
                                             </abp-column>
                                             <abp-column size="_3" class="px-1">
                                                 <abp-input asp-for="@Model.PaymentGroupings[k].Items[i].Amount"

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentApprovals/UpdatePaymentRequestStatus.cshtml.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentApprovals/UpdatePaymentRequestStatus.cshtml.cs
@@ -81,6 +81,7 @@ namespace Unity.Payments.Web.Pages.PaymentApprovals
                 PaymentsApprovalModel request = new()
                 {
                     Id = payment.Id,
+                    ReferenceNumber = payment.ReferenceNumber,
                     CorrelationId = payment.Id,
                     ApplicantName = payment.PayeeName,
                     Amount = payment.Amount,


### PR DESCRIPTION
Changed Payments Request Modal to display Reference Number instead of Payment Id