### PR TITLE
bugfix/AB#29308 - Fix Supplier Name Check with Applicant Info Summary Zone

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/PaymentInfo/Default.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/PaymentInfo/Default.js
@@ -93,12 +93,12 @@
                     abp.notify.success('The payment info has been updated.');
                     disableSaveButton(true);
                     refreshSupplierInfoWidget();
+                    hideSpinner();
+                    abp.ui.unblock();
                 })
                 .catch((error) => {
                     console.error(error);
                     disableSaveButton(false);
-                })
-                .finally(() => {
                     hideSpinner();
                     abp.ui.unblock();
                 });

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/IApplicationApplicantAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/IApplicationApplicantAppService.cs
@@ -10,5 +10,6 @@ namespace Unity.GrantManager.GrantApplications
         Task<ApplicationApplicantInfoDto> GetByApplicationIdAsync(Guid applicationId);
         Task<ApplicantInfoDto> GetApplicantInfoTabAsync(Guid applicationId);
         Task<GrantApplicationDto> UpdatePartialApplicantInfoAsync(Guid applicationId, PartialUpdateDto<UpdateApplicantInfoDto> input);
+        Task<bool> GetSupplierNameMatchesCheck(Guid applicantId, string? supplierName);
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/ApplicationApplicantAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/ApplicationApplicantAppService.cs
@@ -325,4 +325,29 @@ public class ApplicationApplicantAppService(
             }
         }
     }
+
+    public async Task<bool> GetSupplierNameMatchesCheck(Guid applicantId, string? supplierName)
+    {
+        if (string.IsNullOrWhiteSpace(supplierName))
+        {
+            return true; // If supplierName is null or empty, there is nothing to warn about
+        }
+
+        var applicant = await applicantRepository.GetAsync(applicantId) ?? throw new EntityNotFoundException();
+
+        var normalizedSupplierName = supplierName?.Trim();
+        var organizationName = applicant.OrgName?.Trim();
+        var nonRegisteredOrganizationName = applicant.NonRegOrgName?.Trim();
+
+        // Match if either orgName or nonRegisteredOrgName matches supplierName
+        // - If both orgName and nonRegisteredOrgName are null or empty, return true
+        // - Otherwise, return true if supplierName matches either orgName or nonRegisteredOrgName (case-insensitive)
+        if (string.IsNullOrEmpty(organizationName) && string.IsNullOrEmpty(nonRegisteredOrganizationName))
+        {
+            return true;
+        }
+
+        return string.Equals(normalizedSupplierName, organizationName, StringComparison.OrdinalIgnoreCase)
+        || string.Equals(normalizedSupplierName, nonRegisteredOrganizationName, StringComparison.OrdinalIgnoreCase);
+    }
 }


### PR DESCRIPTION
## Pull Request Overview

This PR adds a supplier name matching check in the applicant summary zone and updates the front-end widgets to use the new API and summary-zone elements.

- Exposed `GetSupplierNameMatchesCheck` API endpoint in the application applicant service and its interface  
- Updated `SupplierInfo.js` to reference Applicant Info Summary zone fields and fall back to the new `GetSupplierNameMatchesCheck` API endpoint when Applicant Info Summary is not available

### Reviewed Changes

Copilot reviewed 4 out of 4 changed files in this pull request and generated 2 comments.

| File                                                                                           | Description                                                       |
|------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
| ApplicationApplicantAppService.cs                                                              | Introduces `GetSupplierNameMatchesCheck` method                   |
| IApplicationApplicantAppService.cs                                                             | Adds service contract for the new supplier name check method      |
| SupplierInfo.js                                                                                | Switches to summary-zone selectors, adds API fallback validation  |
| Default.js                                                                                     | Removed .finally() from supplier info update chain             |
