### PR TITLE
bugfix/AB#27999 - Bugfixes for Project Info Zones and Modular Permissions

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.SharedKernel/Constants/UnitySelector.Override.cs
+++ b/applications/Unity.GrantManager/modules/Unity.SharedKernel/Constants/UnitySelector.Override.cs
@@ -40,5 +40,13 @@ public static partial class UnitySelector
                 public const string UpdateFinalStateFields  = "Unity.GrantManager.ApplicationManagement.Project.Summary.Update.UpdateFinalStateFields";
             }
         }
+
+        public static partial class Location
+        {
+            public static partial class Update
+            {
+                public const string UpdateFinalStateFields  = "Unity.GrantManager.ApplicationManagement.Project.Location.Update.UpdateFinalStateFields";
+            }
+        }
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Permissions/GrantApplications/GrantApplicationPermissionDefinitionProvider.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Permissions/GrantApplications/GrantApplicationPermissionDefinitionProvider.cs
@@ -146,6 +146,7 @@ namespace Unity.GrantManager.Permissions.GrantApplications
 
             var upx_Project_Location                                = upx_Project.AddUnityChild(UnitySelector.Project.Location.Default);
             var upx_Project_Location_Update                         = upx_Project_Location.AddUnityChild(UnitySelector.Project.Location.Update.Default);
+            var upx_Project_Location_UpdateFinalStateFields         = upx_Project_Location_Update.AddUnityChild(UnitySelector.Project.Location.Update.UpdateFinalStateFields);
             #endregion
         }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain.Shared/Localization/GrantManager/en.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain.Shared/Localization/GrantManager/en.json
@@ -193,6 +193,7 @@
     "Unity.GrantManager.ApplicationManagement.Project.Summary.Update.UpdateFinalStateFields": "Edit Project Summary after approval",
     "Unity.GrantManager.ApplicationManagement.Project.Location": "Project Location",
     "Unity.GrantManager.ApplicationManagement.Project.Location.Update": "Edit Project Location",
+    "Unity.GrantManager.ApplicationManagement.Project.Location.Update.UpdateFinalStateFields": "Edit Project Location after approval",
 
     "Unity.GrantManager.ApplicationManagement.Applicant": "Applicant Info",
     "Unity.GrantManager.ApplicationManagement.Applicant.Summary": "Applicant Info",

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Permissions/PermissionGrantsDataSeeder.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Permissions/PermissionGrantsDataSeeder.cs
@@ -151,7 +151,11 @@ namespace Unity.GrantManager.Permissions
                     .. ApplicantInfo_CommonPermissions,
                     .. ProjectInfo_CommonPermissions,
                     .. Notifications_CommonPermissions,
-                    .. Dashboard_CommonPermissions
+                    .. Dashboard_CommonPermissions,
+
+                    // Role Specific Permissions
+                    UnitySelector.Project.Summary.Update.UpdateFinalStateFields,
+                    UnitySelector.Project.Location.Update.UpdateFinalStateFields,
                 ], context.TenantId);
 
             // - Approver

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Identity/PolicyRegistrant.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Identity/PolicyRegistrant.cs
@@ -146,7 +146,10 @@ internal static class PolicyRegistrant
         authorizationBuilder.AddPolicy(UnitySelector.Project.UpdatePolicy,
             policy => policy.RequireAssertion(context => 
             context.User.HasClaim(PermissionConstant, UnitySelector.Project.Location.Update.Default) ||
-            context.User.HasClaim(PermissionConstant, UnitySelector.Project.Summary.Update.Default)
+            context.User.HasClaim(PermissionConstant, UnitySelector.Project.Summary.Update.Default) ||
+            
+            // NOTE: This be replaced when Worksheets are normalized with UnitySelector.Project.Worksheet.Update
+            context.User.HasClaim(PermissionConstant, UnitySelector.Project.Default) 
         ));
 
         // Project Info - Summary Policies
@@ -164,6 +167,13 @@ internal static class PolicyRegistrant
             policy => policy.RequireClaim(PermissionConstant, UnitySelector.Project.Location.Update.Default));
         authorizationBuilder.AddPolicy(UnitySelector.Project.Location.Update.UpdateFinalStateFields,
             policy => policy.RequireClaim(PermissionConstant, UnitySelector.Project.Location.Update.UpdateFinalStateFields));
+
+        // Project Info - Worksheet Policies
+        authorizationBuilder.AddPolicy(UnitySelector.Project.Worksheet.Default,
+            policy => policy.RequireClaim(PermissionConstant, UnitySelector.Project.Worksheet.Default));  // NOTE: Will be replaced when Worksheets normalized
+        
+        authorizationBuilder.AddPolicy(UnitySelector.Project.Worksheet.Update,
+            policy => policy.RequireClaim(PermissionConstant, UnitySelector.Project.Worksheet.Update));  // NOTE: Will be replaced when Worksheets normalized
     }
 }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Identity/PolicyRegistrant.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Identity/PolicyRegistrant.cs
@@ -148,7 +148,7 @@ internal static class PolicyRegistrant
             context.User.HasClaim(PermissionConstant, UnitySelector.Project.Location.Update.Default) ||
             context.User.HasClaim(PermissionConstant, UnitySelector.Project.Summary.Update.Default) ||
             
-            // NOTE: This be replaced when Worksheets are normalized with UnitySelector.Project.Worksheet.Update
+            // NOTE: This will be replaced when Worksheets are normalized with UnitySelector.Project.Worksheet.Update
             context.User.HasClaim(PermissionConstant, UnitySelector.Project.Default) 
         ));
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Identity/PolicyRegistrant.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Identity/PolicyRegistrant.cs
@@ -162,6 +162,8 @@ internal static class PolicyRegistrant
             policy => policy.RequireClaim(PermissionConstant, UnitySelector.Project.Location.Default));
         authorizationBuilder.AddPolicy(UnitySelector.Project.Location.Update.Default,
             policy => policy.RequireClaim(PermissionConstant, UnitySelector.Project.Location.Update.Default));
+        authorizationBuilder.AddPolicy(UnitySelector.Project.Location.Update.UpdateFinalStateFields,
+            policy => policy.RequireClaim(PermissionConstant, UnitySelector.Project.Location.Update.UpdateFinalStateFields));
     }
 }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.cshtml
@@ -176,7 +176,7 @@
                 @if (IsZoneVisible(UnitySelector.Project.Default))
                 {
                     <abp-tab name="nav-project-info" title="Project Info">
-                        <div class="w-100 px-2 @ZoneCssClass(UnitySelector.Project.Summary.Default)" id="projectInfoWidget">
+                        <div class="w-100 px-2" id="projectInfoWidget">
                             @await Component.InvokeAsync("ProjectInfo", new { applicationId = Model.ApplicationId, applicationFormVersionId = Model.ApplicationFormVersionId })
                         </div>
                     </abp-tab>

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/TagHelpers/Zone/UnityZoneTagHelperService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/TagHelpers/Zone/UnityZoneTagHelperService.cs
@@ -164,8 +164,11 @@ public class UnityZoneTagHelperService : AbpTagHelperService<UnityZoneTagHelper>
         AddFormIdWithLink(dl);
 
         // Feature and Zone requirements
-        AddRequirementItem(dl, "FeatureRequirement", _featureState,
-            TagHelper.FeatureRequirement, TagHelper.Id);
+        AddRequirementItem(dl, 
+            "FeatureRequirement", 
+            string.IsNullOrEmpty(TagHelper.FeatureRequirement) ? null : _featureState,
+            TagHelper.FeatureRequirement, 
+            TagHelper.Id);
         AddRequirementItem(dl, "ZoneRequirement", _zoneState,
             TagHelper.ZoneRequirement, TagHelper.Id);
 
@@ -174,14 +177,14 @@ public class UnityZoneTagHelperService : AbpTagHelperService<UnityZoneTagHelper>
         // Permission requirements
         AddRequirementItem(dl, "ReadPermissionRequirement", _readPermissionState,
             TagHelper.PermissionRequirement, TagHelper.Id);
-        AddDefinitionItem(dl, "CustomReadCondition", NotApplicableStatusBadge(TagHelper.ReadCondition));
+        AddDefinitionItem(dl, "ReadCondition", NotApplicableStatusBadge(TagHelper.ReadCondition));
 
         AddSeparator(dl);
 
         // Update requirements
         AddRequirementItem(dl, "UpdatePermissionRequirement", _updatePermissionState,
             TagHelper.UpdatePermissionRequirement, null);
-        AddDefinitionItem(dl, "CustomUpdateCondition", NotApplicableStatusBadge(TagHelper.UpdateCondition));
+        AddDefinitionItem(dl, "UpdateCondition", NotApplicableStatusBadge(TagHelper.UpdateCondition));
 
         content.AppendHtml(dl);
         debugAlert.InnerHtml.AppendHtml(content);
@@ -199,10 +202,10 @@ public class UnityZoneTagHelperService : AbpTagHelperService<UnityZoneTagHelper>
         AddDefinitionItem(dl, "Form ID", formLink);
     }
 
-    private static void AddRequirementItem(TagBuilder dl, string label, bool state, string? requirement, string? inheritFrom)
+    private static void AddRequirementItem(TagBuilder dl, string label, bool? state, string? requirement, string? inheritFrom)
     {
         var content = new HtmlContentBuilder();
-        content.AppendHtml(StatusBadge(state));
+        content.AppendHtml(NotApplicableStatusBadge(state));
         content.Append(requirement ?? "N/A");
 
         // Add inheritance notice if applicable

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicationFormConfigWidget/ApplicationFormConfigWidget.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicationFormConfigWidget/ApplicationFormConfigWidget.cs
@@ -14,7 +14,7 @@ namespace Unity.GrantManager.Web.Views.Shared.Components.ApplicationFormConfigWi
 [Widget(
     ScriptFiles = ["/Views/Shared/Components/ApplicationFormConfigWidget/Default.js"],
     StyleFiles = ["/Views/Shared/Components/ApplicationFormConfigWidget/Default.css"],
-    RefreshUrl = "Widgets/ApplicationActionWidget/Refresh",
+    RefreshUrl = "Widgets/ApplicationFormConfigWidget/Refresh",
     AutoInitialize = true
 )]
 public class ApplicationFormConfigWidget : AbpViewComponent

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicationFormConfigWidget/ApplicationFormConfigWidgetController.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicationFormConfigWidget/ApplicationFormConfigWidgetController.cs
@@ -6,7 +6,7 @@ using Unity.GrantManager.ApplicationForms;
 namespace Unity.GrantManager.Web.Views.Shared.Components.ApplicationFormConfigWidget;
 
 [ApiExplorerSettings(IgnoreApi = true)]
-[Route("GrantApplications/Widgets/ApplicationActionWidget")]
+[Route("GrantApplications/Widgets/ApplicationFormConfigWidget")]
 public class ApplicationFormConfigWidgetController : AbpController
 {
     [HttpGet]

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentResults/Default.js
@@ -40,9 +40,10 @@
         });
 
 
-        // Make sure all the custom fields are set in the custom fields object
-        if (typeof Flex === 'function') {
-            Flex?.setCustomFields(assessmentResultObj);
+        if (typeof Flex === 'function' && Object.keys(assessmentResultObj.CustomFields || {}).length > 0) {
+            $("#assessmentResultsCustomForm input:checkbox").each(function () {
+                assessmentResultObj.CustomFields[this.name] = (this.checked).toString();
+            });
         }
 
         try {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ProjectInfo/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ProjectInfo/Default.js
@@ -42,6 +42,11 @@ abp.widgets.ProjectInfo = function ($wrapper) {
                     projectInfoObj.CorrelationId = $("#ProjectInfo_ApplicationFormVersionId").val();
                     projectInfoObj.WorksheetId = $("#ProjectInfo_WorksheetId").val();
 
+                    // Normalize checkboxes to string for custom worksheets
+                    $(`#Unity_GrantManager_ApplicationManagement_Project_Worksheet input:checkbox`).each(function () {
+                        projectInfoObj.CustomFields[this.name] = (this.checked).toString();
+                    });
+
                     customIncludes
                         .add('CustomFields')
                         .add('CorrelationId')

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ProjectInfo/ProjectInfoViewComponent.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ProjectInfo/ProjectInfoViewComponent.cs
@@ -52,7 +52,6 @@ public class ProjectInfoViewComponent : AbpViewComponent
         GrantApplicationDto application = await _grantApplicationAppService.GetAsync(applicationId);
 
         bool IsApplicationOpen = !GrantApplicationStateGroups.FinalDecisionStates.Contains(application.StatusCode);
-        bool UserHasFinalStateUpdate = await _authorizationService.IsGrantedAsync(UnitySelector.Project.Summary.Update.UpdateFinalStateFields);
 
         List<EconomicRegionDto> EconomicRegions = (await _applicationEconomicRegionAppService.GetListAsync()).ToList();
 
@@ -62,6 +61,8 @@ public class ProjectInfoViewComponent : AbpViewComponent
 
         List<CommunityDto> Communities = (await _applicationCommunityAppService.GetListAsync()).ToList();
 
+        bool UserHasFinalStateUpdateSummary = await _authorizationService.IsGrantedAsync(UnitySelector.Project.Summary.Update.UpdateFinalStateFields);
+        bool UserHasFinalStateUpdateLocation = await _authorizationService.IsGrantedAsync(UnitySelector.Project.Location.Update.UpdateFinalStateFields);
         ProjectInfoViewModel model = new()
         {
             ApplicationId = applicationId,
@@ -70,8 +71,8 @@ public class ProjectInfoViewComponent : AbpViewComponent
             RegionalDistricts = RegionalDistricts,
             Communities = Communities,
             EconomicRegions = EconomicRegions,
-            IsSummaryEditable = IsApplicationOpen || UserHasFinalStateUpdate,
-            IsLocationEditable = IsApplicationOpen
+            IsSummaryEditable = IsApplicationOpen || UserHasFinalStateUpdateSummary,
+            IsLocationEditable = IsApplicationOpen || UserHasFinalStateUpdateLocation
         };
 
         model.EconomicRegionList.AddRange(EconomicRegions.Select(EconomicRegion =>


### PR DESCRIPTION
This PR covers:
- AB#29223 - Fix Project Summary Disabled hides all Project Info
- AB#29221 and AB#29222 - Fix Custom Worksheet Checkbox Serialization
- AB#29218 - Add Edit Project Location after approval permission
- General - Fix controller conflict with ApplicationFormConfigWidget
- General - Remove update permission restriction on API for custom fields until worksheet zones are normalized

### Permission Handling:
* Added new permissions `UnitySelector.Project.Location.Update.UpdateFinalStateFields` and `UnitySelector.Project.Summary.Update.UpdateFinalStateFields` for editing project details after approval. These permissions were integrated into `PolicyRegistrant.cs`, `GrantApplicationPermissionDefinitionProvider.cs`, and `PermissionGrantsDataSeeder.cs`. [[1]](diffhunk://#diff-eeae32ba8deaac5b5332e4e87412942bb2d5617b2a780561b559dd2dfd3bff0cR43-R50) [[2]](diffhunk://#diff-b719aac9e187ec808500463491c0bc8824fcec7707619e100d876798497b5e48R149) [[3]](diffhunk://#diff-e6a86203af0bf6871bd879255023204d33b8f21d099f04f39a57b89e7623e8d3L154-R158) [[4]](diffhunk://#diff-d994ef7ffa9b6cf41cd3a1c0c4392f68eb8fc325061f8c9b390425883e7a7204R168-R176)
* Updated `ProjectInfoViewComponent.cs` to check these new permissions when determining editability of project summary and location fields. [[1]](diffhunk://#diff-33c83f4f6f758984cba7c9f818d9e40838e741245412cac3a788361ef90644b3R64-R65) [[2]](diffhunk://#diff-33c83f4f6f758984cba7c9f818d9e40838e741245412cac3a788361ef90644b3L73-R75)

### Localization Updates:
* Added a new localization entry for `UnitySelector.Project.Location.Update.UpdateFinalStateFields` in `en.json` to provide descriptive text for this permission.

### UI and Behavior Refinements:
* Improved handling of checkboxes in `AssessmentResults/Default.js` and `ProjectInfo/Default.js` by normalizing their values to strings for custom fields. [[1]](diffhunk://#diff-1865ece6ef8dc645d2315e85097175ac24e61e3ca60fd7480c1c20c2985386f8L43-R46) [[2]](diffhunk://#diff-d7150c056d21b5e3c12ce86a53c55aadde35b6e723b21fbd0e4a2a43958656b1R45-R49)
* Simplified debug header logic in `UnityZoneTagHelperService.cs` by refining feature and zone requirement handling and renaming condition labels for clarity. [[1]](diffhunk://#diff-d1f3e53c337619918cc65e5cbee6df50d821d947ce19b25f9504a8a2e52e097fL167-R171) [[2]](diffhunk://#diff-d1f3e53c337619918cc65e5cbee6df50d821d947ce19b25f9504a8a2e52e097fL177-R187) [[3]](diffhunk://#diff-d1f3e53c337619918cc65e5cbee6df50d821d947ce19b25f9504a8a2e52e097fL202-R208)

### Widget Fixes:
* Corrected routing and refresh URL issues for `ApplicationFormConfigWidget` in its controller and metadata. [[1]](diffhunk://#diff-d1c4883dc2b1640eb2cbe798a2efa850247de852d4f85f1e50839ac4c3f1017cL17-R17) [[2]](diffhunk://#diff-e8e37f7303f4792382e1710a65343dddf7c14ba81eabc151820617735a4d8136L9-R9)