### PR TITLE
AB#29554 - Hotfix - Payment Info Permissions Loading

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Permissions/PaymentsPermissionDefinitionProvider.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Permissions/PaymentsPermissionDefinitionProvider.cs
@@ -36,8 +36,7 @@ public static class PaymentPermissionGroupDefinitionExtensions
     {
         #region PAYMENT INFO GRANULAR PERMISSIONS
         var upx_Payment                                     = grantApplicationPermissionsGroup
-                                                                                    .AddPermission(UnitySelector.Payment.Default, LocalizableString.Create<PaymentsResource>(UnitySelector.Payment.Default))
-                                                                                    .RequireFeatures("Unity.Payments");
+                                                                                    .AddPermission(UnitySelector.Payment.Default, LocalizableString.Create<PaymentsResource>(UnitySelector.Payment.Default));
 
         var upx_Payment_Summary                             = upx_Payment.AddPaymentChild(UnitySelector.Payment.Summary.Default);
 
@@ -52,6 +51,6 @@ public static class PaymentPermissionGroupDefinitionExtensions
 
     public static PermissionDefinition AddPaymentChild(this PermissionDefinition parent, string name)
     {
-        return parent.AddChild(name, LocalizableString.Create<PaymentsResource>(name)).RequireFeatures("Unity.Payments");
+        return parent.AddChild(name, LocalizableString.Create<PaymentsResource>(name));
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Permissions/PermissionGrantsDataSeeder.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Permissions/PermissionGrantsDataSeeder.cs
@@ -62,7 +62,6 @@ namespace Unity.GrantManager.Permissions
             UnitySelector.Payment.Default,
             UnitySelector.Payment.Summary.Default,
             UnitySelector.Payment.Supplier.Default,
-            UnitySelector.Payment.Supplier.Update,
             UnitySelector.Payment.PaymentList.Default
         ];
 
@@ -122,6 +121,7 @@ namespace Unity.GrantManager.Permissions
                     .. ApplicantInfo_CommonPermissions,
                     .. ProjectInfo_CommonPermissions,
                     .. PaymentInfo_CommonPermissions,
+                    UnitySelector.Payment.Supplier.Update,
                     .. Notifications_CommonPermissions,
                     .. Dashboard_CommonPermissions
             ], context.TenantId);
@@ -180,6 +180,7 @@ namespace Unity.GrantManager.Permissions
                     .. ApplicantInfo_CommonPermissions,
                     .. ProjectInfo_CommonPermissions,
                     .. PaymentInfo_CommonPermissions,
+                    UnitySelector.Payment.Supplier.Update,
                     .. Notifications_CommonPermissions,
                     .. Dashboard_CommonPermissions,
 
@@ -221,6 +222,7 @@ namespace Unity.GrantManager.Permissions
                     .. ApplicantInfo_CommonPermissions,
                     .. ProjectInfo_CommonPermissions,
                     .. PaymentInfo_CommonPermissions,
+                    UnitySelector.Payment.Supplier.Update,
                     .. Notifications_CommonPermissions,
                     NotificationsPermissions.Settings,
                     .. Dashboard_CommonPermissions,


### PR DESCRIPTION
This PR hotfixes how the `Payment.Supplier.Update` permission is seeded and adjusts feature-gating on payment permissions.

- Repositions `UnitySelector.Payment.Supplier.Update` from the global seeder into each role-specific seed call.
- Removes `.RequireFeatures("Unity.Payments")` from the default payment permission and child permissions.
- Updates the `AddPaymentChild` helper to no longer automatically add feature requirements.