### PR TITLE
bugfix/AB#28141-RemoveApplicationFormVersionFromFullAudit

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/ApplicationFormVersion.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/ApplicationFormVersion.cs
@@ -4,7 +4,7 @@ using Volo.Abp.MultiTenancy;
 
 namespace Unity.GrantManager.Applications;
 
-public class ApplicationFormVersion : FullAuditedAggregateRoot<Guid>, IMultiTenant
+public class ApplicationFormVersion : AuditedAggregateRoot<Guid>, IMultiTenant
 {
     public Guid ApplicationFormId { get; set; }
     public string? ChefsApplicationFormGuid { get; set; }


### PR DESCRIPTION
            options.EntityHistorySelectors.Add(
                new NamedTypeSelector(
                    "Abp.FullAuditedEntities",
                    type => typeof(IFullAuditedObject).IsAssignableFrom(type)
                )
            );

I believe this will remove the issue with the AuditingStore - maybe - not sure if the AuditedAggregateRoot will cause the same error:
Image