### PR TITLE
feature/AB#28587 - Add Application hyperlink to Payment Requests table

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.js
@@ -316,10 +316,14 @@ $(function () {
             title: l('ApplicationPaymentListTable:SubmissionConfirmationCode'),
             name: 'submissionConfirmationCode',
             data: 'submissionConfirmationCode',
-            className: 'data-table-header',
+            className: 'data-table-header text-nowrap',
             index: columnIndex,
-            render: function (data) {
-                return data?.length > 0 ? data : null;
+            render: function (data, type, row) {
+                if (row.correlationProvider === 'Application' && data?.length > 0) {
+                    return `<a href="/GrantApplications/Details?ApplicationId=${row.correlationId}">${data}</a>`;
+                }
+
+                return data || null;
             }
         };
     }

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/table-utils.js
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/table-utils.js
@@ -184,6 +184,13 @@ function initializeDataTable(options) {
 
     setExternalSearchFilter(iDt);
 
+    // Prevent row selection when clicking on a link inside a cell
+    iDt.on('user-select', function (e, dt, type, cell, originalEvent) {
+        if (originalEvent.target.nodeName.toLowerCase() === 'a') {
+            e.preventDefault();
+        }
+    });
+
     return iDt;
 }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.js
@@ -236,7 +236,7 @@
             title: 'Submission #',
             data: 'referenceNo',
             name: 'referenceNo',
-            className: 'data-table-header',
+            className: 'data-table-header text-nowrap',
             render: function (data, type, row) {
                 console.log(row);
                 return `<a href="/GrantApplications/Details?ApplicationId=${row.id}">${data}</a>`;


### PR DESCRIPTION
- Added "Submission #" hyperlink to Payment Requests page
- Added logic to prevent row selection on clicking hyperlinks in standard Unity tables
- Changed CSS to prevent "Submission #" header from wrapping