### PR TITLE
AB#28958 address various JS errors on application load

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/WorksheetInstanceWidget/WorksheetInstanceWidget.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/WorksheetInstanceWidget/WorksheetInstanceWidget.cs
@@ -164,6 +164,8 @@ public class WorksheetInstanceWidgetScriptBundleContributor : BundleContributor
     public override void ConfigureBundle(BundleConfigurationContext context)
     {
         context.Files
+           .AddIfNotContains("/libs/jquery-maskmoney/dist/jquery.maskMoney.min.js");
+        context.Files
           .AddIfNotContains("/Views/Shared/Components/WorksheetInstanceWidget/Default.js");
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
@@ -463,9 +463,12 @@ $(function () {
             }
         }
     };
+    
     const assessmentResultObserver = new MutationObserver(widgetCallback);
-    assessmentResultObserver.observe(assessmentResultTargetNode, widgetConfig);
 
+    if (assessmentResultTargetNode) {        
+        assessmentResultObserver.observe(assessmentResultTargetNode, widgetConfig);
+    }    
 
     PubSub.subscribe(
         'application_status_changed',

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/ChefsAttachments.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/ChefsAttachments.js
@@ -42,7 +42,7 @@ $(function () {
 
     function getChefsFileNameColumn() {
         return {
-            title: l('AssessmentResultAttachments:DocumentName'),
+            title: 'Document Name',
             name: 'chefsFileName',
             data: 'fileName',
             className: 'data-table-header text-break',


### PR DESCRIPTION
When certain combinations of the zones are toggled off certain required JS files are not loaded before use.

- currency widget not loading maskmoney (add the JS to the worksheet instance widget)
- the attachments list not loading the language / translation plugin (defer back to inline text)
- the assessments mutationObserver failing when the assessments node is not in the DOM (check for node before observe)