### PR TITLE
AB#29203 openshift template changes

### DIFF
--- a/database/unity-backup-cronjob.yaml
+++ b/database/unity-backup-cronjob.yaml
@@ -38,7 +38,7 @@ parameters:
   value: unity-data-postgres
 - name: DATABASE_BACKUP_KEEP
   description: 'Number of backups to keep'
-  value: '2'
+  value: '1'
 - name: DATABASE_BACKUP_SCHEDULE
   description: 'Cron-like schedule expression m h D M DayOfWeek add +7/8 hours for UTC conversions'
   required: true

--- a/openshift/unity-app-data-web.json
+++ b/openshift/unity-app-data-web.json
@@ -62,6 +62,41 @@
           "kind": "Service",
           "name": "${APPLICATION_NAME}"
         },
+        "httpHeaders": {
+          "actions": {
+            "request": null,
+            "response": [
+              {
+                "action": {
+                  "set": { "value": "SAMEORIGIN" },
+                  "type": "Set"
+                },
+                "name": "X-Frame-Options"
+              },
+              {
+                "action": {
+                  "set": { "value": "nosniff" },
+                  "type": "Set"
+                },
+                "name": "X-Content-Type-Options"
+              },
+              {
+                "action": {
+                  "set": { "value": "strict-origin-when-cross-origin" },
+                  "type": "Set"
+                },
+                "name": "Referrer-Policy"
+              },
+              {
+                "action": {
+                  "set": { "value": "object-src 'none'; frame-ancestors 'none'" },
+                  "type": "Set"
+                },
+                "name": "Content-Security-Policy"
+              }
+            ]
+          }
+        },
         "tls": {
           "termination": "edge",
           "insecureEdgeTerminationPolicy": "Redirect"

--- a/openshift/unity-grantmanager-pgbackup-job.yaml
+++ b/openshift/unity-grantmanager-pgbackup-job.yaml
@@ -38,7 +38,7 @@ parameters:
   value: unity-data-postgres
 - name: DATABASE_BACKUP_KEEP
   description: 'Number of backups to keep'
-  value: '2'
+  value: '1'
 - name: DATABASE_BACKUP_VOLUME_CLAIM
   description: 'Name of the volume claim to be used as storage'
   required: true


### PR DESCRIPTION
Changed the default value of the DATABASE_BACKUP_KEEP parameter from 2 to 1 to ensures that only the most recent backup is retained when the deployment job runs, reducing OpenShift storage.