### PR TITLE
Bugfix/ab#29393 intake reportdata null

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/Handlers/GenerateReportDataHandler.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/Handlers/GenerateReportDataHandler.cs
@@ -41,7 +41,7 @@ namespace Unity.GrantManager.Intakes.Handlers
                     eventData.ApplicationFormSubmission.ReportData = reportingDataGenerator
                         .Generate(eventData.RawSubmission,
                                     eventData.FormVersion?.ReportKeys,
-                                    eventData.ApplicationFormSubmission.Id);
+                                    eventData.ApplicationFormSubmission.Id) ?? "{}";
                 }
             }
         }


### PR DESCRIPTION
- Make sure that ReportData is not null which can break the intake process in edge cases (this was tested with invalid data and in theory should not happen, but this is an added safety net)