### PR TITLE
hotfix/AB#29960 Fix tab save issue

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/GrantApplicationAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/GrantApplicationAppService.cs
@@ -349,7 +349,7 @@ public class GrantApplicationAppService : GrantManagerAppService, IGrantApplicat
         }
 
         // Handle custom fields for assessment info
-        if (HasValue(input.CustomFields) && input.CorrelationId != Guid.Empty)
+        if (input.CustomFields != null && HasValue(input.CustomFields) && input.CorrelationId != Guid.Empty)
         {
             // Handle multiple worksheets
             if (input.WorksheetIds?.Count > 0)
@@ -489,7 +489,7 @@ public class GrantApplicationAppService : GrantManagerAppService, IGrantApplicat
             application.Place = input.Place;
 
             // Handle custom fields for project info
-            if (HasValue(input.CustomFields) && input.CorrelationId != Guid.Empty)
+            if (input.CustomFields != null && HasValue(input.CustomFields) && input.CorrelationId != Guid.Empty)
             {
                 // Handle multiple worksheets
                 if (input.WorksheetIds?.Count > 0)
@@ -567,7 +567,7 @@ public class GrantApplicationAppService : GrantManagerAppService, IGrantApplicat
         application.UpdatePercentageTotalProjectBudget();
 
         // Add custom worksheet data
-        if (HasValue(input.Data.CustomFields) && input.Data.CorrelationId != Guid.Empty)
+        if (input.Data.CustomFields != null && HasValue(input.Data.CustomFields) && input.Data.CorrelationId != Guid.Empty)
         {
             // Handle multiple worksheets
             if (input.Data.WorksheetIds?.Count > 0)
@@ -608,7 +608,7 @@ public class GrantApplicationAppService : GrantManagerAppService, IGrantApplicat
             application.ContractExecutionDate = input.ContractExecutionDate;
 
             // Handle custom fields for funding agreement info
-            if (HasValue(input.CustomFields) && input.CorrelationId != Guid.Empty)
+            if (input.CustomFields != null && HasValue(input.CustomFields) && input.CorrelationId != Guid.Empty)
             {
                 // Handle multiple worksheets
                 if (input.WorksheetIds?.Count > 0)


### PR DESCRIPTION
Added explicit null checks for input.CustomFields and input.Data.CustomFields before calling HasValue to prevent potential null reference exceptions during grant application processing. This fixes Review & Assessments, Project Info and Funding Agreement Tabs