### PR TITLE
ab#8134 email notification

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Notifications/src/Unity.Notifications.Application.Contracts/Emails/EmailCommentDto.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Notifications/src/Unity.Notifications.Application.Contracts/Emails/EmailCommentDto.cs
@@ -9,5 +9,6 @@ public class EmailCommentDto
     public string Subject { get; set; } = string.Empty;
     public string From { get; set; } = string.Empty;
     public string Body { get; set; } = string.Empty;
+    public string ApplicationId { get; set; } = string.Empty;
     public List<string> MentionNamesEmail { get; set; } = [];
 }

--- a/applications/Unity.GrantManager/modules/Unity.Notifications/src/Unity.Notifications.Application/EmailNotificaions/IEmailNotificationService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Notifications/src/Unity.Notifications.Application/EmailNotificaions/IEmailNotificationService.cs
@@ -15,7 +15,7 @@ namespace Unity.Notifications.EmailNotifications
         Task<EmailLog?> InitializeEmailLog(string emailTo, string body, string subject, Guid applicationId, string? emailFrom);
         Task<EmailLog?> GetEmailLogById(Guid id);
         Task<HttpResponseMessage> SendCommentNotification(EmailCommentDto input);
-        Task<HttpResponseMessage> SendEmailNotification(string emailTo, string body, string subject, string? emailFrom);
+        Task<HttpResponseMessage> SendEmailNotification(string emailTo, string body, string subject, string? emailFrom, string? emailBodyType);
         Task SendEmailToQueue(EmailLog emailLog);
         string GetApprovalBody();
         string GetDeclineBody();

--- a/applications/Unity.GrantManager/modules/Unity.Notifications/src/Unity.Notifications.Application/Integrations/RabbitMQ/EmailConsumer.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Notifications/src/Unity.Notifications.Application/Integrations/RabbitMQ/EmailConsumer.cs
@@ -79,7 +79,7 @@ public class EmailConsumer : IQueueConsumer<EmailMessages>
                                                                                     emailLog.ToAddress,
                                                                                     emailLog.Body,
                                                                                     emailLog.Subject,
-                                                                                    emailLog.FromAddress);
+                                                                                    emailLog.FromAddress, "text");
                 // Update the response
                 emailLog.ChesResponse = JsonConvert.SerializeObject(response);
                 emailLog.ChesStatus = response.StatusCode.ToString();

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/CommentsWidget/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/CommentsWidget/Default.js
@@ -118,30 +118,33 @@ function saveComment(ownerId, comment, commentType, mentionList) {
 }
 
 function sendComment(tempIsEdit, tempOwnerId, tempCommentType, tempComment, tempMentionedNamesEmail, tempItemId, mentionList) {
-    const submissionNo = document.getElementsByClassName("reference-no")[0].textContent;
-    const applicantName = document.getElementsByClassName("applicant-name")[0].textContent;
-    const currentUserName = document.getElementById("CurrentUserName").value;
+    const submissionNo = $(".reference-no").first().text();
+    const applicantName = $(".applicant-name").first().text();
+    const currentUserName = $("#CurrentUserName").val();
+    const appId = $("#DetailsViewApplicationId").val();
+
+    const requestData = {
+        subject: `${submissionNo}-${applicantName}`,
+        from: currentUserName,
+        body: tempComment,
+        applicationId: appId,
+        mentionNamesEmail: tempMentionedNamesEmail
+    };
 
     return $.ajax({
         url: `/api/app/email-notification/send-comment-notification`,
         type: "POST",
         contentType: "application/json",
-        data: JSON.stringify({
-            "subject": `${submissionNo}-${applicantName}`,
-            "from": currentUserName,
-            "body": tempComment,
-            "mentionNamesEmail": tempMentionedNamesEmail
-        }),
+        data: JSON.stringify(requestData),
     }).then(response => {
         if (tempIsEdit) {
-            updateComment(tempOwnerId, tempItemId, tempComment, tempCommentType, mentionList)
+            updateComment(tempOwnerId, tempItemId, tempComment, tempCommentType, mentionList);
         } else {
             saveComment(tempOwnerId, tempComment, tempCommentType, mentionList);
         }
-    })
-        .catch(error => {
-            console.error('There was a problem with the post operation:', error);
-        });
+    }).catch(error => {
+        console.error('There was a problem with the post operation:', error);
+    });
 }
 
 function initTribute(mentionData) {
@@ -153,16 +156,14 @@ function initTribute(mentionData) {
         selectTemplate: function (item) {
             if (typeof item === 'undefined') return null;
             if (this.range.isContentEditable(this.current.element)) {
-                return ('<span contenteditable="false"><a class="name-highlighted" href="#"  onclick="return false;">' + item.original.value + '</a><span>');
+                return (`<span contenteditable="false"><a class="name-highlighted" href="#" onclick="return false;">${item.original.value}</a><span>`);
             }
-            return "@" + item.original.value;
+            return `@${item.original.value}`;
         },
         requireLeadingSpace: false,
     })
 
     areaWithMentions.forEach(item => {
-        console.log(item.id)
         tribute.attach(document.getElementById(item.id));
     });
-
 }


### PR DESCRIPTION
- Include the email subject line with the submission number and the applicant's name.
- Add a new parameter 'emailBodyType', to specify the formatting of the body text in the response
- Update the email notification service to display the email in HTML format for better UI/UX. Currently, only the 'SendCommentNotification' service utilizes the 'html' body type
- Add a link in the email notification that redirects to the application