### PR TITLE
bugfix/AB#29395 - Fix Cascading Authorization Exception on Application Breadcrumb Widget

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/ApplicationApplicantAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/ApplicationApplicantAppService.cs
@@ -92,7 +92,7 @@ public class ApplicationApplicantAppService(
     }
 
     [Obsolete("Use GetApplicantInfoTabAsync instead.")]
-    [Authorize(UnitySelector.Applicant.Default)]
+    [Authorize]
     public async Task<ApplicationApplicantInfoDto> GetByApplicationIdAsync(Guid applicationId)
     {
         var applicantInfo = await applicationRepository.WithBasicDetailsAsync(applicationId);


### PR DESCRIPTION
Fix Cascading Authorization Exception blocks Application Breadcrumb Widget From Rendering