### PR TITLE
bugfix/AB#29688 - Add border to display-input labels shown in Details tab

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/SummaryWidget/Default.css
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/SummaryWidget/Default.css
@@ -22,7 +22,7 @@
     background-color: var(--bc-colors-grey-hover) !important;
     opacity: var(--bs-btn-disabled-opacity);
     background-blend-mode: difference;
-    border: none !important;
+    border: var(--bs-border-width) solid var(--bs-border-color);
     padding: 0.4rem;
     border-radius: var(--bc-layout-margin-small) !important;
     min-height: 2rem;


### PR DESCRIPTION
Added a slight border to all display-input labels to make them distinguishable from the background. Change requested from QA.