### PR TITLE
feature/AB#25263-UTCIssue

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Integrations/Cas/InvoiceService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Integrations/Cas/InvoiceService.cs
@@ -69,9 +69,10 @@ namespace Unity.Payments.Integrations.Cas
 
             if (site != null && site.Supplier != null && site.Supplier.Number != null && accountDistributionCode != null)
             {
-                var currentMonth = DateTime.UtcNow.ToString("MMM").Trim('.');
-                var currentDay = DateTime.UtcNow.ToString("dd");
-                var currentYear = DateTime.UtcNow.ToString("yyyy");
+                // This can not be UTC Now it is sent to cas and can not be in the future - this is not being stored in Unity as a date
+                var currentMonth = DateTime.Now.ToString("MMM").Trim('.');
+                var currentDay = DateTime.Now.ToString("dd");
+                var currentYear = DateTime.Now.ToString("yyyy");
                 var dateStringDayMonYear = $"{currentDay}-{currentMonth}-{currentYear}";
 
                 casInvoice.SupplierNumber = site.Supplier.Number; // This is from each Applicant
@@ -176,7 +177,7 @@ namespace Unity.Payments.Integrations.Cas
             {
                 if(response.Content != null && response.StatusCode != HttpStatusCode.NotFound)
                 {
-                    var contentString = Unity.Modules.Shared.Http.ResilientHttpRequest.ContentToString(response.Content);
+                    var contentString = ResilientHttpRequest.ContentToString(response.Content);
                     var result = JsonSerializer.Deserialize<InvoiceResponse>(contentString)
                         ?? throw new UserFriendlyException("CAS InvoiceService CreateInvoiceAsync Exception: " + response);
                     result.CASHttpStatusCode = response.StatusCode;


### PR DESCRIPTION
2024-12-13 00:04:14.983068 - This is the Date of the failing invoice which is at 4AM of the next day 
UTC -8 would  have been 2024-12-12 at 00:20:14

This code was changed at some point we changed as part of feature 23411:

var currentMonth = DateTime.Now.ToString("MMM").Trim('.'); to var currentMonth = DateTime.UTCNow.ToString("MMM").Trim('.');

This causes CAS to think that the date is in the future and causes the invoice to fail. Since we are not storing the Invoice in the Unity database there is no reason to convert this to UTC

                // This can not be UTC Now it is sent to cas and can not be in the future - this is not being stored in Unity as a date
                var currentMonth = DateTime.Now.ToString("MMM").Trim('.');
                var currentDay = DateTime.Now.ToString("dd");
                var currentYear = DateTime.Now.ToString("yyyy");
                var dateStringDayMonYear = $"{currentDay}-{currentMonth}-{currentYear}";
                casInvoice.InvoiceDate = dateStringDayMonYear; //DD-MMM-YYYY
                casInvoice.DateInvoiceReceived = dateStringDayMonYear;