### PR TITLE
AB#29825: Fix error on form configuration when FormSchema is empty string

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/ApplicationFormVersion.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/ApplicationFormVersion.cs
@@ -21,7 +21,7 @@ public class ApplicationFormVersion : AuditedAggregateRoot<Guid>, IMultiTenant
     public string ReportKeys { get; set; } = string.Empty;
     public string ReportViewName { get; set; } = string.Empty;
     [Column(TypeName = "jsonb")]
-    public string? FormSchema { get; set; } = string.Empty;
+    public string? FormSchema { get; set; } = null;
 
     /// <summary>
     /// Checks if the submission header mapping contains a specific field.


### PR DESCRIPTION
Empty string on ApplicationFormVersion.FormSchema is throwing an error