### PR TITLE
bugfix/AB#29423 - Fix Bundling Regressions and Upgrade Dockerfile NodeJS to LTS

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/Bundling/UnityThemeUX2GlobalScriptContributor.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/Bundling/UnityThemeUX2GlobalScriptContributor.cs
@@ -18,6 +18,7 @@ public class UnityThemeUX2GlobalScriptContributor : BundleContributor
         context.Files.Add("/themes/ux2/table-utils.js");
 
         context.Files.AddIfNotContains("/libs/pubsub-js/src/pubsub.js");
+        context.Files.AddIfNotContains("/themes/ux2/zone-extensions.js");
 
         context.Files.AddIfNotContains("/libs/datatables.net/js/jquery.dataTables.js");
         context.Files.AddIfNotContains("/libs/datatables.net-bs5/js/dataTables.bootstrap5.min.js");

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Dockerfile
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Dockerfile
@@ -7,10 +7,10 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 
 # set up node
-ARG NODE_VERSION=18.17.1
-ARG YARN_VERSION=1.22.19
+ARG NODE_VERSION=22.17.0
+ARG YARN_VERSION=1.22.22
 ARG NODE_DOWNLOAD_URL=https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz
-ARG NODE_DOWNLOAD_SHA=2cb75f2bc04b0a3498733fbee779b2f76fe3f655188b4ac69ef2887b6721da2d
+ARG NODE_DOWNLOAD_SHA=0fa01328a0f3d10800623f7107fbcd654a60ec178fab1ef5b9779e94e0419e1a
 
 RUN curl -SL --compressed "${NODE_DOWNLOAD_URL}" --output nodejs.tar.gz \
     && echo "${NODE_DOWNLOAD_SHA} nodejs.tar.gz" | sha256sum -c - \


### PR DESCRIPTION
### Regression Fix to bundling configuration:

* [`UnityThemeUX2GlobalScriptContributor.cs`](diffhunk://#diff-49dca2e290ed475988d6bf47380460c8fd6acb6426fb372d356b70c6aee104d0R21): Added `/themes/ux2/zone-extensions.js` to the global script bundle to extend functionality related to UX2 themes.

### Dependency updates:

* [`Dockerfile`](diffhunk://#diff-256170693946cd5ec16c3f2f49c8d32ea6ad15e69b78d7152145866fffaf7a04L10-R13): Upgraded Node.js to version 22.17.0 and Yarn to version 1.22.22, along with updating the corresponding SHA checksum for Node.js to ensure integrity during installation.