### PR TITLE
hotfix/AB#29374 - Fix Cascading Authorization issue on ApplicationFormAppService

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/ApplicationForms/IApplicationFormAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/ApplicationForms/IApplicationFormAppService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Unity.GrantManager.Forms;
+using Unity.GrantManager.GrantApplications;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 
@@ -13,6 +14,7 @@ namespace Unity.GrantManager.ApplicationForms
             PagedAndSortedResultRequestDto,
             CreateUpdateApplicationFormDto>
     {
+        Task<AddressType> GetElectoralDistrictAddressTypeAsync(Guid id);
         Task<IList<ApplicationFormVersionDto>> GetVersionsAsync(Guid id);
         Task<IList<ApplicationFormVersionDto>> GetPublishedVersionsAsync(Guid id);
         Task PatchOtherConfig(Guid id, OtherConfigDto config);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormAppService.cs
@@ -6,139 +6,153 @@ using System.Linq;
 using System.Threading.Tasks;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Forms;
+using Unity.GrantManager.GrantApplications;
 using Unity.GrantManager.Integration.Chefs;
 using Unity.GrantManager.Permissions;
 using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
-using Volo.Abp.ObjectMapping;
 using Volo.Abp.Security.Encryption;
 
-namespace Unity.GrantManager.ApplicationForms
+namespace Unity.GrantManager.ApplicationForms;
+
+[Authorize]
+public class ApplicationFormAppService :
+CrudAppService<
+    ApplicationForm,
+    ApplicationFormDto,
+    Guid,
+    PagedAndSortedResultRequestDto,
+    CreateUpdateApplicationFormDto>,
+    IApplicationFormAppService
 {
-    [Authorize(GrantManagerPermissions.ApplicationForms.Default)]
-    public class ApplicationFormAppService :
-    CrudAppService<
-        ApplicationForm,
-        ApplicationFormDto,
-        Guid,
-        PagedAndSortedResultRequestDto,
-        CreateUpdateApplicationFormDto>,
-        IApplicationFormAppService
+    private readonly IStringEncryptionService _stringEncryptionService;
+    private readonly IFormsApiService _formsApiService;
+    private readonly IApplicationFormVersionAppService _applicationFormVersionAppService;
+    private readonly IApplicationFormVersionRepository _applicationFormVersionRepository;
+    private readonly IRepository<ApplicationForm, Guid> _applicationFormRepository;
+    public ApplicationFormAppService(IRepository<ApplicationForm, Guid> repository,
+        IStringEncryptionService stringEncryptionService,
+        IApplicationFormVersionAppService applicationFormVersionAppService,
+        IApplicationFormVersionRepository applicationFormVersionRepository,
+        IFormsApiService formsApiService)
+        : base(repository)
     {
-        private readonly IStringEncryptionService _stringEncryptionService;
-        private readonly IFormsApiService _formsApiService;
-        private readonly IApplicationFormVersionAppService _applicationFormVersionAppService;
-        private readonly IApplicationFormVersionRepository _applicationFormVersionRepository;
-        private readonly IRepository<ApplicationForm, Guid> _applicationFormRepository;
-        public ApplicationFormAppService(IRepository<ApplicationForm, Guid> repository,
-            IStringEncryptionService stringEncryptionService,
-            IApplicationFormVersionAppService applicationFormVersionAppService,
-            IApplicationFormVersionRepository applicationFormVersionRepository,
-            IFormsApiService formsApiService)
-            : base(repository)
+        _stringEncryptionService = stringEncryptionService;
+        _applicationFormVersionAppService = applicationFormVersionAppService;
+        _formsApiService = formsApiService;
+        _applicationFormVersionRepository = applicationFormVersionRepository;
+        _applicationFormRepository = repository;
+    }
+
+    [Authorize(GrantManagerPermissions.ApplicationForms.Default)]
+    public override async Task<ApplicationFormDto> CreateAsync(CreateUpdateApplicationFormDto input)
+    {
+        input.ApiKey = _stringEncryptionService.Encrypt(input.ApiKey);
+        ApplicationFormDto applicationFormDto = await base.CreateAsync(input);
+        return await InitializeFormVersion(applicationFormDto.Id, input);
+    }
+
+    [Authorize(GrantManagerPermissions.ApplicationForms.Default)]
+    public override async Task<ApplicationFormDto> UpdateAsync(Guid id, CreateUpdateApplicationFormDto input)
+    {
+        var existingForm = await Repository.GetAsync(id);
+        input.ApiKey = _stringEncryptionService.Encrypt(input.ApiKey);
+
+        bool hasFormGuidChanged = existingForm.ChefsApplicationFormGuid != input.ChefsApplicationFormGuid;
+        bool hasFormApiKeyChanged = existingForm.ApiKey != input.ApiKey;
+
+        // Only initialize form version if changes are made to form connection details
+        if (hasFormGuidChanged || hasFormApiKeyChanged)
         {
-            _stringEncryptionService = stringEncryptionService;
-            _applicationFormVersionAppService = applicationFormVersionAppService;
-            _formsApiService = formsApiService;
-            _applicationFormVersionRepository = applicationFormVersionRepository;
-            _applicationFormRepository = repository;
+            return await InitializeFormVersion(id, input);
         }
-
-        public override async Task<ApplicationFormDto> CreateAsync(CreateUpdateApplicationFormDto input)
+        else
         {
-            input.ApiKey = _stringEncryptionService.Encrypt(input.ApiKey);
-            ApplicationFormDto applicationFormDto = await base.CreateAsync(input);
-            return await InitializeFormVersion(applicationFormDto.Id, input);
+            return await base.UpdateAsync(id, input);
         }
+    }
 
-        public override async Task<ApplicationFormDto> UpdateAsync(Guid id, CreateUpdateApplicationFormDto input)
+    [Authorize(GrantManagerPermissions.ApplicationForms.Default)]
+    private async Task<ApplicationFormDto> InitializeFormVersion(Guid id, CreateUpdateApplicationFormDto input)
+    {
+        var applicationFormDto = new ApplicationFormDto();
+        try
         {
-            var existingForm = await Repository.GetAsync(id);
-            input.ApiKey = _stringEncryptionService.Encrypt(input.ApiKey);
-
-            bool hasFormGuidChanged = existingForm.ChefsApplicationFormGuid != input.ChefsApplicationFormGuid;
-            bool hasFormApiKeyChanged = existingForm.ApiKey != input.ApiKey;
-
-            // Only initialize form version if changes are made to form connection details
-            if (hasFormGuidChanged || hasFormApiKeyChanged)
+            if (input.ChefsApplicationFormGuid != null && input.ApiKey != null)
             {
-                return await InitializeFormVersion(id, input);
-            }
-            else
-            {
-                return await base.UpdateAsync(id, input);
-            }
-        }
-
-        private async Task<ApplicationFormDto> InitializeFormVersion(Guid id, CreateUpdateApplicationFormDto input)
-        {
-            var applicationFormDto = new ApplicationFormDto();
-            try
-            {
-                if (input.ChefsApplicationFormGuid != null && input.ApiKey != null)
+                dynamic form = await _formsApiService.GetForm(Guid.Parse(input.ChefsApplicationFormGuid), input.ChefsApplicationFormGuid.ToString(), input.ApiKey);
+                if (form != null)
                 {
-                    dynamic form = await _formsApiService.GetForm(Guid.Parse(input.ChefsApplicationFormGuid), input.ChefsApplicationFormGuid.ToString(), input.ApiKey);
-                    if (form != null)
+                    JObject formObject = JObject.Parse(form.ToString());
+                    var formName = formObject.SelectToken("name");
+                    if (formName != null)
                     {
-                        JObject formObject = JObject.Parse(form.ToString());
-                        var formName = formObject.SelectToken("name");
-                        if (formName != null)
-                        {
-                            input.ApplicationFormName = formName.ToString();
-                            applicationFormDto = await base.UpdateAsync(id, input);
-                        }
-                        bool initializePublishedOnly = false;
-                        await _applicationFormVersionAppService.InitializePublishedFormVersion(form, id, initializePublishedOnly);
+                        input.ApplicationFormName = formName.ToString();
+                        applicationFormDto = await base.UpdateAsync(id, input);
                     }
+                    bool initializePublishedOnly = false;
+                    await _applicationFormVersionAppService.InitializePublishedFormVersion(form, id, initializePublishedOnly);
                 }
-                return applicationFormDto;
             }
-            catch (Exception ex)
-            {
-                throw new UserFriendlyException("Exception: " + ex.Message + "\n\r Please check the CHEFS Form ID and CHEFS Form API Key");
-            }
-
+            return applicationFormDto;
         }
-
-        public override async Task<ApplicationFormDto> GetAsync(Guid id)
+        catch (Exception ex)
         {
-            var dto = await base.GetAsync(id);
-            dto.ApiKey = _stringEncryptionService.Decrypt(dto.ApiKey);
-            dto.ApiToken = _stringEncryptionService.Decrypt(dto.ApiToken);
-            return dto;
+            throw new UserFriendlyException("Exception: " + ex.Message + "\n\r Please check the CHEFS Form ID and CHEFS Form API Key");
         }
 
-        public async Task<IList<ApplicationFormVersionDto>> GetPublishedVersionsAsync(Guid id)
-        {
-            IQueryable<ApplicationFormVersion> queryableFormVersions = _applicationFormVersionRepository.GetQueryableAsync().Result;
-            var formVersions = queryableFormVersions.Where(c => c.ApplicationFormId.Equals(id) && c.Published.Equals(true)).ToList();
-            return await Task.FromResult<IList<ApplicationFormVersionDto>>(ObjectMapper.Map<List<ApplicationFormVersion>, List<ApplicationFormVersionDto>>(formVersions.OrderByDescending(s => s.Version).ToList()));
-        }
+    }
 
-        public async Task<IList<ApplicationFormVersionDto>> GetVersionsAsync(Guid id)
-        {
-            IQueryable<ApplicationFormVersion> queryableFormVersions = _applicationFormVersionRepository.GetQueryableAsync().Result;
-            var formVersions = queryableFormVersions.Where(c => c.ApplicationFormId.Equals(id)).ToList();
-            return await Task.FromResult<IList<ApplicationFormVersionDto>>(ObjectMapper.Map<List<ApplicationFormVersion>, List<ApplicationFormVersionDto>>(formVersions.OrderByDescending(s => s.Version).ToList()));
-        }
+    [Authorize(GrantManagerPermissions.ApplicationForms.Default)]
+    public override async Task<ApplicationFormDto> GetAsync(Guid id)
+    {
+        var dto = await base.GetAsync(id);
+        dto.ApiKey = _stringEncryptionService.Decrypt(dto.ApiKey);
+        dto.ApiToken = _stringEncryptionService.Decrypt(dto.ApiToken);
+        return dto;
+    }
 
-        public async Task SaveApplicationFormScoresheet(FormScoresheetDto dto)
-        {
-            var appForm = await _applicationFormRepository.GetAsync(dto.ApplicationFormId);
-            appForm.ScoresheetId = dto.ScoresheetId;
-            await _applicationFormRepository.UpdateAsync(appForm);
-        }
+    [Authorize]
+    public async Task<AddressType> GetElectoralDistrictAddressTypeAsync(Guid id)
+    {
+        var applicationFormDto = await base.GetAsync(id);
+        return applicationFormDto?.ElectoralDistrictAddressType ?? ApplicationForm.GetDefaultElectoralDistrictAddressType();
+    }
 
-        public async Task PatchOtherConfig(Guid id, OtherConfigDto config)
-        {
-            var form = await _applicationFormRepository.GetAsync(id);
+    [Authorize(GrantManagerPermissions.ApplicationForms.Default)]
+    public async Task<IList<ApplicationFormVersionDto>> GetPublishedVersionsAsync(Guid id)
+    {
+        IQueryable<ApplicationFormVersion> queryableFormVersions = _applicationFormVersionRepository.GetQueryableAsync().Result;
+        var formVersions = queryableFormVersions.Where(c => c.ApplicationFormId.Equals(id) && c.Published.Equals(true)).ToList();
+        return await Task.FromResult<IList<ApplicationFormVersionDto>>(ObjectMapper.Map<List<ApplicationFormVersion>, List<ApplicationFormVersionDto>>(formVersions.OrderByDescending(s => s.Version).ToList()));
+    }
 
-            form.IsDirectApproval = config.IsDirectApproval;            
-            form.ElectoralDistrictAddressType = config.ElectoralDistrictAddressType;
-            
-            await _applicationFormRepository.UpdateAsync(form);
-        }
+    [Authorize(GrantManagerPermissions.ApplicationForms.Default)]
+    public async Task<IList<ApplicationFormVersionDto>> GetVersionsAsync(Guid id)
+    {
+        IQueryable<ApplicationFormVersion> queryableFormVersions = _applicationFormVersionRepository.GetQueryableAsync().Result;
+        var formVersions = queryableFormVersions.Where(c => c.ApplicationFormId.Equals(id)).ToList();
+        return await Task.FromResult<IList<ApplicationFormVersionDto>>(ObjectMapper.Map<List<ApplicationFormVersion>, List<ApplicationFormVersionDto>>(formVersions.OrderByDescending(s => s.Version).ToList()));
+    }
+
+    [Authorize(GrantManagerPermissions.ApplicationForms.Default)]
+    public async Task SaveApplicationFormScoresheet(FormScoresheetDto dto)
+    {
+        var appForm = await _applicationFormRepository.GetAsync(dto.ApplicationFormId);
+        appForm.ScoresheetId = dto.ScoresheetId;
+        await _applicationFormRepository.UpdateAsync(appForm);
+    }
+
+    [Authorize(GrantManagerPermissions.ApplicationForms.Default)]
+    public async Task PatchOtherConfig(Guid id, OtherConfigDto config)
+    {
+        var form = await _applicationFormRepository.GetAsync(id);
+
+        form.IsDirectApproval = config.IsDirectApproval;
+        form.ElectoralDistrictAddressType = config.ElectoralDistrictAddressType;
+
+        await _applicationFormRepository.UpdateAsync(form);
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicantInfo/ApplicantInfoViewComponent.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicantInfo/ApplicantInfoViewComponent.cs
@@ -29,7 +29,7 @@ namespace Unity.GrantManager.Web.Views.Shared.Components.ApplicantInfo
         public async Task<IViewComponentResult> InvokeAsync(Guid applicationId, Guid applicationFormVersionId)
         {
             var applicantInfoDto = await applicationAppicantService.GetByApplicationIdAsync(applicationId);
-            var applicationForm = await applicationFormAppService.GetAsync(applicantInfoDto.ApplicationFormId);
+            var electoralDistrictAddressType = await applicationFormAppService.GetElectoralDistrictAddressTypeAsync(applicantInfoDto.ApplicationFormId);
 
             ApplicantInfoViewModel model = new()
             {
@@ -62,8 +62,7 @@ namespace Unity.GrantManager.Web.Views.Shared.Components.ApplicantInfo
                 FiscalMonth = applicantInfoDto.FiscalMonth,
                 NonRegOrgName = applicantInfoDto.NonRegOrgName,
                 ElectoralDistrict = applicantInfoDto.ElectoralDistrict,
-                ApplicantElectoralAddressType = applicationForm.ElectoralDistrictAddressType 
-                    ?? ApplicationForm.GetDefaultElectoralDistrictAddressType(),
+                ApplicantElectoralAddressType = electoralDistrictAddressType,
             };
 
             await PopulateSectorsAndSubSectorsAsync(model);


### PR DESCRIPTION
This pull request fixes a Cascading Authorization issue on ApplicationFormAppService that was causing GrantApplication Details to not load for users without permissions.

### Authorization Enhancements:
* Added `[Authorize]` and `[Authorize(GrantManagerPermissions.ApplicationForms.Default)]` attributes to multiple methods in `ApplicationFormAppService`, ensuring that proper permissions are enforced for accessing and modifying application forms. [[1]](diffhunk://#diff-4865ffec769431b964798fc0b0137153df8a765e6cf7df8ef24643eb8709a55dR9-R20) [[2]](diffhunk://#diff-4865ffec769431b964798fc0b0137153df8a765e6cf7df8ef24643eb8709a55dR49-R57) [[3]](diffhunk://#diff-4865ffec769431b964798fc0b0137153df8a765e6cf7df8ef24643eb8709a55dR77) [[4]](diffhunk://#diff-4865ffec769431b964798fc0b0137153df8a765e6cf7df8ef24643eb8709a55dR108) [[5]](diffhunk://#diff-4865ffec769431b964798fc0b0137153df8a765e6cf7df8ef24643eb8709a55dR117-R148)

### New Method for Electoral District Address Type:
* Added the `GetElectoralDistrictAddressTypeAsync` method in `IApplicationFormAppService` and implemented it in `ApplicationFormAppService`. This method retrieves the electoral district address type for a given application form, defaulting to a predefined value if none is set. [[1]](diffhunk://#diff-5ce67b1fbba92278f2cbf8ed87f33b4ddb3517a3c67e2d2e4d83aed4fe48a210R17) [[2]](diffhunk://#diff-4865ffec769431b964798fc0b0137153df8a765e6cf7df8ef24643eb8709a55dR117-R148)

### Updates to ApplicantInfoViewComponent:
* Modified `ApplicantInfoViewComponent` to use the new `GetElectoralDistrictAddressTypeAsync` method instead of directly accessing the `ApplicationForm` object for electoral district address type. This change simplifies the component and aligns it with the new service method. [[1]](diffhunk://#diff-bd1f15adb3f28cb645876de879e1cb34084ba48330d0092b9444e0985be3f883L32-R32) [[2]](diffhunk://#diff-bd1f15adb3f28cb645876de879e1cb34084ba48330d0092b9444e0985be3f883L65-R65)