### PR TITLE
AB#32538: Handle Existing Duplicate Sites in the Database

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Handlers/UpsertSupplierHandler.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Handlers/UpsertSupplierHandler.cs
@@ -26,7 +26,10 @@ namespace Unity.Payments.Handlers
         {
             SupplierDto supplierDto = await GetSupplierFromEvent(eventData);
             var existingSites = await siteAppService.GetSitesBySupplierIdAsync(supplierDto.Id);
-            var existingSitesDictionary = existingSites?.ToDictionary(s => s.Number) ?? new Dictionary<string, Site>();
+            var existingSitesDictionary = existingSites?
+                .GroupBy(s => s.Number)
+                .ToDictionary(g => g.Key, g => g.First())
+                ?? new Dictionary<string, Site>();
 
             var defaultPaymentGroup = await ResolveDefaultPaymentGroupAsync(eventData);
             await UpsertSitesFromEventDtoAsync(existingSitesDictionary, supplierDto.Id, eventData, defaultPaymentGroup);

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CreatePaymentRequests.cshtml.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CreatePaymentRequests.cshtml.cs
@@ -319,7 +319,7 @@ namespace Unity.Payments.Web.Pages.Payments
 
             // Get parent links for this application
             var allLinks = await applicationLinksService.GetListByApplicationAsync(application.Id);
-            var parentLink = allLinks.Find(link => link.LinkType == ApplicationLinkType.Parent && link.ApplicationId != application.Id);
+            var parentLink = allLinks.Find(link => link.LinkType == ApplicationLinkType.Parent);
 
             // Rule 2: No parent link exists
             if (parentLink == null)

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CreatePaymentRequests.cshtml.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CreatePaymentRequests.cshtml.cs
@@ -319,7 +319,7 @@ namespace Unity.Payments.Web.Pages.Payments
 
             // Get parent links for this application
             var allLinks = await applicationLinksService.GetListByApplicationAsync(application.Id);
-            var parentLink = allLinks.Find(link => link.LinkType == ApplicationLinkType.Parent);
+            var parentLink = allLinks.Find(link => link.LinkType == ApplicationLinkType.Parent && link.ApplicationId != application.Id);
 
             // Rule 2: No parent link exists
             if (parentLink == null)


### PR DESCRIPTION
Error currently happens when Refreshing Sites that have duplicates in the database.  This PR will handle those scenario.