### PR TITLE
bugfix/AB#29539 Added clearing filters to default view logic

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.js
@@ -95,7 +95,10 @@
                         })
                         dt.colReorder.order(orderedIndexes);
 
-                        dt.order([4, 'desc']).search('').draw();
+                        $('#search, .custom-filter-input').val('');
+                        dt.columns().search('');
+                        dt.search('');
+                        dt.order([4, 'desc']).draw();
 
                         // Close the dropdown
                         dt.buttons('.grp-savedStates')


### PR DESCRIPTION
Added to the default view button to include clearing all search parameters and filters 