### PR TITLE
bugfix/AB#29715 Payment request update note

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/PaymentRequests/PaymentRequestAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/PaymentRequests/PaymentRequestAppService.cs
@@ -199,7 +199,17 @@ namespace Unity.Payments.PaymentRequests
                 try
                 {
                     var payment = await paymentRequestsRepository.GetAsync(dto.PaymentRequestId);
-                    payment.SetNote(dto.Note);
+                    if (payment == null)
+                        continue;
+
+                    if (!string.IsNullOrWhiteSpace(payment.Note) && !string.IsNullOrWhiteSpace(dto.Note))
+                    {
+                        payment.SetNote($"{payment.Note}; {dto.Note}");
+                    }
+                    else
+                    {
+                        payment.SetNote(dto.Note);
+                    }
 
                     var triggerAction = await DetermineTriggerActionAsync(dto, payment);
 

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentApprovals/UpdatePaymentRequestStatus.cshtml.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentApprovals/UpdatePaymentRequestStatus.cshtml.cs
@@ -222,7 +222,8 @@ namespace Unity.Payments.Web.Pages.PaymentApprovals
             .Select(payment => new UpdatePaymentStatusRequestDto
             {
                 PaymentRequestId = payment.Id,
-                IsApprove = IsApproval
+                IsApprove = IsApproval,
+                Note = Note ?? String.Empty
             })
             .ToList();
 


### PR DESCRIPTION
- Fix Note to payment status update UpdatePaymentStatusRequestDto that allows additional information to be passed when approve/decline payments
- Note is appended to the existing note separated by a semicolon. Also prevent overwriting existing notes and ensures all relevant information is retained.