### PR TITLE
AB#29471 - Fix typo in EmailGroupUsersAppService.cs

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Notifications/src/Unity.Notifications.Application/EmailGroupUsers/EmailGroupUsersAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Notifications/src/Unity.Notifications.Application/EmailGroupUsers/EmailGroupUsersAppService.cs
@@ -78,7 +78,7 @@ namespace Unity.Notifications.EmailGroups
             }
         }
 
-        public async Task<List<EmailGroupUsersDto>> GetEmailGroupUsersByGroupIdsync(Guid id)
+        public async Task<List<EmailGroupUsersDto>> GetEmailGroupUsersByGroupIdAsync(Guid id)
         {
             var users = await _emailGroupUsersRepository.GetListAsync(u => u.GroupId == id);
 


### PR DESCRIPTION
## Pull Request Overview

This PR fixes a typo in the method name `GetEmailGroupUsersByGroupIdsync` by correcting it to `GetEmailGroupUsersByGroupIdAsync` to properly indicate its asynchronous nature and maintain naming consistency.

- Corrects method name typo from "Idsync" to "IdAsync"