### PR TITLE
AB#31068:  Bugfix:  Dont Include Self-Reference When Getting Parent

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CreatePaymentRequests.cshtml.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CreatePaymentRequests.cshtml.cs
@@ -319,7 +319,7 @@ namespace Unity.Payments.Web.Pages.Payments
 
             // Get parent links for this application
             var allLinks = await applicationLinksService.GetListByApplicationAsync(application.Id);
-            var parentLink = allLinks.Find(link => link.LinkType == ApplicationLinkType.Parent);
+            var parentLink = allLinks.Find(link => link.LinkType == ApplicationLinkType.Parent && link.ApplicationId != application.Id);
 
             // Rule 2: No parent link exists
             if (parentLink == null)

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CreatePaymentRequests.cshtml.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CreatePaymentRequests.cshtml.cs
@@ -485,7 +485,7 @@ namespace Unity.Payments.Web.Pages.Payments
                     // Parent not in submission, get from first child's link
                     var firstChild = await applicationService.GetAsync(children[0].CorrelationId);
                     var allLinks = await applicationLinksService.GetListByApplicationAsync(firstChild.Id);
-                    var parentLink = allLinks.Find(link => link.LinkType == ApplicationLinkType.Parent);
+                    var parentLink = allLinks.Find(link => link.LinkType == ApplicationLinkType.Parent && link.ApplicationId != firstChild.Id);
 
                     if (parentLink == null)
                     {
@@ -569,7 +569,7 @@ namespace Unity.Payments.Web.Pages.Payments
                     // Parent not in submission, get from first child's link
                     var firstChild = await applicationService.GetAsync(children[0].CorrelationId);
                     var allLinks = await applicationLinksService.GetListByApplicationAsync(firstChild.Id);
-                    var parentLink = allLinks.Find(link => link.LinkType == ApplicationLinkType.Parent);
+                    var parentLink = allLinks.Find(link => link.LinkType == ApplicationLinkType.Parent && link.ApplicationId != firstChild.Id);
 
                     if (parentLink == null)
                     {


### PR DESCRIPTION
This is a fix for the wrong label in Create Payment Dialog box where a Parent Id is displayed as self.

<img width="1029" height="606" alt="image" src="https://github.com/user-attachments/assets/ea8eefa1-7362-464e-b95a-0b69df49aa3b" />
