### PR TITLE
bugfix/AB#28931 - Fix Assessment List Button Permissions and Workflow

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Assessments/AssessmentAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Assessments/AssessmentAppService.cs
@@ -333,7 +333,7 @@ namespace Unity.GrantManager.Assessments
 
         private async Task ValidateValidScoresheetAsync(Guid assessmentId, AssessmentAction triggerAction)
         {
-            if (await _featureChecker.IsEnabledAsync(UnityFlex) && triggerAction == AssessmentAction.Confirm)
+            if (await _featureChecker.IsEnabledAsync(UnityFlex) && triggerAction == AssessmentAction.Complete)
             {
                 var requirementsMetResult = await _scoresheetInstanceAppService.ValidateAnswersAsync(assessmentId);
 
@@ -346,7 +346,16 @@ namespace Unity.GrantManager.Assessments
 
         private static OperationAuthorizationRequirement GetActionAuthorizationRequirement(AssessmentAction triggerAction)
         {
-            return new OperationAuthorizationRequirement { Name = $"{UnitySelector.Review.AssessmentReviewList.Default}.{triggerAction}" };
+            if (triggerAction == AssessmentAction.SendBack || triggerAction == AssessmentAction.Complete)
+            {
+                // Actions that require parent Update permissions
+                return new OperationAuthorizationRequirement { Name = $"{UnitySelector.Review.AssessmentReviewList.Update.Default}.{triggerAction}" };
+
+            } else
+            {
+                // Actions for generic Create, Update, Delete permissions
+                return new OperationAuthorizationRequirement { Name = $"{UnitySelector.Review.AssessmentReviewList.Default}.{triggerAction}" };
+            }
         }
         #endregion ASSESSMENT WORKFLOW
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain.Shared/Assessments/AssessmentAction.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain.Shared/Assessments/AssessmentAction.cs
@@ -6,7 +6,6 @@ namespace Unity.GrantManager.Assessments;
 public enum AssessmentAction
 {
     Create,
-    SendTo,
     SendBack,
-    Confirm
+    Complete
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain.Shared/Localization/GrantManager/en.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain.Shared/Localization/GrantManager/en.json
@@ -107,9 +107,8 @@
     "Enum:AssessmentState.COMPLETED": "Completed",
 
     "Enum:AssessmentAction.Create": "Create Assessment",
-    "Enum:AssessmentAction.SendTo": "Send To...",
-    "Enum:AssessmentAction.Confirm": "Complete Assessment",
     "Enum:AssessmentAction.SendBack": "Send Back",
+    "Enum:AssessmentAction.Complete": "Complete Assessment",
 
     "Permission:GrantManagerManagement": "Grant Manager Management",
     "Permission:GrantManagerManagement.Default": "Default",

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Assessments/Assessment.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Assessments/Assessment.cs
@@ -62,12 +62,12 @@ public class Assessment : AuditedAggregateRoot<Guid>, IHasWorkflow<AssessmentSta
     public void ConfigureWorkflow(StateMachine<AssessmentState, AssessmentAction> stateMachine)
     {
         stateMachine.Configure(AssessmentState.IN_PROGRESS)
-            .Permit(AssessmentAction.Confirm, AssessmentState.COMPLETED);
+            .Permit(AssessmentAction.Complete, AssessmentState.COMPLETED);
 
         // NOTE: This will be removed when there are no more assessments IN_REVIEW
         stateMachine.Configure(AssessmentState.IN_REVIEW)
             .Permit(AssessmentAction.SendBack, AssessmentState.IN_PROGRESS)
-            .Permit(AssessmentAction.Confirm, AssessmentState.COMPLETED);
+            .Permit(AssessmentAction.Complete, AssessmentState.COMPLETED);
 
         stateMachine.Configure(AssessmentState.COMPLETED)
             .Permit(AssessmentAction.SendBack, AssessmentState.IN_PROGRESS)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ReviewList/ReviewList.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ReviewList/ReviewList.js
@@ -3,7 +3,7 @@ const pageApplicationId = decodeURIComponent(document.querySelector("#DetailsVie
 
 const actionButtonConfigMap = {
     Create: { buttonType: 'createButton', order: 1 },
-    Confirm: { buttonType: 'unityWorkflow', order: 2 },
+    Complete: { buttonType: 'unityWorkflow', order: 2 },
     SendBack: { buttonType: 'unityWorkflow', order: 3 },
     _Fallback: { buttonType: 'unityWorkflow', order: 100 }
 }

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/Assessments/AssessmentAppServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/Assessments/AssessmentAppServiceTests.cs
@@ -240,7 +240,7 @@ namespace Unity.GrantManager.Assessments
 
             // Act
             var transitionedAssessment =
-                await _assessmentAppService.ExecuteAssessmentAction(assessment.Id, AssessmentAction.Confirm);
+                await _assessmentAppService.ExecuteAssessmentAction(assessment.Id, AssessmentAction.Complete);
 
             // Assert            
             Assert.Equal(AssessmentState.COMPLETED, transitionedAssessment.Status);


### PR DESCRIPTION
This pull request introduces a bugfix change to the `AssessmentAction` workflow by replacing the `Confirm` action with a new `Complete` action across the application. The changes ensure consistency in the workflow logic, localization, permissions, zones, and UI elements, as well as updating relevant tests.

### Workflow Changes:
* Replaced `AssessmentAction.Confirm` with `AssessmentAction.Complete` in the workflow configuration to transition assessments to the `COMPLETED` state (`Assessment.cs`).

### Code Logic Updates:
* Updated the validation logic in `ValidateValidScoresheetAsync` to use `AssessmentAction.Complete` instead of `Confirm` (`AssessmentAppService.cs`).
* Adjusted the `GetActionAuthorizationRequirement` method to handle `AssessmentAction.Complete` and `SendBack` with specific permissions (`AssessmentAppService.cs`).

### Enum and Localization Updates:
* Replaced `Confirm` with `Complete` in the `AssessmentAction` enum and updated corresponding localization strings (`AssessmentAction.cs`, `en.json`). [[1]](diffhunk://#diff-64d21436553456de9e743cfcff45e12dad3defcba63e50aa05fefa5c32434416L9-R10) [[2]](diffhunk://#diff-8583ff570ed4b451ee8fe98ca796c360a3f81e192fc5116df3fdffbe198b1aafL110-R111)

### UI Updates:
* Updated the action button configuration in the review list to reflect the new `Complete` action (`ReviewList.js`).

### Test Updates:
* Updated the test `ExecuteAssessmentActions_Should_Execute_Valid_State_Transition` to use `AssessmentAction.Complete` and validate the state transition to `COMPLETED` (`AssessmentAppServiceTests.cs`).