### PR TITLE
ab#28853 improve table state view localStorage

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/table-utils.js
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/table-utils.js
@@ -150,20 +150,52 @@ function initializeDataTable(options) {
             },
            stateLoadParams: function (settings, data) {
                $(settings.oInit.externalSearchInputId).val(data.search.search);
+               let stateCorrupted = false;
+               const tableId = settings.sTableId || settings.nTable.id;
 
                data.columns.forEach((column, index) => {
-                   if(settings.aoColumns[index] +"" != "undefined") {
+                   if (settings.aoColumns[index] + "" != "undefined") {
                        const title = settings.aoColumns[index].sTitle;
                        const name = settings.aoColumns[index].name;
-                       //Find the object based on column unique keys / names
                        const dataObj = data.columns.find(col => col.uniqueKey === name);
-                       const value = dataObj.search.search;
-                       filterData[title] = value;
+                       if (typeof dataObj === "undefined") {
+                           localStorage.removeItem(`DataTables_${tableId}_${window.location.pathname}`);
+                           cleanInvalidStateRestore(tableId);
+                           stateCorrupted = true;
+                       } else {
+                           const value = dataObj.search && dataObj.search.search ? dataObj.search.search : '';
+                           filterData[title] = value;
+                       }
                    }
                });
+
+               if (stateCorrupted) {
+                   window.location.reload();
+                   return false;
+               }
             }
         })
     );
+
+    function cleanInvalidStateRestore(tableId) {
+        Object.keys(localStorage)
+            .filter(key => key.includes('DataTables_stateRestore') && key.includes(`${tableId}`))
+            .forEach(key => {
+                try {
+                    const value = localStorage.getItem(key);
+                    if (!value) return;
+                    const obj = JSON.parse(value);
+                    if (Array.isArray(obj.columns)) {
+                        const hasMissingUniqueKey = obj.columns.some(col => !('uniqueKey' in col));
+                        if (hasMissingUniqueKey) {
+                            localStorage.removeItem(key);
+                        }
+                    }
+                } catch (e) {
+                    console.warn(`Could not process DataTables state for key: ${key}`, e);
+                }
+            });
+    }
 
     // Add custom manage columns button that remains sorted alphabetically
     if (!disableColumnSelect) {


### PR DESCRIPTION
Add validation checks for undefined dataObj entries in localStorage. If a dataObj is found to be undefined, remove the corresponding item from localStorage and reload the page. Additionally, implement checks within the stateRestore object in localStorage to identify and remove any entries related to undefined dataObj values. This will remove any existing, invalid saved views.