### PR TITLE
AB#28812 - Bugfix for Datatables Warning on Intake, Users, and Roles

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/index.js
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/index.js
@@ -80,6 +80,7 @@ $(function () {
                         orderable: false,
                         className: 'notexport text-center',
                         name: 'rowActions',
+                        data: 'id',
                         index: 0,
                         rowAction: {
                             items: abp.ui.extensions.entityActions.get('identity.role').actions.toArray()

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/index.js
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/index.js
@@ -180,6 +180,7 @@ $(function () {
                         orderable: false,
                         className: 'notexport text-center',
                         name: 'rowActions',
+                        data: 'id',
                         index: 0,
                         rowAction: {
                             items: abp.ui.extensions.entityActions.get('identity.user').actions.toArray()

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Index.js
@@ -16,7 +16,7 @@
             title: l('Actions'),
             orderable: false,
             className: 'notexport text-center',
-            data: null,
+            data: 'id',
             name: 'rowActions',
             index: 0,
             rowAction: {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantPrograms/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantPrograms/Index.js
@@ -26,6 +26,7 @@
         },
         {
             title: l('Actions'),
+            data: 'tenantId',
             orderable: false,
             className: 'notexport text-center',
             name: 'rowActions',

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Intakes/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Intakes/Index.js
@@ -55,6 +55,7 @@
         },
         {
             title: l('Actions'),
+            data: 'id',
             orderable: false,
             className: 'notexport text-center',
             name: 'rowActions',


### PR DESCRIPTION
Bugfix for Datatables Warning on Intake, Users, and Roles to prevent Datatable.net alerts from showing.

This issue only appears when the JavaScript is bundled and minified.
https://abp.io/docs/latest/framework/ui/mvc-razor-pages/bundling-minification#bundling-mode