### PR TITLE
Feature/ab#32465 model endpoint configuration management

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
@@ -49,6 +49,8 @@ namespace Unity.AI.Runtime
         private const string DefaultMaxTokensParameterName = "max_completion_tokens";
         private const string LegacyMaxTokensParameterName = "max_tokens";
         private const string DefaultProviderName = "OpenAI";
+        private const string OpenAiApiKeyEnvironmentVariableName = "AZURE_OPENAI_API_KEY";
+        private const string OpenAiEndpointEnvironmentVariableName = "AZURE_OPENAI_ENDPOINT";
         private const int DefaultCompletionTokens = 2000;
         private const int DefaultAttachmentSummaryCompletionTokens = 2000;
         private const int DefaultApplicationAnalysisCompletionTokens = 4000;
@@ -742,6 +744,15 @@ namespace Unity.AI.Runtime
         private string? ResolveApiKey(string? operationName = null)
         {
             var providerName = ResolveProviderName(operationName);
+            if (string.Equals(providerName, DefaultProviderName, StringComparison.Ordinal))
+            {
+                var injectedApiKey = _configuration[OpenAiApiKeyEnvironmentVariableName];
+                if (!string.IsNullOrWhiteSpace(injectedApiKey))
+                {
+                    return injectedApiKey;
+                }
+            }
+
             return _configuration[$"Azure:{providerName}:ApiKey"];
         }
 
@@ -772,7 +783,13 @@ namespace Unity.AI.Runtime
             var providerName = ResolveProviderName(operationName);
             var profileName = ResolveProfileName(operationName);
             var profileApiUrl = ResolveProfileSetting(providerName, profileName, "ApiUrl");
+            var injectedEndpoint = ResolveInjectedEndpoint(providerName);
             var legacyOpenAiApiUrl = _configuration["Azure:OpenAI:ApiUrl"];
+
+            if (!string.IsNullOrWhiteSpace(injectedEndpoint) && !string.IsNullOrWhiteSpace(profileApiUrl))
+            {
+                return CombineEndpointAndPath(injectedEndpoint, profileApiUrl);
+            }
 
             if (!string.IsNullOrWhiteSpace(profileApiUrl))
             {
@@ -785,6 +802,22 @@ namespace Unity.AI.Runtime
             }
 
             throw new InvalidOperationException($"AI API URL is not configured for provider '{providerName}'.");
+        }
+
+        private string? ResolveInjectedEndpoint(string providerName)
+        {
+            if (!string.Equals(providerName, DefaultProviderName, StringComparison.Ordinal))
+            {
+                return _configuration[$"Azure:{providerName}:Endpoint"];
+            }
+
+            var injectedEndpoint = _configuration[OpenAiEndpointEnvironmentVariableName];
+            if (!string.IsNullOrWhiteSpace(injectedEndpoint))
+            {
+                return injectedEndpoint;
+            }
+
+            return _configuration["Azure:OpenAI:Endpoint"];
         }
 
         private string? ResolveProfileName(string? operationName)
@@ -811,6 +844,23 @@ namespace Unity.AI.Runtime
 
             var profileSetting = _configuration[$"Azure:{providerName}:Profiles:{profileName}:{settingName}"];
             return string.IsNullOrWhiteSpace(profileSetting) ? null : profileSetting;
+        }
+
+        private static string CombineEndpointAndPath(string endpoint, string profilePath)
+        {
+            if (Uri.TryCreate(profilePath, UriKind.Absolute, out var absoluteUri))
+            {
+                return absoluteUri.ToString();
+            }
+
+            var trimmedEndpoint = endpoint.Trim().TrimEnd('/');
+            var trimmedPath = profilePath.Trim();
+            if (!trimmedPath.StartsWith("/", StringComparison.Ordinal))
+            {
+                trimmedPath = "/" + trimmedPath;
+            }
+
+            return trimmedEndpoint + trimmedPath;
         }
 
         private static ApplicationAnalysisResponse ParseApplicationAnalysisResponse(string raw)

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
@@ -848,16 +848,18 @@ namespace Unity.AI.Runtime
 
         private static string CombineEndpointAndPath(string endpoint, string profilePath)
         {
+            const char UrlPathSeparator = '/';
+
             if (Uri.TryCreate(profilePath, UriKind.Absolute, out var absoluteUri))
             {
                 return absoluteUri.ToString();
             }
 
-            var trimmedEndpoint = endpoint.Trim().TrimEnd('/');
+            var trimmedEndpoint = endpoint.Trim().TrimEnd(UrlPathSeparator);
             var trimmedPath = profilePath.Trim();
-            if (!trimmedPath.StartsWith("/", StringComparison.Ordinal))
+            if (!trimmedPath.StartsWith(UrlPathSeparator))
             {
-                trimmedPath = "/" + trimmedPath;
+                trimmedPath = string.Concat(UrlPathSeparator, trimmedPath);
             }
 
             return trimmedEndpoint + trimmedPath;

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.Development.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.Development.json
@@ -155,14 +155,15 @@
     },
     "OpenAI": {
       "ApiKey": "",
+      "Endpoint": "",
       "Profiles": {
         "Gpt4oMini": {
-          "ApiUrl": "",
+          "ApiUrl": "/openai/deployments/gpt-4o-mini/chat/completions?api-version=2024-02-01",
           "MaxTokensParameter": "max_tokens",
           "Temperature": 0.3
         },
         "Gpt5Mini": {
-          "ApiUrl": "",
+          "ApiUrl": "/openai/deployments/gpt-5-mini/chat/completions?api-version=2024-10-01-preview",
           "MaxTokensParameter": "max_completion_tokens"
         }
       }


### PR DESCRIPTION
## Pull request overview

This pull request refactors Unity AI endpoint configuration so deployed environments can inject only `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_ENDPOINT`, while the runtime continues to resolve model/profile settings from versioned configuration. The OpenAI runtime now prefers those injected values and composes the final request URL from the injected base endpoint plus the configured profile path.

It also updates the development configuration template so `Azure:OpenAI` uses a blank `Endpoint` value and relative profile `ApiUrl` paths, which keeps the tracked config free of Azure OpenAI secrets and environment-specific absolute URLs.

**Changes:**
- Added support for `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_ENDPOINT` overrides in the AI runtime
- Composed the final OpenAI request URL from the injected endpoint and the configured profile path
- Updated the development AI config template to use a blank endpoint and relative profile `ApiUrl` values
