### PR TITLE
Feature/ab#27913 edit applicantId(unitytApplicantId) in applicant info tab

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Applicants/ApplicantAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Applicants/ApplicantAppService.cs
@@ -134,10 +134,10 @@ public class ApplicantAppService(IApplicantRepository applicantRepository,
         // Convert UnityApplicantId to int, filter only valid numbers
         var unityIds = applicants
             .Where(a => int.TryParse(a.UnityApplicantId, out _)) // Ensure it's numeric
-            .Select(a => int.Parse(a.UnityApplicantId))
+            .Select(a => int.Parse(a.UnityApplicantId!))
             .ToList();
 
-        int nextId = unityIds.Any() ? unityIds.Max() + 1 : 000001;
+        int nextId = unityIds.Count > 0 ? unityIds.Max() + 1 : 000001;
 
         return nextId;
     }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/IApplicantRepository.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/IApplicantRepository.cs
@@ -10,4 +10,5 @@ public interface IApplicantRepository : IRepository<Applicant, Guid>
     Task<List<Applicant>> GetUnmatchedApplicantsAsync();
     Task<Applicant?> GetByUnityApplicantIdAsync(string unityApplicantId);
     Task<Applicant?> GetByUnityApplicantNameAsync(string unityApplicantName);
+    Task<List<Applicant>> GetApplicantsWithUnityApplicantIdAsync();
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/ApplicantRepository.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/ApplicantRepository.cs
@@ -46,5 +46,12 @@ namespace Unity.GrantManager.Repositories
                                           a.ApplicantName.ToLower() == unityApplicantNameNormalized);
 
         }
+        public async Task<List<Applicant>> GetApplicantsWithUnityApplicantIdAsync()
+        {
+            var dbContext = await GetDbContextAsync();
+            return await dbContext.Applicants
+                .Where(x => x.UnityApplicantId != null)
+                .ToListAsync();
+        }
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicantInfo/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicantInfo/Default.cshtml
@@ -76,7 +76,12 @@
                 </abp-row>
                 <abp-row class="m-0 p-0">
                     <abp-column size="_4" class="px-1">
-                        <abp-input asp-for="@Model.ApplicantInfo.UnityApplicantId" onchange="enableApplicantInfoSaveBtn(this)" />
+                        <div class="input-group unt-input-group">
+                            <abp-input asp-for="@Model.ApplicantInfo.UnityApplicantId" maxlength="6" class="unt-input" id="applicantInfoUnityApplicantId" onchange="enableApplicantInfoSaveBtn(this)" />
+                            <div class="unt-input-group-append">
+                                <button class="btn unt-btn-outline-primary btn-outline-primary" id="btn-generate" type="button" onclick="generateUnityApplicantIdBtn()"><i class="unt-icon-sm fa-solid fa-shuffle"></i></button>
+                            </div>
+                        </div>
                     </abp-column>
                     <abp-column size="_4" class="px-1">
                         <abp-select asp-for="@Model.ApplicantInfo.FiscalDay" asp-items="@Model.FiscalDayList"

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicantInfo/Default.css
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicantInfo/Default.css
@@ -41,3 +41,19 @@
     margin-left: 15px;
     padding-top: 5px;
 }
+
+.unt-input-group .mb-3 {
+    width: 100%;
+}
+
+.unt-input-group-append {
+    position: absolute;
+    right: 0;
+    margin: 32px 10px 0px 0px;
+}
+
+.unt-input-group-append .unt-btn-outline-primary {
+    padding: 6px;
+    min-height: 25px;
+    border-radius: 2em;
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicantInfo/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicantInfo/Default.js
@@ -4,6 +4,10 @@
         $(this).maskMoney('mask', this.value);
     });
 
+    const $unityAppId = $('#applicantInfoUnityApplicantId');
+    let previousUnityAppId = $unityAppId.val();
+    console.log(previousUnityAppId);
+
     $('body').on('click', '#saveApplicantInfoBtn', function () {
         let applicationId = document.getElementById('ApplicantInfoViewApplicationId').value;
         let formData = $("#ApplicantInfoForm").serializeArray();
@@ -48,22 +52,16 @@
 
             ApplicantInfoObj['correlationId'] = formVersionId;
             ApplicantInfoObj['worksheetId'] = worksheetId;
-            unity.grantManager.grantApplications.grantApplication
-                .updateProjectApplicantInfo(applicationId, ApplicantInfoObj)
-                .done(function () {
-                    abp.notify.success(
-                        'The Applicant info has been updated.'
-                    );
-                    $('#saveApplicantInfoBtn').prop('disabled', true);
-                    PubSub.publish("refresh_detail_panel_summary");
-                    PubSub.publish('applicant_info_updated', ApplicantInfoObj);
-                    refreshSupplierInfoWidget();
-                })
-                .then(function () {
-                    $('.cas-spinner').hide();
-                }).catch(function () {
-                    $('.cas-spinner').hide();
-                });
+
+            if (ApplicantInfoObj['UnityApplicantId'] !== null) {
+                if (previousUnityAppId !== ApplicantInfoObj['UnityApplicantId']) {
+                    checkUnityApplicantIdExist(ApplicantInfoObj['UnityApplicantId'], applicationId, ApplicantInfoObj);
+                } else {
+                    updateApplicantInfo(applicationId, ApplicantInfoObj);
+                    }
+            } else { 
+                updateApplicantInfo(applicationId, ApplicantInfoObj);
+            }
         }
         catch (error) {
             $('.cas-spinner').hide();
@@ -71,29 +69,6 @@
             $('#saveApplicantInfoBtn').prop('disabled', false);
         }
     });
-
-    function refreshSupplierInfoWidget() {
-        const applicantId = $("#ApplicantInfoViewApplicantId").val();
-        const url = `../Payments/Widget/SupplierInfo/Refresh?applicantId=${applicantId}`;
-        fetch(url)
-            .then(response => response.text())
-            .then(data => {
-                let supplierInfo = document.getElementById('supplier-info-widget');
-                const parser = new DOMParser();
-                const doc = parser.parseFromString(data, 'text/html');
-                const siteIdValue = doc.querySelector('#SiteId').value;
-
-                if (supplierInfo) {
-                    supplierInfo.innerHTML = data;
-                    PubSub.publish('reload_sites_list', siteIdValue);
-                }
-                $('.cas-spinner').hide();
-            })
-            .catch(error => {
-                $('.cas-spinner').hide();
-                console.error('Error refreshing supplier-info-widget:', error);
-            });
-    }
 
     $('#orgSectorDropdown').change(function () {
         const selectedValue = $(this).val();
@@ -115,6 +90,14 @@
         });
     });
 
+    $unityAppId.on('change', function () {
+        if ($unityAppId.val().trim() !== previousUnityAppId) {
+            $('#saveApplicantInfoBtn').prop('disabled', false);
+        } else {
+            $('#saveApplicantInfoBtn').prop('disabled', true);
+        }
+    })
+
     PubSub.subscribe(
         'fields_applicantinfo',
         () => {
@@ -126,6 +109,65 @@
 });
 
 
+async function generateUnityApplicantIdBtn() {
+    try {
+        let nextUnityApplicantId = await unity.grantManager.applicants.applicant.getNextUnityApplicantId().then(data => {
+            return data;
+        });
+        document.getElementById('applicantInfoUnityApplicantId').value = nextUnityApplicantId;
+        $('#saveApplicantInfoBtn').prop('disabled', false);
+    }
+    catch (error) {
+        console.log(error);
+    }
+};
+
+async function checkUnityApplicantIdExist(unityAppId, appId, appInfoObj ) {
+    try {
+        let existingApplicant = await unity.grantManager.applicants.applicant.getExistingApplicant(unityAppId).then(data => {
+            return data;
+        });
+
+        if (existingApplicant) {
+            Swal.fire({
+                icon: "error",
+                text: "Applicatn ID already exists. Please enter a unique ID.",
+                confirmButtonText: 'Ok',
+                customClass: {
+                    confirmButton: 'btn btn-primary'
+                }
+            });
+        } else {
+            updateApplicantInfo(appId, appInfoObj);
+        }
+    }
+    catch (error) {
+        console.log(error);
+    }
+}
+function refreshSupplierInfoWidget() {
+    const applicantId = $("#ApplicantInfoViewApplicantId").val();
+    const url = `../Payments/Widget/SupplierInfo/Refresh?applicantId=${applicantId}`;
+    fetch(url)
+        .then(response => response.text())
+        .then(data => {
+            let supplierInfo = document.getElementById('supplier-info-widget');
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(data, 'text/html');
+            const siteIdValue = doc.querySelector('#SiteId').value;
+
+            if (supplierInfo) {
+                supplierInfo.innerHTML = data;
+                PubSub.publish('reload_sites_list', siteIdValue);
+            }
+            $('.cas-spinner').hide();
+        })
+        .catch(error => {
+            $('.cas-spinner').hide();
+            console.error('Error refreshing supplier-info-widget:', error);
+        });
+}
+
 function enableApplicantInfoSaveBtn(inputText) {
     if (!$("#ApplicantInfoForm").valid()
         || !abp.auth.isGranted('GrantApplicationManagement.ApplicantInfo.Update')
@@ -136,4 +178,22 @@ function enableApplicantInfoSaveBtn(inputText) {
     $('#saveApplicantInfoBtn').prop('disabled', false);
 }
 
+function updateApplicantInfo(appId, appInfoObj) { 
+    return unity.grantManager.grantApplications.grantApplication
+        .updateProjectApplicantInfo(appId, appInfoObj)
+        .done(function () {
+            abp.notify.success(
+                'The Applicant info has been updated.'
+            );
+            $('#saveApplicantInfoBtn').prop('disabled', true);
+            PubSub.publish("refresh_detail_panel_summary");
+            PubSub.publish('applicant_info_updated', appInfoObj);
+            refreshSupplierInfoWidget();
+        })
+        .then(function () {
+            $('.cas-spinner').hide();
+        }).catch(function () {
+            $('.cas-spinner').hide();
+        });
+}
 


### PR DESCRIPTION
- Implement a new service to retrieve the next UnityApplicantId
- Change the access modifier of the GetExistingApplicantAsync service, which is used to check if a UnityApplicantId exists
- Add a new UI feature for the UnityApplicantId field that includes a button to generate a new UnityApplicantId
- Add validation check to ensure that the entered UnityApplicantId does not already exist
- ApplicantId (UnityApplicantId) field is editable and has a maximum length of 6 digits