### PR TITLE
bugfix/AB#29965-Fix payment tab updateAsync

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/PaymentInfo/PaymentInfoAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/PaymentInfo/PaymentInfoAppService.cs
@@ -21,7 +21,7 @@ namespace Unity.Payments.PaymentInfo
         public async Task<PaymentInfoDto> UpdateAsync(Guid id, CreateUpdatePaymentInfoDto input)
         {
             // Handle custom fields for payment info
-            if (HasValue(input.CustomFields) && input.CorrelationId != Guid.Empty)
+            if (input.CustomFields != null && HasValue(input.CustomFields) && input.CorrelationId != Guid.Empty)
             {
                 // Handle multiple worksheets
                 if (input.WorksheetIds?.Count > 0)


### PR DESCRIPTION
Added a null check for input.CustomFields in the UpdateAsync method to prevent potential null reference exceptions when handling custom fields for payment info