### PR TITLE
bugfix/AB#29438 Fix dropdown alignment for column visibility option

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.css
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.css
@@ -124,4 +124,9 @@ table.dataTable tbody tr {
     border-radius:inherit;
 }
 
+.dt-button-collection.shift-left {
+    left: unset !important; 
+    right: 0px !important;
+}
+
 /**end**/

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.js
@@ -1258,6 +1258,25 @@
             dataTable.rows({ 'page': 'current' }).deselect();
         }
     });
+
+
+    /* Fix when selecting option 'Other Sector/Sub/Industry Description' in the dropdown column list */
+    $(document).on('click', '.dt-button-collection .buttons-columnVisibilitynull span', function () {
+        if ($(this).text().trim() === 'Other Sector/Sub/Industry Description') {
+            // Add a custom class to the open dropdown
+            $('.dt-button-collection').addClass('shift-left');
+        } else {
+            // Optionally remove the class if another button is clicked
+            $('.dt-button-collection').removeClass('shift-left');
+        }
+    });
+
+    $(document).on('click', function (e) {
+        if (!$(e.target).closest('.dt-button-collection').length) {
+            $('.dt-button-collection').removeClass('shift-left');
+        }
+    });
+
 });
 function payoutDefinition(approvedAmount, totalPaid) {
     if ((approvedAmount > 0 && totalPaid > 0) && (approvedAmount  === totalPaid)) {


### PR DESCRIPTION
- Add logic to shift the DataTables column visibility dropdown to the right when 'Other Sector/Sub/Industry Description' is selected, addressing alignment issues.