### PR TITLE
AB#29282 Add missing contents write permission into main branch

### DIFF
--- a/.github/workflows/docker-build-main.yml
+++ b/.github/workflows/docker-build-main.yml
@@ -89,6 +89,8 @@ jobs:
     needs: [Setup,Branch]
     runs-on: ubuntu-latest
     environment: main
+    permissions:
+      contents: write
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
This PR updates the Docker build workflow for the main branch in GitHub Actions.
add   GenerateTag:    environment: main    permissions:      contents: write