### PR TITLE
AB#29415 - Bugfix - Remove legacy tab display JS controls

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
@@ -21,7 +21,6 @@ $(function () {
 
     function initializeDetailsPage() {
         setStoredDividerWidth();
-        updateTabDisplay();
         initCommentsWidget();
         initEmailsWidget();
         updateLinksCounters();
@@ -1076,19 +1075,4 @@ function clearCurrencyError(input) {
     let errorSpan = input.attr('id') + "-error";
     document.getElementById(errorSpan).textContent = '';
     input.attr('aria-invalid', 'false');
-}
-
-function updateTabDisplay() {
-    let tabMapping = {
-        "GrantManager.UI.Tabs.Submission": "nav-summery",
-        "GrantManager.UI.Tabs.Assessment": "nav-review-and-assessment-tab",
-        "GrantManager.UI.Tabs.Project": "nav-project-info-tab",
-        "GrantManager.UI.Tabs.Applicant": "nav-organization-info-tab",
-        "GrantManager.UI.Tabs.FundingAgreement": "nav-funding-agreement-info-tab"
-    };
-
-    Object.keys(tabMapping).forEach(key => {
-        const elementId = tabMapping[key];
-        $(`#${elementId}`).closest('.nav-item').toggleClass('d-none', abp.setting.values[key] === "False");
-    });
 }


### PR DESCRIPTION
Removed legacy tab toggle controls that were conflicting with GrantApplication Details tab rendering in rare cases where a tabs configuration previously existed.