### PR TITLE
feature/AB#29220 - Permission-Role Matrix

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/PermissionRoleMatrix.cshtml
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/PermissionRoleMatrix.cshtml
@@ -1,0 +1,158 @@
+﻿@page
+
+@using Microsoft.Extensions.Localization
+@using Unity.GrantManager.Localization
+@using Volo.Abp.AspNetCore.Mvc.UI.Layout
+@using Volo.Abp.MultiTenancy
+
+@model Unity.GrantManager.Web.Pages.Identity.Roles.PermissionRoleMatrixModel
+
+@inject ICurrentTenant CurrentTenant
+@inject IPageLayout PageLayout
+@inject IStringLocalizer<GrantManagerResource> L
+
+@tagHelperPrefix th:
+
+@{
+    PageLayout.Content.Title = "Permission-Role Matrix";
+    ViewBag.PageTitle = "Permission-Role Matrix";
+    int rowCount = 1;
+    int maxDepth = Model.PermissionRoleMatrix.Max(item => item.Depth);
+    int headerLevel = maxDepth + 1;
+}
+
+@section scripts {
+    <th:abp-script src="/Pages/Identity/Roles/PermissionRoleMatrix.js" />
+}
+
+@section styles {
+    <style>
+        #permissionTableContainer {
+            position: relative;
+            min-height: 200px;
+        }
+        #permissionTable {
+            display: none;
+        }
+        .loading-spinner {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            text-align: center;
+        }
+    </style>
+}
+
+<div class="container-fluid px-0">
+    <div class="action-bar p-2 filter-search-action-bar">
+        <div class="unity-page-titlebar">
+            <h4 id="PermissionRoleMatrixTitle">Permission-Role Matrix - @CurrentTenant.Name</h4>
+        </div>
+        <div class="filter-search-action-bar_search-wrapper">
+            <input type="search" id="search" placeholder="Search" class="tbl-search">
+        </div>
+
+        <div class="btn-group" id="app_custom_buttons">
+        </div>
+
+        <div id="dynamicButtonContainerId" class="dynamic-buttons-div button-gap-1"></div>
+    </div>
+    <div class="p-3 pt-0">
+    <div id="permissionTableContainer" class="p-3 pt-0">
+        <div class="loading-spinner">
+            <p>Loading permission matrix...</p>
+        </div>
+        <table id="permissionTable" class="table table-bordered" aria-describedby="PermissionRoleMatrixTitle">
+            @if (!Model.IsExpanded)
+            {
+                <thead>
+                    <tr>
+                        <th scope="col">#</th>
+                        <th scope="col">L</th>
+                        <th scope="col">Permission Group</th>
+                        <th scope="col">Permission</th>
+                        <th scope="col">Description</th>
+                        @foreach (var role in Model.PermissionRoleMatrix.FirstOrDefault()?.RolePermissions.Keys ?? Enumerable.Empty<string>())
+                        {
+                            <th scope="col" class="role-name" data-role-header="@role">@role</th>
+                        }
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var permission in Model.PermissionRoleMatrix)
+                    {
+                        <tr>
+                            <td>@rowCount.ToString("D2")</td>
+                            @{
+                                rowCount++;
+                            }
+                            <td>@permission.Depth.ToString("D1")</td>
+                            <td>@permission.GroupName</td>
+                            <td>@permission.PermissionName</td>
+                            <td>@(L[permission.PermissionDisplayName].Value)</td>
+                            @foreach (var hasPermission in permission.RolePermissions.Values)
+                            {
+                                <td>@(hasPermission ? "TRUE" : string.Empty)</td>
+                            }
+                        </tr>
+                    }
+                </tbody>
+            }
+            else
+            {
+                <thead>
+                    <tr>
+                        <th scope="col" rowspan="2" data-dt-order="disable">#</th>
+                        <th scope="col" rowspan="2" data-dt-order="disable">L</th>
+                        <th scope="col" rowspan="2">Permission Group</th>
+                        <th scope="colgroup" colspan="@headerLevel" data-dt-order="disable">Permission</th>
+                        <th scope="col" rowspan="2">Description</th>
+                        @foreach (var role in Model.PermissionRoleMatrix.FirstOrDefault()?.RolePermissions.Keys ?? Enumerable.Empty<string>())
+                        {
+                            <th scope="col" rowspan="2" class="role-name" data-role-header="@role">@role</th>
+                        }
+                    </tr>
+                    <tr>
+                        @for (int groupLevel = 1; groupLevel < headerLevel + 1; groupLevel++)
+                        {
+                            <th scope="col">Level @groupLevel</th>
+                        }
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var permission in Model.PermissionRoleMatrix)
+                    {
+                        <tr>
+                            <td>
+                                @rowCount.ToString("D2")
+                            </td>
+                            @{
+                                rowCount++;
+                            }
+                            <td>@permission.Depth.ToString("D1")</td>
+                            <td>@permission.GroupName</td>
+                            @for (int i = 0; i < permission.Depth; i++)
+                            {
+                                <td></td>
+                            }
+
+                            <td>@permission.PermissionName</td>
+
+                            @for (int j = permission.Depth; j < maxDepth; j++)
+                            {
+                                <td></td>
+                            }
+
+                            <td>@permission.PermissionDisplayName</td>
+
+                            @foreach (var hasPermission in permission.RolePermissions.Values)
+                            {
+                                <td>@(hasPermission ? "TRUE" : string.Empty)</td>
+                            }
+                        </tr>
+                    }
+                </tbody>
+            }
+        </table>
+    </div>
+</div>

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/PermissionRoleMatrix.cshtml.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/PermissionRoleMatrix.cshtml.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Unity.GrantManager.Repositories;
+using Volo.Abp.AspNetCore.Mvc.UI.RazorPages;
+using Volo.Abp.Localization;
+
+namespace Unity.GrantManager.Web.Pages.Identity.Roles;
+
+public class PermissionRoleMatrixModel(IPermissionRoleMatrixRepository repository) : AbpPageModel
+{
+    public bool IsExpanded { get; private set; }
+    public required IList<PermissionRoleMatrixDto> PermissionRoleMatrix { get; set; }
+
+    public async Task OnGetAsync()
+    {
+        // Check if the query parameter "Render" is set to "Expanded"
+        IsExpanded = Request.Query["Render"].ToString().Equals("Expanded", StringComparison.OrdinalIgnoreCase);
+
+        PermissionRoleMatrix = await repository.GetPermissionRoleMatrixAsync();
+        foreach (var item in PermissionRoleMatrix.Where(item => item.PermissionDisplayName.StartsWith("L:")))
+        {
+            var parts = item.PermissionDisplayName[2..].Split(',');
+            if (parts.Length == 2)
+            {
+                var resourceName = parts[0];
+                var name = parts[1];
+                var displayName = new LocalizableString(name, resourceName);
+                item.PermissionDisplayName = (await displayName.LocalizeAsync(StringLocalizerFactory))?.Value ?? item.PermissionDisplayName;
+            }
+        }
+    }
+}

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/PermissionRoleMatrix.js
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/PermissionRoleMatrix.js
@@ -1,0 +1,147 @@
+﻿$(document).ready(function () {
+    const urlParams = new URLSearchParams(window.location.search);
+    const isExpanded = urlParams.get('Render') === 'Expanded';
+    const exportTitle = `${abp.currentTenant.name}_${(new Date()).toISOString().slice(0, 10)}_Permission-Role Matrix`;
+
+    const userRoles = abp.currentUser.roles;
+    const userPolicies = abp.auth.grantedPolicies;
+
+    let _permissionsModal = new abp.ModalManager(
+        abp.appPath + 'AbpPermissionManagement/PermissionManagementModal'
+    );
+    _permissionsModal.onClose(function () {
+        // Refresh the page to show updated permissions
+        window.location.reload();
+    });
+
+    const roleColumnIndexes = [];
+    $('#permissionTable th[data-role-header]').each(function (index) {
+        roleColumnIndexes.push($(this).index());
+    });
+
+    const columnDefs = [
+        {
+            targets: 0,
+            orderable: false,
+            className: 'notexport'
+        }
+    ];
+
+    if (roleColumnIndexes.length > 0) {
+        columnDefs.push({
+            targets: roleColumnIndexes,
+            orderable: false
+        });
+    }
+
+    $.fn.dataTable.Buttons.defaults.dom.button.className = 'btn flex-none';
+    let localTable = $('#permissionTable').DataTable({
+        paging: false,
+        searching: true,
+        ordering: true,
+        fixedHeader: {
+            header: true,
+            footer: false,
+            headerOffset: 0
+        },
+        scrollX: true,
+        scrollCollapse: true,
+        dom: 'Blfrtip',
+        columnDefs: columnDefs,
+        buttons: [
+            {
+                text: isExpanded
+                    ? '<i class="fl fl-back-to-window align-middle"></i> <span>View Simple</span>'
+                    : '<i class="fl fl-fullscreen align-middle"></i> <span>View Expanded</span>',
+                className: 'btn-light rounded-1',
+                action: function (e, dt, button, config) {
+                    window.location = isExpanded
+                        ? '/Identity/Roles/PermissionRoleMatrix'
+                        : '/Identity/Roles/PermissionRoleMatrix?Render=Expanded';
+                }
+            },
+            {
+                extend: 'copy',
+                text: 'Copy',
+                title: exportTitle,
+                className: 'custom-table-btn flex-none btn btn-secondary',
+                exportOptions: {
+                    columns: ':visible:not(.notexport)'
+                }
+            },
+            {
+                extend: 'csv',
+                text: 'Export',
+                title: exportTitle,
+                className: 'custom-table-btn flex-none btn btn-secondary',
+                exportOptions: {
+                    columns: ':visible:not(.notexport)'
+                }
+            }
+        ],
+        createdRow: function (row, data, dataIndex) {
+            $('td', row).each(function () {
+                let cellText = $(this).text().trim();
+
+                // Check if the cell text matches a key in userPolicies
+                if (userPolicies[cellText]) {
+                    $(this).addClass('text-decoration-underline');
+                }
+
+                if (cellText === "TRUE") {
+                    $(this).addClass('bg-success text-dark bg-opacity-25 fw-bold border border-success dt-center');
+                }
+            });
+        },
+        initComplete: function () {
+            const table = this.api();
+
+            // Required for DataTable 1.x - Disable sorting for role name columns after table initialization
+            // Explicitly disable ordering for role columns using the API
+            $('th[data-role-header]').removeClass('sorting').addClass('sorting_disabled');
+
+            const headers = table.columns().header().toArray().map(header => $(header).text().trim());
+
+            // Highlight columns where the header matches a user role
+            headers.forEach((header, index) => {
+                if (userRoles.includes(header.toLowerCase())) {
+                    $(table.column(index).header()).addClass('text-decoration-underline');
+                    table.column(index).nodes().to$().filter(function () {
+                        return !$(this).text().trim();
+                    }).addClass('bg-light');
+                }
+            });
+        }
+    });
+
+    localTable.buttons().container().prependTo('#dynamicButtonContainerId');
+    $("#search").on('input', function () {
+        localTable.search($(this).val()).draw();
+    });
+
+    // Hide spinner and show table after initialization
+    $('.loading-spinner').hide();
+    $('#permissionTable').show();
+
+    // Add click handlers to role column headers using data-role-header attribute
+    $(document).on('click', 'th[data-role-header]', function () {
+        const roleName = $(this).attr('data-role-header');
+        _permissionsModal.open({
+            providerName: 'R',
+            providerKey: roleName,
+            providerKeyDisplayName: roleName
+        });
+    });
+
+    // Add styles to all headers, including dynamically created ones
+    $(document).on('mouseover', 'th[data-role-header]', function () {
+        $(this).css('cursor', 'pointer');
+        if (!$(this).attr('title')) {
+            $(this).attr('title', 'Click to manage permissions for this role');
+        }
+    });
+
+    init(localTable);
+    // Workaround - required until Datatables.net 2.x
+    $('th[data-role-header]').removeClass('sorting').addClass('sorting_disabled');
+});

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/index.js
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/index.js
@@ -121,6 +121,13 @@ $(function () {
     $.fn.dataTable.Buttons.defaults.dom.button.className = 'btn flex-none';
     let actionButtons = [
         {
+            text: '<i class="fl fl-multi-select align-middle"></i><span>View Role Matrix</span>',
+            className: 'btn-light rounded-1',
+            action: function (e, dt, button, config) {
+                window.location = '/Identity/Roles/PermissionRoleMatrix'
+            }
+        },
+        {
             text: '<i class="fl fl-add-to align-middle"></i> <span>' + l('NewRole') + '</span>',
             titleAttr: l('NewRole'),
             id: 'CreateRoleButton',

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Unity.Identity.Web.csproj
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Unity.Identity.Web.csproj
@@ -46,6 +46,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Unity.GrantManager.Application.Contracts\Unity.GrantManager.Application.Contracts.csproj" />
+    <ProjectReference Include="..\..\..\src\Unity.GrantManager.EntityFrameworkCore\Unity.GrantManager.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\Unity.Theme.UX2\src\Unity.Theme.UX2\Unity.AspNetCore.Mvc.UI.Theme.UX2.csproj" />    
   </ItemGroup>
 

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/UnitydentityWebModule.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/UnitydentityWebModule.cs
@@ -69,6 +69,8 @@ public class UnitydentityWebModule : AbpModule
             options.Conventions.AuthorizePage("/Identity/Roles/Index", IdentityPermissions.Roles.Default);
             options.Conventions.AuthorizePage("/Identity/Roles/CreateModal", IdentityPermissions.Roles.Create);
             options.Conventions.AuthorizePage("/Identity/Roles/EditModal", IdentityPermissions.Roles.Update);
+
+            options.Conventions.AuthorizePage("/Identity/Roles/PermissionRoleMatrix", IdentityPermissions.Roles.Default);
         });
 
         Configure<DynamicJavaScriptProxyOptions>(options =>

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/fluentui-icons.css
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/fluentui-icons.css
@@ -108,6 +108,11 @@
     content: '\E89F';
 }
 
+/*GID144 : U+E740*/
+.fl-fullscreen:before {
+    content: '\E740';
+}
+
 /*GID144 : U+E871*/
 .fl-back-to-window:before {
     content: '\E73F';

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.css
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/layout.css
@@ -166,13 +166,18 @@ body {
     font-size: var(--bc-font-size-sm);
 }
 
-    .dataTables_wrapper table th:first-child {
-        border-top-left-radius: 10px;
-    }
+.dataTables_wrapper table th:first-child {
+    border-top-left-radius: 10px;
+}
 
-    .dataTables_wrapper table th:last-child {
-        border-top-right-radius: 10px;
-    }
+.dataTables_wrapper table th:last-child {
+    border-top-right-radius: 10px;
+}
+
+.dataTables_wrapper table thead tr:not(:first-child) th:first-child,
+.dataTables_wrapper table thead tr:not(:first-child) th:last-child {
+    border-radius: inherit;
+}
 
 .dataTables_wrapper thead tr.filters th {
     border-top-left-radius: 0;

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/PermissionRoleMatrixRepository.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/PermissionRoleMatrixRepository.cs
@@ -1,0 +1,86 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Unity.GrantManager.EntityFrameworkCore;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Repositories.EntityFrameworkCore;
+using Volo.Abp.EntityFrameworkCore;
+using Volo.Abp.Identity;
+using Volo.Abp.MultiTenancy;
+using Volo.Abp.PermissionManagement;
+
+namespace Unity.GrantManager.Repositories;
+
+[Dependency(ReplaceServices = true)]
+[ExposeServices(typeof(IPermissionRoleMatrixRepository))]
+public class PermissionRoleMatrixRepository(IDbContextProvider<GrantManagerDbContext> dbContextProvider) : EfCoreRepository<GrantManagerDbContext, PermissionGrant, Guid>(dbContextProvider), IPermissionRoleMatrixRepository
+{
+    public async Task<IList<PermissionRoleMatrixDto>> GetPermissionRoleMatrixAsync()
+    {
+        var dbContext = await GetDbContextAsync();
+
+        // Query permissionGrants and roles
+        var permissions = await dbContext.Set<PermissionDefinitionRecord>()
+            .Where(p => p.IsEnabled && p.MultiTenancySide != MultiTenancySides.Host)
+            .ToListAsync();
+
+        var permissionGrants = await dbContext.Set<PermissionGrant>()
+            .ToListAsync();
+
+        var roles = await dbContext.Set<IdentityRole>()
+            .OrderBy(r => r.Name)
+            .ToListAsync();
+
+        var matrix = permissions
+            .Select(permission => new PermissionRoleMatrixDto
+            {
+                GroupName = permission.GroupName,
+                PermissionName = permission.Name,
+                PermissionDisplayName = permission.DisplayName,
+                Depth = CalculatePermissionDepth(permission.Name, permissions),
+                RolePermissions = roles.ToDictionary(
+                    role => role.Name,
+                    role => permissionGrants.Any(pg =>
+                        pg.Name == permission.Name &&
+                        pg.ProviderName == "R" &&
+                        pg.TenantId == CurrentTenant.Id &&
+                        pg.ProviderKey.Equals(role.Name, StringComparison.CurrentCultureIgnoreCase))
+                )
+            })
+            .OrderBy(p => p.GroupName)
+            .ThenBy(p => p.PermissionName)
+            .ToList();
+
+        return matrix;
+    }
+
+    private static int CalculatePermissionDepth(string permissionName, List<PermissionDefinitionRecord> permissions)
+    {
+        var parentPermission = permissions.FirstOrDefault(p => p.Name == permissionName)?.ParentName;
+
+        if (string.IsNullOrEmpty(parentPermission))
+        {
+            // If there is no parent, this is a top-level permission (depth = 0)
+            return 0;
+        }
+
+        // Recursively calculate the depth of the parent permission
+        return 1 + CalculatePermissionDepth(parentPermission, permissions);
+    }
+}
+
+public interface IPermissionRoleMatrixRepository
+{
+    Task<IList<PermissionRoleMatrixDto>> GetPermissionRoleMatrixAsync();
+}
+
+public class PermissionRoleMatrixDto
+{
+    public required string GroupName { get; set; }
+    public required string PermissionName { get; set; }
+    public required string PermissionDisplayName { get; set; }
+    public int Depth { get; set; }
+    public required Dictionary<string, bool> RolePermissions { get; set; }
+}


### PR DESCRIPTION
This PR adds the Permission-Role Matrix with the following features:

- Simple view of permissions against roles
- Expanded view of permissions against roles
- Added authorization handling on P-R page to match Roles page
- Copy/Export out to Excel to compare environments
- Click on role headers to access Permission Management modal for each role