### PR TITLE
bugfix/AB#28209 - Payment Info Tab - Localize Payment Status Text

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Shared/Localization/Payments/en.json
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Shared/Localization/Payments/en.json
@@ -102,13 +102,28 @@
     "ApplicationPaymentStatusRequest:L2ApproveOrDeclineTitle": "Approve/Decline L2 Payment Requests",
     "ApplicationPaymentStatusRequest:L3ApproveOrDeclineTitle": "Approve/Decline L3 Payment Requests",
 
-
     "Permission:Payments": "Payments",
     "Permission:Payments.Default": "Payments",
     "Permission:Payments.L1ApproveOrDecline": "Approve/Decline L1 Payments",
     "Permission:Payments.L2ApproveOrDecline": "Approve/Decline L2 Payments",
     "Permission:Payments.L3ApproveOrDecline": "Approve/Decline L3 Payments",
     "Permission:Payments.RequestPayment": "Request Payment",
-    "Permission:Payments.EditSupplierInfo": "Update Supplier Info"
+    "Permission:Payments.EditSupplierInfo": "Update Supplier Info",
+
+    "Enum:PaymentRequestStatus.L1Pending": "L1 Pending",
+    "Enum:PaymentRequestStatus.L1Approved": "L1 Approved",
+    "Enum:PaymentRequestStatus.L1Declined": "L1 Declined",
+    "Enum:PaymentRequestStatus.L2Pending": "L2 Pending",
+    "Enum:PaymentRequestStatus.L2Approved": "L2 Approved",
+    "Enum:PaymentRequestStatus.L2Declined": "L2 Declined",
+    "Enum:PaymentRequestStatus.L3Pending": "L3 Pending",
+    "Enum:PaymentRequestStatus.L3Approved": "L3 Approved",
+    "Enum:PaymentRequestStatus.L3Declined": "L3 Declined",
+    "Enum:PaymentRequestStatus.Submitted": "Submitted to CAS",
+    "Enum:PaymentRequestStatus.Validated": "Validated",
+    "Enum:PaymentRequestStatus.NotValidated": "Not Validated",
+    "Enum:PaymentRequestStatus.Paid": "Paid",
+    "Enum:PaymentRequestStatus.Failed": "Payment Failed",
+    "Enum:PaymentRequestStatus.PaymentFailed": "Payment Failed"
   }
 }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.js
@@ -424,10 +424,8 @@ $(function () {
             className: 'data-table-header',
             index: columnIndex,
             render: function (data) {
-
-                let statusText = getStatusText(data);
                 let statusColor = getStatusTextColor(data);
-                return '<span style="color:' + statusColor + ';">' + statusText + '</span>';
+                return `<span style="color:${statusColor};">` + l(`Enum:PaymentRequestStatus.${data}`) + '</span>';
             }
         };
     }
@@ -653,57 +651,11 @@ $(function () {
             case "Paid":
                 return "#42814A";
 
-            case "PaymentFailed":
+            case "Failed":
                 return "#CE3E39";
 
             default:
                 return "#053662";
-        }
-    }
-
-    function getStatusText(status) {
-
-        switch (status) {
-
-            case "L1Pending":
-                return "L1 Pending";
-
-            case "L1Approved":
-                return "L1 Approved";
-
-            case "L1Declined":
-                return "L1 Declined";
-
-            case "L2Pending":
-                return "L2 Pending";
-
-            case "L2Approved":
-                return "L2 Approved";
-
-            case "L2Declined":
-                return "L2 Declined";
-
-            case "L3Pending":
-                return "L3 Pending";
-
-            case "L3Approved":
-                return "L3 Approved";
-
-            case "L3Declined":
-                return "L3 Declined";
-
-            case "Submitted":
-                return "Submitted to CAS";
-
-            case "Paid":
-                return "Paid";
-
-            case "PaymentFailed":
-                return "Payment Failed";
-
-
-            default:
-                return "Created";
         }
     }
 

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/PaymentInfo/Default.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/PaymentInfo/Default.js
@@ -244,7 +244,11 @@
             name: 'status',
             data: 'status',
             className: 'data-table-header',
-            index: 3
+            index: 3,
+            render: function (data) {
+                let statusColor = getPaymentStatusTextColor(data);
+                return `<span style="color:${statusColor};">` + l(`Enum:PaymentRequestStatus.${data}`) + '</span>';
+            }
         };
     }
 
@@ -430,4 +434,38 @@ function enablePaymentInfoSaveBtn() {
 
 function nullToEmpty(value) {
     return value == null ? '' : value;
+}
+
+function getPaymentStatusTextColor(status) {
+    switch (status) {
+        case "L1Pending":
+            return "#053662";
+
+        case "L1Declined":
+            return "#CE3E39";
+
+        case "L2Pending":
+            return "#053662";
+
+        case "L2Declined":
+            return "#CE3E39";
+
+        case "L3Pending":
+            return "#053662";
+
+        case "L3Declined":
+            return "#CE3E39";
+
+        case "Submitted":
+            return "#5595D9";
+
+        case "Paid":
+            return "#42814A";
+
+        case "Failed":
+            return "#CE3E39";
+
+        default:
+            return "#053662";
+    }
 }


### PR DESCRIPTION
Added localization to Payment Info Tab's payment list so Payment Status text and color matches the Payment Request page.