### PR TITLE
Feature/ab#28377 intake submission handling

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Intakes/IntakeSubmissionBackgroundJobArgs.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Intakes/IntakeSubmissionBackgroundJobArgs.cs
@@ -7,6 +7,5 @@ namespace Unity.GrantManager.Intakes
     {
         public EventSubscriptionDto? EventSubscriptionDto { get; set; }
         public Guid? TenantId { get; set; }
-        public int ProcessDelayMs { get; set; }
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Intakes/IntakeSubmissionBackgroundJobArgs.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Intakes/IntakeSubmissionBackgroundJobArgs.cs
@@ -7,5 +7,6 @@ namespace Unity.GrantManager.Intakes
     {
         public EventSubscriptionDto? EventSubscriptionDto { get; set; }
         public Guid? TenantId { get; set; }
+        public Guid ConfirmationId { get; set; }
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Intakes/IntakeSubmissionBackgroundJobArgs.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Intakes/IntakeSubmissionBackgroundJobArgs.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Unity.GrantManager.Events;
+
+namespace Unity.GrantManager.Intakes
+{
+    public class IntakeSubmissionBackgroundJobArgs
+    {
+        public EventSubscriptionDto? EventSubscriptionDto { get; set; }
+        public Guid? TenantId { get; set; }
+        public int ProcessDelayMs { get; set; }
+    }
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantManagerApplicationModule.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantManagerApplicationModule.cs
@@ -39,8 +39,6 @@ using Volo.Abp.DistributedLocking;
 using Medallion.Threading.Redis;
 using Medallion.Threading;
 using StackExchange.Redis;
-using System.Threading;
-using System.Threading.Tasks;
 using Unity.GrantManager.Locks;
 
 namespace Unity.GrantManager;

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/BackgroundWorkers/IntakeSubmissionBackgroundJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/BackgroundWorkers/IntakeSubmissionBackgroundJob.cs
@@ -1,0 +1,42 @@
+using System.Threading.Tasks;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.MultiTenancy;
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace Unity.GrantManager.Intakes.BackgroundWorkers
+{
+    public class IntakeSubmissionBackgroundJob(
+        IIntakeSubmissionAppService intakeSubmissionAppService,
+        ICurrentTenant currentTenant,
+        ILogger<IntakeSubmissionBackgroundJob> logger) : AsyncBackgroundJob<IntakeSubmissionBackgroundJobArgs>, ITransientDependency
+    {
+        public override async Task ExecuteAsync(IntakeSubmissionBackgroundJobArgs args)
+        {
+            using (currentTenant.Change(args.TenantId))
+            {
+                try
+                {
+                    if (args.EventSubscriptionDto == null)
+                    {
+                        logger.LogWarning("EventSubscriptionDto is null");
+                        return;
+                    }
+
+                    Logger.LogInformation("Was {X} Millseconds Before Processing", args.ProcessDelayMs);
+
+                    await Task.Delay(args.ProcessDelayMs); // Delay
+
+                    Logger.LogInformation("Processing Intake In Background");
+
+                    await intakeSubmissionAppService.CreateIntakeSubmissionAsync(args.EventSubscriptionDto);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Error processing intake submission");
+                }
+            }
+        }
+    }
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/BackgroundWorkers/IntakeSubmissionBackgroundJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/BackgroundWorkers/IntakeSubmissionBackgroundJob.cs
@@ -14,6 +14,8 @@ namespace Unity.GrantManager.Intakes.BackgroundWorkers
     {
         public override async Task ExecuteAsync(IntakeSubmissionBackgroundJobArgs args)
         {
+            logger.LogInformation("Executing intake submission background job for confirmation id: {confirmationId}", args.ConfirmationId);
+
             using (currentTenant.Change(args.TenantId))
             {
                 try
@@ -30,7 +32,7 @@ namespace Unity.GrantManager.Intakes.BackgroundWorkers
                 }
                 catch (Exception ex)
                 {
-                    logger.LogError(ex, "Error processing intake submission");
+                    logger.LogError(ex, "Error processing intake submission for confirmation id: {confirmationId}", args.ConfirmationId);
                 }
             }
         }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/BackgroundWorkers/IntakeSubmissionBackgroundJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/BackgroundWorkers/IntakeSubmissionBackgroundJob.cs
@@ -14,7 +14,7 @@ namespace Unity.GrantManager.Intakes.BackgroundWorkers
     {
         public override async Task ExecuteAsync(IntakeSubmissionBackgroundJobArgs args)
         {
-            logger.LogInformation("Executing intake submission background job for confirmation id: {confirmationId}", args.ConfirmationId);
+            logger.LogInformation("Executing intake submission background job for confirmation id: {ConfirmationId}", args.ConfirmationId);
 
             using (currentTenant.Change(args.TenantId))
             {
@@ -32,7 +32,7 @@ namespace Unity.GrantManager.Intakes.BackgroundWorkers
                 }
                 catch (Exception ex)
                 {
-                    logger.LogError(ex, "Error processing intake submission for confirmation id: {confirmationId}", args.ConfirmationId);
+                    logger.LogError(ex, "Error processing intake submission for confirmation id: {ConfirmationId}", args.ConfirmationId);
                 }
             }
         }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/BackgroundWorkers/IntakeSubmissionBackgroundJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/BackgroundWorkers/IntakeSubmissionBackgroundJob.cs
@@ -24,11 +24,7 @@ namespace Unity.GrantManager.Intakes.BackgroundWorkers
                         return;
                     }
 
-                    Logger.LogInformation("Was {X} Millseconds Before Processing", args.ProcessDelayMs);
-
-                    await Task.Delay(args.ProcessDelayMs); // Delay
-
-                    Logger.LogInformation("Processing Intake In Background");
+                    Logger.LogInformation("Processing intake in background for submissionId {Id}", args.EventSubscriptionDto.SubmissionId);
 
                     await intakeSubmissionAppService.CreateIntakeSubmissionAsync(args.EventSubscriptionDto);
                 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/IntakeFormSubmissionManager.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/IntakeFormSubmissionManager.cs
@@ -57,7 +57,7 @@ namespace Unity.GrantManager.Intakes
             intakeMap.ConfirmationId = formSubmission.submission.confirmationId;
             using var uow = _unitOfWorkManager.Begin();
             var application = await CreateNewApplicationAsync(intakeMap, applicationForm);
-            _intakeFormSubmissionMapper.SaveChefsFiles(formSubmission, application.Id);
+            await _intakeFormSubmissionMapper.SaveChefsFiles(formSubmission, application.Id);
 
             var newSubmission = new ApplicationFormSubmission
             {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Locks/InMemoryDistributedLock.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Locks/InMemoryDistributedLock.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Medallion.Threading;
+
+namespace Unity.GrantManager.Locks
+{
+    public class InMemoryDistributedLock(string name, ConcurrentDictionary<string, SemaphoreSlim> locks) : IDistributedLock
+    {
+        public string Name => name;
+
+        public IDistributedSynchronizationHandle Acquire(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var semaphore = locks.GetOrAdd(name, _ => new SemaphoreSlim(1, 1));
+            if (!semaphore.Wait(timeout ?? TimeSpan.FromSeconds(30), cancellationToken))
+            {
+                throw new TimeoutException("Failed to acquire lock within the specified timeout.");
+            }
+            return new InMemoryDistributedSynchronizationHandle(semaphore);
+        }
+
+        public async ValueTask<IDistributedSynchronizationHandle> AcquireAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var semaphore = locks.GetOrAdd(name, _ => new SemaphoreSlim(1, 1));
+            if (!await semaphore.WaitAsync(timeout ?? TimeSpan.FromSeconds(30), cancellationToken))
+            {
+                throw new TimeoutException("Failed to acquire lock within the specified timeout.");
+            }
+            return new InMemoryDistributedSynchronizationHandle(semaphore);
+        }
+
+        public IDistributedSynchronizationHandle? TryAcquire(TimeSpan timeout = default, CancellationToken cancellationToken = default)
+        {
+            var semaphore = locks.GetOrAdd(name, _ => new SemaphoreSlim(1, 1));
+            if (!semaphore.Wait(timeout, cancellationToken))
+            {
+                return null;
+            }
+            return new InMemoryDistributedSynchronizationHandle(semaphore);
+        }
+
+        public async ValueTask<IDistributedSynchronizationHandle?> TryAcquireAsync(TimeSpan timeout = default, CancellationToken cancellationToken = default)
+        {
+            var semaphore = locks.GetOrAdd(name, _ => new SemaphoreSlim(1, 1));
+            if (!await semaphore.WaitAsync(timeout, cancellationToken))
+            {
+                return null;
+            }
+            return new InMemoryDistributedSynchronizationHandle(semaphore);
+        }
+    }
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Locks/InMemoryDistributedLockProvider.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Locks/InMemoryDistributedLockProvider.cs
@@ -1,0 +1,16 @@
+﻿using Medallion.Threading;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Unity.GrantManager.Locks
+{
+    public class InMemoryDistributedLockProvider : IDistributedLockProvider
+    {
+        private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
+
+        public IDistributedLock CreateLock(string name)
+        {
+            return new InMemoryDistributedLock(name, _locks);
+        }
+    }
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Locks/InMemoryDistributedSynchronizationHandle.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Locks/InMemoryDistributedSynchronizationHandle.cs
@@ -21,6 +21,8 @@ namespace Unity.GrantManager.Locks
                 if (disposing)
                 {
                     semaphore.Release();
+                    _cancellationTokenSource.Cancel();
+                    _cancellationTokenSource.Dispose();
                 }
                 _disposed = true;
             }
@@ -37,6 +39,8 @@ namespace Unity.GrantManager.Locks
             if (!_disposed)
             {
                 semaphore.Release();
+                _cancellationTokenSource.Cancel();
+                _cancellationTokenSource.Dispose();
                 _disposed = true;
             }
             await ValueTask.CompletedTask;

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Locks/InMemoryDistributedSynchronizationHandle.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Locks/InMemoryDistributedSynchronizationHandle.cs
@@ -39,7 +39,7 @@ namespace Unity.GrantManager.Locks
             if (!_disposed)
             {
                 semaphore.Release();
-                _cancellationTokenSource.Cancel();
+                await _cancellationTokenSource.CancelAsync();
                 _cancellationTokenSource.Dispose();
                 _disposed = true;
             }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Locks/InMemoryDistributedSynchronizationHandle.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Locks/InMemoryDistributedSynchronizationHandle.cs
@@ -1,0 +1,46 @@
+﻿using Medallion.Threading;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Unity.GrantManager.Locks
+{
+    public class InMemoryDistributedSynchronizationHandle(SemaphoreSlim semaphore) : IDistributedSynchronizationHandle
+    {
+        private bool _disposed = false;
+#pragma warning disable S3604 // Member initializer values should not be redundant
+        private readonly CancellationTokenSource _cancellationTokenSource = new();
+#pragma warning restore S3604 // Member initializer values should not be redundant
+
+        public CancellationToken HandleLostToken => _cancellationTokenSource.Token;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    semaphore.Release();
+                }
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (!_disposed)
+            {
+                semaphore.Release();
+                _disposed = true;
+            }
+            await ValueTask.CompletedTask;
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Unity.GrantManager.Application.csproj
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Unity.GrantManager.Application.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+	<PackageReference Include="DistributedLock.Redis" Version="1.0.3" />
 	<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
 	<PackageReference Include="System.Text.Json" Version="8.0.5" />
 	<PackageReference Include="Volo.Abp.Autofac" Version="8.3.4" />
@@ -34,6 +35,7 @@
     <PackageReference Include="Volo.Abp.BackgroundWorkers.Quartz" Version="8.3.4" />
     <PackageReference Include="Volo.Abp.BlobStoring" Version="8.3.4" />
 	<PackageReference Include="Volo.Abp.Caching" Version="8.3.4" />
+	<PackageReference Include="Volo.Abp.DistributedLocking" Version="8.3.4" />
     <PackageReference Include="Volo.Abp.Identity.Application" Version="8.3.4" />
     <PackageReference Include="Volo.Abp.PermissionManagement.Application" Version="8.3.4" />
     <PackageReference Include="Volo.Abp.TenantManagement.Application" Version="8.3.4" />

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/ApplicantAgent.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/ApplicantAgent.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 using Volo.Abp.Domain.Entities.Auditing;
 using Volo.Abp.MultiTenancy;
 
@@ -9,12 +10,15 @@ public class ApplicantAgent : AuditedAggregateRoot<Guid>, IMultiTenant
     public string? OidcSubUser { get; set; }
     public Guid ApplicantId { get; set; }
     public Guid? ApplicationId { get; set; }
+
+    [JsonIgnore]
     public virtual Application Application
     {
         set => _application = value;
         get => _application
                ?? throw new InvalidOperationException("Uninitialized property: " + nameof(Application));
     }
+
     private Application? _application;
     public Guid? TenantId { get; set; }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.HttpApi/Controllers/EventSubscriptionController.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.HttpApi/Controllers/EventSubscriptionController.cs
@@ -56,10 +56,12 @@ namespace Unity.GrantManager.Controllers
         {
             EventSubscriptionDto eventSubscriptionDto = ObjectMapper.Map<EventSubscription, EventSubscriptionDto>(eventSubscription);
 
+            Logger.LogInformation("Handling Intake Event Of Type: {Type}", eventSubscription.SubscriptionEvent?.ToString() ?? "UNDEFINED");
+
             if (eventSubscription.SubscriptionEvent == ChefsEventTypesConsts.FORM_SUBMITTED)
             {
                 await DelayAsync();                
-            }
+            }            
 
             return eventSubscription.SubscriptionEvent switch
             {
@@ -72,7 +74,7 @@ namespace Unity.GrantManager.Controllers
 
         private async Task DelayAsync()
         {
-            Logger.LogInformation("Delaying for 5 seconds");
+            Logger.LogInformation("Delaying Intake Event For Processing By 5 Seconds");
             await Task.Delay(5000); // Delay for 5 seconds
         }
     }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.HttpApi/Controllers/EventSubscriptionController.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.HttpApi/Controllers/EventSubscriptionController.cs
@@ -58,7 +58,6 @@ namespace Unity.GrantManager.Controllers
                 {
                     EventSubscriptionDto = eventSubscriptionDto,
                     TenantId = currentTenant.Id,
-                    ProcessDelayMs = 10000 // Could be moved to a configuration setting
                 };
 
                 await backgroundJobManager.EnqueueAsync(args);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.HttpApi/Controllers/EventSubscriptionController.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.HttpApi/Controllers/EventSubscriptionController.cs
@@ -54,17 +54,23 @@ namespace Unity.GrantManager.Controllers
 
             if (eventSubscription.SubscriptionEvent == ChefsEventTypesConsts.FORM_SUBMITTED)
             {
+                var confirmationId = Guid.NewGuid();
+
                 var args = new IntakeSubmissionBackgroundJobArgs
                 {
                     EventSubscriptionDto = eventSubscriptionDto,
                     TenantId = currentTenant.Id,
+                    ConfirmationId = confirmationId
                 };
 
                 await backgroundJobManager.EnqueueAsync(args);
 
                 // Return a response immediately
-                return new EventSubscriptionConfirmationDto() { ConfirmationId = Guid.NewGuid(), ExceptionMessage = "Processing.." };
+                return new EventSubscriptionConfirmationDto() { ConfirmationId = confirmationId, ExceptionMessage = "Processing.." };
             }
+
+            // Not specifcifiying the event type will default to creating an intake submission
+            // This processing type will also be inline and not queued
 
             return eventSubscription.SubscriptionEvent switch
             {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.HttpApi/Controllers/EventSubscriptionController.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.HttpApi/Controllers/EventSubscriptionController.cs
@@ -7,6 +7,7 @@ using Unity.GrantManager.GrantApplications;
 using Volo.Abp.TenantManagement;
 using Unity.GrantManager.Controllers.Auth.FormSubmission;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Logging;
 
 namespace Unity.GrantManager.Controllers
 {
@@ -54,6 +55,12 @@ namespace Unity.GrantManager.Controllers
         private async Task<dynamic> HandleIntakeEventAsync(EventSubscription eventSubscription)
         {
             EventSubscriptionDto eventSubscriptionDto = ObjectMapper.Map<EventSubscription, EventSubscriptionDto>(eventSubscription);
+
+            if (eventSubscription.SubscriptionEvent == ChefsEventTypesConsts.FORM_SUBMITTED)
+            {
+                await DelayAsync();                
+            }
+
             return eventSubscription.SubscriptionEvent switch
             {
                 ChefsEventTypesConsts.FORM_SUBMITTED => await _intakeSubmissionAppService.CreateIntakeSubmissionAsync(eventSubscriptionDto),
@@ -61,6 +68,12 @@ namespace Unity.GrantManager.Controllers
                 ChefsEventTypesConsts.FORM_DRAFT_PUBLISHED => await _iChefsEventSubscriptionService.PublishedFormAsync(eventSubscriptionDto),
                 _ => await _intakeSubmissionAppService.CreateIntakeSubmissionAsync(eventSubscriptionDto),
             };
+        }
+
+        private async Task DelayAsync()
+        {
+            Logger.LogInformation("Delaying for 5 seconds");
+            await Task.Delay(5000); // Delay for 5 seconds
         }
     }
 }


### PR DESCRIPTION
- Defer the intake to a ABP background task
- Include distributed locking implementation
- Implemented an InMemory distributed locking provider for when not running in Redis mode (only way i found to get this working in our setup)
- Added JsonIgnore to the Applicant->Applicant agent relation to prevent the json cyclic error for this
- Added possibly missing await from the Intake SaveChefs file callout