### PR TITLE
feature/AB#32346 - Standardize blank applicant names

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.js
@@ -380,14 +380,15 @@ $(function () {
             className: 'data-table-header',
             index: columnIndex,
             render: function (data, type, row) {
-                let applicantName = (typeof data !== 'string' || data.trim() === '') ? '(Applicant Name)' : data;
+                let applicantName = (typeof data !== 'string' || data.trim() === '') ? 'Applicant Name' : data;
 
                 if (type === 'sort' || type === 'filter') {
                     return applicantName;
                 }
 
+                const safeApplicantName = $.fn.dataTable.render.text().display(applicantName);
+
                 if (type === 'display' && abp.auth.isGranted('GrantApplicationManagement.Applicants.ViewList')) {
-                    const safeApplicantName = $.fn.dataTable.render.text().display(applicantName);
                     const applicantId = row?.correlationId;
                     const isGuid = applicantId && guidPattern.test(applicantId);
 

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.js
@@ -2,6 +2,7 @@ $(function () {
     const l = abp.localization.getResource('Payments');
     const nullPlaceholder = '—';
     const formatter = createNumberFormatter();
+    const guidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     let dt = $('#PaymentRequestListTable');
     let dataTable;
     let isApprove = false;
@@ -377,7 +378,28 @@ $(function () {
             name: 'applicantName',
             data: 'payeeName',
             className: 'data-table-header',
-            index: columnIndex
+            index: columnIndex,
+            render: function (data, type, row) {
+                let applicantName = (typeof data !== 'string' || data.trim() === '') ? '(Applicant Name)' : data;
+
+                if (type === 'sort' || type === 'filter') {
+                    return applicantName;
+                }
+
+                if (type === 'display' && abp.auth.isGranted('GrantApplicationManagement.Applicants.ViewList')) {
+                    const safeApplicantName = $.fn.dataTable.render.text().display(applicantName);
+                    const applicantId = row?.correlationId;
+                    const isGuid = applicantId && guidPattern.test(applicantId);
+
+                    if (row?.correlationProvider === 'Application' && isGuid) {
+                        return `<a href="/GrantApplicants/Details?ApplicationId=${encodeURIComponent(applicantId)}">${safeApplicantName}</a>`;
+                    }
+
+                    return safeApplicantName;
+                }
+
+                return applicantName;
+            },
         };
     }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Applicants/Details.cshtml.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Applicants/Details.cshtml.cs
@@ -72,7 +72,7 @@ namespace Unity.GrantManager.Web.Pages.Applicants
                 // Set properties for breadcrumb and display
                 ApplicantDisplayName = !string.IsNullOrEmpty(Applicant.ApplicantName)
                     ? Applicant.ApplicantName
-                    : "Unknown Applicant";
+                    : "Applicant Name";
 
                 UnityApplicantId = Applicant.UnityApplicantId ?? "N/A";
                 Status = Applicant.Status ?? "Active";

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Applicants/Details.cshtml.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Applicants/Details.cshtml.cs
@@ -49,8 +49,15 @@ namespace Unity.GrantManager.Web.Pages.Applicants
             // Resolve ApplicantId from ApplicationId if needed
             if (ApplicantId == Guid.Empty && ApplicationId.HasValue)
             {
-                var application = await _applicationRepository.WithBasicDetailsAsync(ApplicationId.Value);
-                ApplicantId = application.ApplicantId;
+                try
+                {
+                    var application = await _applicationRepository.WithBasicDetailsAsync(ApplicationId.Value);
+                    ApplicantId = application.ApplicantId;
+                }
+                catch (Exception)
+                {
+                    return NotFound();
+                }
             }
 
             if (ApplicantId == Guid.Empty)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Applicants/Details.cshtml.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Applicants/Details.cshtml.cs
@@ -13,9 +13,13 @@ namespace Unity.GrantManager.Web.Pages.Applicants
     public class DetailsModel : GrantManagerPageModel
     {
         private readonly IApplicantRepository _applicantRepository;
+        private readonly IApplicationRepository _applicationRepository;
 
         [BindProperty(SupportsGet = true)]
         public Guid ApplicantId { get; set; }
+
+        [BindProperty(SupportsGet = true)]
+        public Guid? ApplicationId { get; set; } = null;
 
         public Applicant? Applicant { get; set; }
         public string ApplicantDisplayName { get; set; } = string.Empty;
@@ -28,10 +32,12 @@ namespace Unity.GrantManager.Web.Pages.Applicants
 
         public DetailsModel(
             IApplicantRepository applicantRepository,
+            IApplicationRepository applicationRepository,
             ICurrentUser currentUser,
             IConfiguration configuration)
         {
             _applicantRepository = applicantRepository;
+            _applicationRepository = applicationRepository;
             CurrentUserId = currentUser.Id;
             CurrentUserName = currentUser.SurName + ", " + currentUser.Name;
             Extensions = configuration["S3:DisallowedFileTypes"] ?? "";
@@ -40,6 +46,13 @@ namespace Unity.GrantManager.Web.Pages.Applicants
 
         public async Task<IActionResult> OnGetAsync()
         {
+            // Resolve ApplicantId from ApplicationId if needed
+            if (ApplicantId == Guid.Empty && ApplicationId.HasValue)
+            {
+                var application = await _applicationRepository.WithBasicDetailsAsync(ApplicationId.Value);
+                ApplicantId = application.ApplicantId;
+            }
+
             if (ApplicantId == Guid.Empty)
             {
                 return NotFound();

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Applicants/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Applicants/Index.js
@@ -1,6 +1,7 @@
 $(function () {    
     let dt = $('#ApplicantsTable');
     let dataTable;
+    const guidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
     // Default visible columns as per requirements
     const defaultVisibleColumns = [
@@ -87,7 +88,28 @@ $(function () {
             data: 'applicantName',
             name: 'applicantName',
             className: 'data-table-header',
-            index: columnIndex
+            index: columnIndex,
+            render: function (data, type, row) {
+                let applicantName = (typeof data !== 'string' || data.trim() === '') ? '(Applicant Name)' : data;
+
+                if (type === 'sort' || type === 'filter') {
+                    return applicantName;
+                }
+
+                if (type === 'display') {
+                    const safeApplicantName = $.fn.dataTable.render.text().display(applicantName);
+                    const applicantId = row?.id;
+                    const isGuid = applicantId && guidPattern.test(applicantId);
+
+                    if (isGuid) {
+                        return `<a href="/GrantApplicants/Details?ApplicantId=${encodeURIComponent(applicantId)}">${safeApplicantName}</a>`;
+                    }
+
+                    return safeApplicantName;
+                }
+
+                return applicantName;
+            }
         }
     }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Applicants/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Applicants/Index.js
@@ -90,14 +90,15 @@ $(function () {
             className: 'data-table-header',
             index: columnIndex,
             render: function (data, type, row) {
-                let applicantName = (typeof data !== 'string' || data.trim() === '') ? '(Applicant Name)' : data;
+                let applicantName = (typeof data !== 'string' || data.trim() === '') ? 'Applicant Name' : data;
 
                 if (type === 'sort' || type === 'filter') {
                     return applicantName;
                 }
 
+                const safeApplicantName = $.fn.dataTable.render.text().display(applicantName);
+
                 if (type === 'display') {
-                    const safeApplicantName = $.fn.dataTable.render.text().display(applicantName);
                     const applicantId = row?.id;
                     const isGuid = applicantId && guidPattern.test(applicantId);
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.js
@@ -587,7 +587,7 @@ $(function () {
             className: 'data-table-header',
             index: columnIndex,
             render: function(data, type, row) {
-                let applicantName = (typeof data !== 'string' || data.trim() === '') ? '(Unknown Applicant)' : data;
+                let applicantName = (typeof data !== 'string' || data.trim() === '') ? '(Applicant Name)' : data;
 
                 if (type === 'sort' || type === 'filter') { 
                     return applicantName;

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.js
@@ -587,14 +587,15 @@ $(function () {
             className: 'data-table-header',
             index: columnIndex,
             render: function(data, type, row) {
-                let applicantName = (typeof data !== 'string' || data.trim() === '') ? '(Applicant Name)' : data;
+                let applicantName = (typeof data !== 'string' || data.trim() === '') ? 'Applicant Name' : data;
 
                 if (type === 'sort' || type === 'filter') { 
                     return applicantName;
                 }
 
+                const safeApplicantName = $.fn.dataTable.render.text().display(applicantName);
+
                 if (type === 'display' && abp.auth.isGranted('GrantApplicationManagement.Applicants.ViewList')) {
-                    const safeApplicantName = $.fn.dataTable.render.text().display(applicantName);
                     const applicantId = row?.applicant?.id;
                     const isGuid = applicantId && guidPattern.test(applicantId);
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicantBreadcrumbWidget/ApplicantBreadcrumbWidget.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicantBreadcrumbWidget/ApplicantBreadcrumbWidget.cs
@@ -36,7 +36,7 @@ namespace Unity.GrantManager.Web.Views.Shared.Components.ApplicantBreadcrumbWidg
                     UnityApplicantId = applicant.UnityApplicantId ?? "N/A",
                     ApplicantName = !string.IsNullOrEmpty(applicant.ApplicantName) 
                             ? applicant.ApplicantName 
-                            : "Unknown Applicant",
+                            : "Applicant Name",
                     Status = applicant.Status ?? "Active"
                 };
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicantBreadcrumbWidget/ApplicantBreadcrumbWidgetViewComponent.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicantBreadcrumbWidget/ApplicantBreadcrumbWidgetViewComponent.cs
@@ -27,7 +27,7 @@ namespace Unity.GrantManager.Web.Views.Shared.Components.ApplicantBreadcrumbWidg
                     UnityApplicantId = applicant.UnityApplicantId ?? "N/A",
                     ApplicantName = !string.IsNullOrEmpty(applicant.ApplicantName) 
                             ? applicant.ApplicantName 
-                            : "Unknown Applicant",
+                            : "Applicant Name",
                     Status = applicant.Status ?? "Active"
                 };
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicationBreadcrumbWidget/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicationBreadcrumbWidget/Default.cshtml
@@ -7,7 +7,7 @@
 @model ApplicationBreadcrumbWidgetViewModel
 
 @{
-    var renderedApplicantName = string.IsNullOrWhiteSpace(Model.ApplicantName) ? "Unknown Applicant" : Model.ApplicantName;
+    var renderedApplicantName = string.IsNullOrWhiteSpace(Model.ApplicantName) ? "Applicant Name" : Model.ApplicantName;
     var hasViewPermission = await PermissionChecker.IsGrantedAsync(GrantApplicationPermissions.Applicants.ViewList);
 }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicationLinksWidget/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicationLinksWidget/Default.js
@@ -484,7 +484,7 @@ $(function () {
 
         prepareDisplayData: function(link) {
             const referenceNumber = escapeHtml(link.referenceNumber || 'Unknown Reference');
-            const applicantName = escapeHtml(link.applicantName || 'Unknown Applicant');
+            const applicantName = escapeHtml(link.applicantName || 'Applicant Name');
             const category = escapeHtml(link.category || 'Unknown Category');
             const applicationStatus = escapeHtml(link.applicationStatus || 'Status Unavailable');
             const linkType = escapeHtml(link.linkType || 'Related');


### PR DESCRIPTION
## Pull request overview

Standardizes how blank applicant names are displayed across list views and adds convenient navigation to applicant details from additional contexts.

**Changes:**
- Replaces the blank/unknown applicant placeholder text with a standardized “Applicant Name” value.
- Adds DataTables rendering for applicant name to safely display and optionally link to applicant details.
- Allows `/GrantApplicants/Details` to resolve `ApplicantId` from an `ApplicationId` query parameter (used by payments).
