### PR TITLE
Feature/AB#32291 Tenant Configurable Control of AI Analysis Generation

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/Settings/AITenantConfigurationDto.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/Settings/AITenantConfigurationDto.cs
@@ -1,0 +1,7 @@
+namespace Unity.AI.Settings;
+
+public class AITenantConfigurationDto
+{
+    public bool AutomaticGenerationEnabled { get; set; }
+    public bool ManualGenerationEnabled { get; set; }
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/Settings/IAIConfigurationAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/Settings/IAIConfigurationAppService.cs
@@ -1,8 +1,10 @@
+using System.Threading.Tasks;
 using Volo.Abp.Application.Services;
 
 namespace Unity.AI.Settings;
 
 public interface IAIConfigurationAppService : IApplicationService
 {
-    // Tenant AI configuration methods added in AB#32291
+    Task<AITenantConfigurationDto> GetTenantConfigurationAsync();
+    Task UpdateTenantConfigurationAsync(UpdateAITenantConfigurationDto input);
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/Settings/UpdateAITenantConfigurationDto.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/Settings/UpdateAITenantConfigurationDto.cs
@@ -1,0 +1,7 @@
+namespace Unity.AI.Settings;
+
+public class UpdateAITenantConfigurationDto
+{
+    public bool AutomaticGenerationEnabled { get; set; }
+    public bool ManualGenerationEnabled { get; set; }
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Settings/AIConfigurationAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Settings/AIConfigurationAppService.cs
@@ -1,6 +1,45 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Unity.AI.Permissions;
+using Volo.Abp.MultiTenancy;
+using Volo.Abp.Settings;
+using Volo.Abp.SettingManagement;
+
 namespace Unity.AI.Settings;
 
-public class AIConfigurationAppService : AIAppService, IAIConfigurationAppService
+public class AIConfigurationAppService(
+    ISettingProvider settingProvider,
+    ISettingManager settingManager,
+    ICurrentTenant currentTenant) : AIAppService, IAIConfigurationAppService
 {
-    // Tenant AI configuration methods added in AB#32291
+    private readonly ISettingProvider _settingProvider = settingProvider;
+    private readonly ISettingManager _settingManager = settingManager;
+    private readonly ICurrentTenant _currentTenant = currentTenant;
+
+    public virtual async Task<AITenantConfigurationDto> GetTenantConfigurationAsync()
+    {
+        return new AITenantConfigurationDto
+        {
+            AutomaticGenerationEnabled = await _settingProvider.GetAsync<bool>(
+                AISettings.AutomaticGenerationEnabled, defaultValue: false),
+            ManualGenerationEnabled = await _settingProvider.GetAsync<bool>(
+                AISettings.ManualGenerationEnabled, defaultValue: false)
+        };
+    }
+
+    [Authorize(AIPermissions.Configuration.ConfigureAI)]
+    public virtual async Task UpdateTenantConfigurationAsync(UpdateAITenantConfigurationDto input)
+    {
+        await _settingManager.SetAsync(
+            AISettings.AutomaticGenerationEnabled,
+            input.AutomaticGenerationEnabled.ToString().ToLowerInvariant(),
+            TenantSettingValueProvider.ProviderName,
+            _currentTenant.Id?.ToString());
+
+        await _settingManager.SetAsync(
+            AISettings.ManualGenerationEnabled,
+            input.ManualGenerationEnabled.ToString().ToLowerInvariant(),
+            TenantSettingValueProvider.ProviderName,
+            _currentTenant.Id?.ToString());
+    }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Settings/AISettingDefinitionProvider.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Settings/AISettingDefinitionProvider.cs
@@ -1,3 +1,5 @@
+using Unity.AI.Localization;
+using Volo.Abp.Localization;
 using Volo.Abp.Settings;
 
 namespace Unity.AI.Settings;
@@ -6,6 +8,31 @@ public class AISettingDefinitionProvider : SettingDefinitionProvider
 {
     public override void Define(ISettingDefinitionContext context)
     {
-        // Tenant AI configuration settings are defined in AB#32291
+        context.Add(
+            new SettingDefinition(
+                AISettings.AutomaticGenerationEnabled,
+                "false",
+                L("Setting:AI.AutomaticGenerationEnabled"),
+                isVisibleToClients: false,
+                isInherited: false,
+                isEncrypted: false)
+            .WithProviders(TenantSettingValueProvider.ProviderName)
+        );
+
+        context.Add(
+            new SettingDefinition(
+                AISettings.ManualGenerationEnabled,
+                "false",
+                L("Setting:AI.ManualGenerationEnabled"),
+                isVisibleToClients: false,
+                isInherited: false,
+                isEncrypted: false)
+            .WithProviders(TenantSettingValueProvider.ProviderName)
+        );
+    }
+
+    private static LocalizableString L(string name)
+    {
+        return LocalizableString.Create<AIResource>(name);
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Domain.Shared/Localization/AI/en.json
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Domain.Shared/Localization/AI/en.json
@@ -15,6 +15,10 @@
     "Permission:AI.Prompts.Create": "Create Prompts",
     "Permission:AI.Prompts.Update": "Edit Prompts",
     "Permission:AI.Prompts.Delete": "Delete Prompts",
+
+    "Setting:AI.AutomaticGenerationEnabled": "Automatically Generate AI Analysis",
+    "Setting:AI.ManualGenerationEnabled": "Manually Initiate AI Analysis",
+
     "AIPrompts": "AI Prompts",
     "AIPrompt": "AI Prompt",
     "AIPromptVersion": "Prompt Version",

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Domain.Shared/Settings/AISettings.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Domain.Shared/Settings/AISettings.cs
@@ -1,7 +1,7 @@
 namespace Unity.AI.Settings;
 
-#pragma warning disable S2094
 public static class AISettings
-#pragma warning restore S2094
 {
+    public const string AutomaticGenerationEnabled = "GrantManager.AI.AutomaticGenerationEnabled";
+    public const string ManualGenerationEnabled    = "GrantManager.AI.ManualGenerationEnabled";
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Web/Views/Settings/AISettingGroup/AISettingViewComponent.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Web/Views/Settings/AISettingGroup/AISettingViewComponent.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
+using Unity.AI.Settings;
 using Volo.Abp.AspNetCore.Mvc;
 using Volo.Abp.AspNetCore.Mvc.UI.Bundling;
 using Volo.Abp.AspNetCore.Mvc.UI.Widgets;
+using Volo.Abp.Settings;
 
 namespace Unity.AI.Web.Views.Settings.AISettingGroup;
 
@@ -10,12 +12,19 @@ namespace Unity.AI.Web.Views.Settings.AISettingGroup;
     ScriptTypes = [typeof(AISettingScriptBundleContributor)],
     AutoInitialize = true
 )]
-public class AISettingViewComponent : AbpViewComponent
+public class AISettingViewComponent(ISettingProvider settingProvider) : AbpViewComponent
 {
-    public virtual Task<IViewComponentResult> InvokeAsync()
+    public virtual async Task<IViewComponentResult> InvokeAsync()
     {
-        return Task.FromResult<IViewComponentResult>(
-            View("~/Views/Settings/AISettingGroup/Default.cshtml", new AISettingViewModel()));
+        var model = new AISettingViewModel
+        {
+            AutomaticGenerationEnabled = await settingProvider.GetAsync<bool>(
+                AISettings.AutomaticGenerationEnabled, defaultValue: false),
+            ManualGenerationEnabled = await settingProvider.GetAsync<bool>(
+                AISettings.ManualGenerationEnabled, defaultValue: false)
+        };
+
+        return View("~/Views/Settings/AISettingGroup/Default.cshtml", model);
     }
 
     public class AISettingScriptBundleContributor : BundleContributor

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Web/Views/Settings/AISettingGroup/AISettingViewModel.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Web/Views/Settings/AISettingGroup/AISettingViewModel.cs
@@ -1,8 +1,7 @@
 namespace Unity.AI.Web.Views.Settings.AISettingGroup;
 
-#pragma warning disable S2094
 public class AISettingViewModel
-#pragma warning restore S2094
 {
-    // AI configuration properties added in AB#32291
+    public bool AutomaticGenerationEnabled { get; set; }
+    public bool ManualGenerationEnabled { get; set; }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Web/Views/Settings/AISettingGroup/Default.cshtml
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Web/Views/Settings/AISettingGroup/Default.cshtml
@@ -1,12 +1,66 @@
 @model Unity.AI.Web.Views.Settings.AISettingGroup.AISettingViewModel
 
+<abp-script src="/Views/Settings/AISettingGroup/Default.js" />
+
 <div class="container-fluid px-0">
     <div class="unity-page-titlebar">
         <h4 class="m-0">AI Configuration</h4>
     </div>
+
     <div class="row">
         <div class="p-3">
-            <p class="text-muted">AI configuration settings will appear here.</p>
+            <form id="AISettingsForm">
+                <abp-row>
+                    <abp-column size-md="_12" class="mx-2">
+                        <div class="form-check form-switch mb-3">
+                            <input class="form-check-input"
+                                   type="checkbox"
+                                   id="AutomaticGenerationEnabled"
+                                   name="AutomaticGenerationEnabled"
+                                   value="true"
+                                   @(Model.AutomaticGenerationEnabled ? "checked" : "") />
+                            <label class="form-check-label fw-bold" for="AutomaticGenerationEnabled">
+                                Automatically Generate AI Analysis
+                            </label>
+                            <div class="text-muted small">
+                                When enabled, AI analysis runs automatically on new application intake (subject to form-level AI configuration).
+                            </div>
+                        </div>
+
+                        <div class="form-check form-switch">
+                            <input class="form-check-input"
+                                   type="checkbox"
+                                   id="ManualGenerationEnabled"
+                                   name="ManualGenerationEnabled"
+                                   value="true"
+                                   @(Model.ManualGenerationEnabled ? "checked" : "") />
+                            <label class="form-check-label fw-bold" for="ManualGenerationEnabled">
+                                Manually Initiate AI Analysis
+                            </label>
+                            <div class="text-muted small">
+                                When enabled, users with appropriate permissions can manually generate or regenerate AI analysis.
+                            </div>
+                        </div>
+                    </abp-column>
+                </abp-row>
+
+                <abp-row>
+                    <hr class="my-4" />
+                    <div class="d-flex p-2">
+                        <abp-button id="AISettingsSaveButton"
+                                    text="Save Changes"
+                                    button-type="Primary"
+                                    class="me-2"
+                                    type="submit" />
+
+                        <abp-button id="AISettingsDiscardButton"
+                                    text="Discard Changes"
+                                    button-type="Light"
+                                    class="me-2"
+                                    disabled="true" />
+                    </div>
+                </abp-row>
+            </form>
         </div>
     </div>
 </div>

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Web/Views/Settings/AISettingGroup/Default.js
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Web/Views/Settings/AISettingGroup/Default.js
@@ -1,3 +1,43 @@
 $(function () {
-    // AI configuration UI logic added in AB#32291
+    const uiElements = {
+        settingForm: $('#AISettingsForm'),
+        saveButton: $('#AISettingsSaveButton'),
+        discardButton: $('#AISettingsDiscardButton')
+    };
+
+    let initialFormState = uiElements.settingForm.serialize();
+
+    function checkFormChanges() {
+        let isFormChanged = uiElements.settingForm.serialize() !== initialFormState;
+        uiElements.saveButton.prop('disabled', !isFormChanged);
+        uiElements.discardButton.prop('disabled', !isFormChanged);
+    }
+
+    uiElements.settingForm.on('change', function () {
+        checkFormChanges();
+    });
+
+    uiElements.settingForm.on('submit', function (event) {
+        event.preventDefault();
+
+        const automaticEnabled = $('#AutomaticGenerationEnabled').is(':checked');
+        const manualEnabled = $('#ManualGenerationEnabled').is(':checked');
+
+        unity.aI.settings.aIConfiguration.updateTenantConfiguration({
+            automaticGenerationEnabled: automaticEnabled,
+            manualGenerationEnabled: manualEnabled
+        }).then(function () {
+            $(document).trigger('AbpSettingSaved');
+            initialFormState = uiElements.settingForm.serialize();
+            checkFormChanges();
+        });
+    });
+
+    uiElements.discardButton.on('click', function () {
+        uiElements.settingForm[0].reset();
+        initialFormState = uiElements.settingForm.serialize();
+        checkFormChanges();
+    });
+
+    checkFormChanges();
 });

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/AIOperationServices.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/AIOperationServices.cs
@@ -1,0 +1,17 @@
+using Unity.AI;
+using Unity.AI.Operations;
+using Volo.Abp.DependencyInjection;
+
+namespace Unity.GrantManager.GrantApplications.Automation.BackgroundJobs;
+
+/// <summary>
+/// Aggregates the four AI operation services used by <see cref="RunApplicationAIPipelineJob"/>.
+/// Introduced to keep the constructor within SonarQube's 7-parameter limit (S107)
+/// while preserving explicit, testable constructor injection for each dependency.
+/// Implements <see cref="ITransientDependency"/> so ABP's DI scanning registers it in the container.
+/// </summary>
+public record AIOperationServices(
+    IAttachmentSummaryService AttachmentSummary,
+    IApplicationAnalysisService ApplicationAnalysis,
+    IApplicationScoringService ApplicationScoring,
+    IAIService AI) : ITransientDependency;

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/RunApplicationAIPipelineJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/RunApplicationAIPipelineJob.cs
@@ -1,29 +1,36 @@
 using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
-using Unity.AI;
-using Unity.AI.Operations;
+using Unity.AI.Settings;
 using Unity.GrantManager.GrantApplications.Automation.Events;
 using Volo.Abp.BackgroundJobs;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.EventBus.Local;
 using Volo.Abp.Features;
 using Volo.Abp.MultiTenancy;
+using Volo.Abp.Settings;
 namespace Unity.GrantManager.GrantApplications.Automation.BackgroundJobs;
 public class RunApplicationAIPipelineJob(
-    IAttachmentSummaryService attachmentSummaryService,
-    IApplicationAnalysisService applicationAnalysisService,
-    IApplicationScoringService applicationScoringService,
-    IAIService aiService,
+    AIOperationServices aiOperationServices,
     IFeatureChecker featureChecker,
     ILocalEventBus localEventBus,
     ICurrentTenant currentTenant,
+    ISettingProvider settingProvider,
     ILogger<RunApplicationAIPipelineJob> logger) : AsyncBackgroundJob<RunApplicationAIPipelineJobArgs>, ITransientDependency
 {
     public override async Task ExecuteAsync(RunApplicationAIPipelineJobArgs args)
     {
         using (currentTenant.Change(args.TenantId))
         {
+            var automaticGenerationEnabled = await settingProvider.GetAsync<bool>(
+                AISettings.AutomaticGenerationEnabled, defaultValue: false);
+
+            if (!automaticGenerationEnabled)
+            {
+                logger.LogDebug("Automatic AI generation is disabled at tenant level, skipping intake pipeline for application {ApplicationId}.", args.ApplicationId);
+                return;
+            }
+
             var attachmentSummariesEnabled = await featureChecker.IsEnabledAsync("Unity.AI.AttachmentSummaries");
             var applicationAnalysisEnabled = await featureChecker.IsEnabledAsync("Unity.AI.ApplicationAnalysis");
             var scoringEnabled = await featureChecker.IsEnabledAsync("Unity.AI.Scoring");
@@ -32,7 +39,7 @@ public class RunApplicationAIPipelineJob(
                 logger.LogDebug("All AI features are disabled, skipping queued AI generation for application {ApplicationId}.", args.ApplicationId);
                 return;
             }
-            if (!await aiService.IsAvailableAsync())
+            if (!await aiOperationServices.AI.IsAvailableAsync())
             {
                 logger.LogWarning("AI service is not available, skipping queued AI generation for application {ApplicationId}.", args.ApplicationId);
                 return;
@@ -40,7 +47,7 @@ public class RunApplicationAIPipelineJob(
             logger.LogInformation("Executing queued AI content pipeline for application {ApplicationId}.", args.ApplicationId);
             if (attachmentSummariesEnabled)
             {
-                await attachmentSummaryService.GenerateForApplicationAsync(args.ApplicationId, args.PromptVersion);
+                await aiOperationServices.AttachmentSummary.GenerateForApplicationAsync(args.ApplicationId, args.PromptVersion);
             }
             Exception? analysisException = null;
             Exception? scoringException = null;
@@ -48,7 +55,7 @@ public class RunApplicationAIPipelineJob(
             {
                 try
                 {
-                    await applicationAnalysisService.RegenerateAndSaveAsync(args.ApplicationId, args.PromptVersion);
+                    await aiOperationServices.ApplicationAnalysis.RegenerateAndSaveAsync(args.ApplicationId, args.PromptVersion);
                 }
                 catch (Exception ex)
                 {
@@ -60,7 +67,7 @@ public class RunApplicationAIPipelineJob(
             {
                 try
                 {
-                    var result = await applicationScoringService.RegenerateAndSaveAsync(args.ApplicationId, args.PromptVersion);
+                    var result = await aiOperationServices.ApplicationScoring.RegenerateAndSaveAsync(args.ApplicationId, args.PromptVersion);
                     if (!string.Equals(result, "{}", StringComparison.Ordinal))
                     {
                         await localEventBus.PublishAsync(new ApplicationAIScoringGeneratedEvent

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/Handlers/CreateAIAssessmentOnScoringGeneratedHandler.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/Handlers/CreateAIAssessmentOnScoringGeneratedHandler.cs
@@ -1,18 +1,21 @@
 using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
+using Unity.AI.Settings;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Assessments;
 using Unity.GrantManager.GrantApplications.Automation.Events;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.EventBus;
 using Volo.Abp.Features;
+using Volo.Abp.Settings;
 using Volo.Abp.Uow;
 namespace Unity.GrantManager.GrantApplications.Automation.Handlers;
 public class CreateAIAssessmentOnScoringGeneratedHandler(
     AssessmentManager assessmentManager,
     IApplicationRepository applicationRepository,
     IFeatureChecker featureChecker,
+    ISettingProvider settingProvider,
     IUnitOfWorkManager unitOfWorkManager,
     ILogger<CreateAIAssessmentOnScoringGeneratedHandler> logger) : ILocalEventHandler<ApplicationAIScoringGeneratedEvent>, ITransientDependency
 {
@@ -21,6 +24,10 @@ public class CreateAIAssessmentOnScoringGeneratedHandler(
         if (eventData == null || eventData.ApplicationId == Guid.Empty)
         {
             logger.LogWarning("Event data or application ID is null in CreateAIAssessmentOnScoringGeneratedHandler.");
+            return;
+        }
+        if (!await settingProvider.GetAsync<bool>(AISettings.AutomaticGenerationEnabled, defaultValue: false))
+        {
             return;
         }
         if (!await featureChecker.IsEnabledAsync("Unity.AI.Scoring"))

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/CreateAIAssessmentOnScoringGeneratedHandlerTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/CreateAIAssessmentOnScoringGeneratedHandlerTests.cs
@@ -4,12 +4,14 @@ using Shouldly;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Unity.AI.Settings;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Assessments;
 using Unity.GrantManager.GrantApplications.Automation.Events;
 using Unity.GrantManager.GrantApplications.Automation.Handlers;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Features;
+using Volo.Abp.Settings;
 using Volo.Abp.Uow;
 using Xunit;
 using Xunit.Abstractions;
@@ -27,12 +29,21 @@ public class CreateAIAssessmentOnScoringGeneratedHandlerTests : GrantManagerAppl
         _applicationRepository = GetRequiredService<IApplicationRepository>();
         _unitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
     }
-    private CreateAIAssessmentOnScoringGeneratedHandler BuildHandler(IFeatureChecker featureChecker)
+    private CreateAIAssessmentOnScoringGeneratedHandler BuildHandler(
+        IFeatureChecker featureChecker,
+        ISettingProvider? settingProvider = null)
     {
+        var settings = settingProvider ?? Substitute.For<ISettingProvider>();
+        if (settingProvider == null)
+        {
+            settings.GetOrNullAsync(AISettings.AutomaticGenerationEnabled).Returns("true");
+        }
+
         return new CreateAIAssessmentOnScoringGeneratedHandler(
             _assessmentManager,
             _applicationRepository,
             featureChecker,
+            settings,
             _unitOfWorkManager,
             NullLogger<CreateAIAssessmentOnScoringGeneratedHandler>.Instance);
     }

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/CreateAIAssessmentOnScoringGeneratedHandlerTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/CreateAIAssessmentOnScoringGeneratedHandlerTests.cs
@@ -90,6 +90,30 @@ public class CreateAIAssessmentOnScoringGeneratedHandlerTests : GrantManagerAppl
     }
     [Fact]
     [Trait("Category", "Integration")]
+    public async Task Should_Skip_AssessmentCreation_When_AutomaticGenerationEnabled_Is_False()
+    {
+        // Arrange - automatic generation OFF at tenant level
+        var featureChecker = Substitute.For<IFeatureChecker>();
+        featureChecker.IsEnabledAsync("Unity.AI.Scoring").Returns(true);
+
+        var settings = Substitute.For<ISettingProvider>();
+        settings.GetOrNullAsync(AISettings.AutomaticGenerationEnabled).Returns("false");
+
+        var handler = BuildHandler(featureChecker, settings);
+        using var uow = _unitOfWorkManager.Begin();
+        var application = (await _applicationRepository.GetListAsync())[0];
+        var beforeCount = (await _assessmentRepository.GetQueryableAsync()).Count(a => a.IsAiAssessment);
+
+        // Act
+        await handler.HandleEventAsync(new ApplicationAIScoringGeneratedEvent { ApplicationId = application.Id });
+
+        // Assert - no new AI assessment created
+        var afterCount = (await _assessmentRepository.GetQueryableAsync()).Count(a => a.IsAiAssessment);
+        afterCount.ShouldBe(beforeCount);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
     public async Task HandleEventAsync_Should_Be_Idempotent()
     {
         var featureChecker = Substitute.For<IFeatureChecker>();

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/RunApplicationAIPipelineJobTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/RunApplicationAIPipelineJobTests.cs
@@ -4,10 +4,12 @@ using System;
 using System.Threading.Tasks;
 using Unity.AI;
 using Unity.AI.Operations;
+using Unity.AI.Settings;
 using Unity.GrantManager.GrantApplications.Automation.BackgroundJobs;
 using Volo.Abp.EventBus.Local;
 using Volo.Abp.Features;
 using Volo.Abp.MultiTenancy;
+using Volo.Abp.Settings;
 using Xunit;
 using Xunit.Abstractions;
 namespace Unity.GrantManager.GrantApplications.Automation;
@@ -16,18 +18,30 @@ public class RunApplicationAIPipelineJobTests(ITestOutputHelper outputHelper) : 
     private static RunApplicationAIPipelineJob BuildJob(
         IFeatureChecker featureChecker,
         IApplicationScoringService? scoringService = null,
-        IAIService? aiService = null)
+        IAIService? aiService = null,
+        ISettingProvider? settingProvider = null)
     {
         var ai = aiService ?? Substitute.For<IAIService>();
         ai.IsAvailableAsync().Returns(true);
-        return new RunApplicationAIPipelineJob(
+
+        var settings = settingProvider ?? Substitute.For<ISettingProvider>();
+        if (settingProvider == null)
+        {
+            settings.GetOrNullAsync(AISettings.AutomaticGenerationEnabled).Returns("true");
+        }
+
+        var aiServices = new AIOperationServices(
             Substitute.For<IAttachmentSummaryService>(),
             Substitute.For<IApplicationAnalysisService>(),
             scoringService ?? Substitute.For<IApplicationScoringService>(),
-            ai,
+            ai);
+
+        return new RunApplicationAIPipelineJob(
+            aiServices,
             featureChecker,
             Substitute.For<ILocalEventBus>(),
             Substitute.For<ICurrentTenant>(),
+            settings,
             NullLogger<RunApplicationAIPipelineJob>.Instance);
     }
     [Fact]

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/RunApplicationAIPipelineJobTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/RunApplicationAIPipelineJobTests.cs
@@ -59,4 +59,49 @@ public class RunApplicationAIPipelineJobTests(ITestOutputHelper outputHelper) : 
         // Assert - scoring service never called
         await scoringService.DidNotReceive().RegenerateAndSaveAsync(Arg.Any<Guid>(), Arg.Any<string?>());
     }
+
+    [Fact]
+    public async Task Should_Skip_Pipeline_When_AutomaticGenerationEnabled_Is_False()
+    {
+        // Arrange - automatic generation OFF at tenant level
+        var settings = Substitute.For<ISettingProvider>();
+        settings.GetOrNullAsync(AISettings.AutomaticGenerationEnabled).Returns("false");
+
+        var featureChecker = Substitute.For<IFeatureChecker>();
+        featureChecker.IsEnabledAsync(Arg.Any<string>()).Returns(true);
+
+        var scoringService = Substitute.For<IApplicationScoringService>();
+        var job = BuildJob(featureChecker, scoringService, settingProvider: settings);
+
+        // Act
+        await job.ExecuteAsync(new RunApplicationAIPipelineJobArgs { ApplicationId = Guid.NewGuid() });
+
+        // Assert - pipeline never reaches any AI service
+        await scoringService.DidNotReceive().RegenerateAndSaveAsync(Arg.Any<Guid>(), Arg.Any<string?>());
+        await featureChecker.DidNotReceive().IsEnabledAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task Should_Run_Pipeline_When_AutomaticGenerationEnabled_Is_True()
+    {
+        // Arrange - automatic generation ON, all features enabled
+        var settings = Substitute.For<ISettingProvider>();
+        settings.GetOrNullAsync(AISettings.AutomaticGenerationEnabled).Returns("true");
+
+        var featureChecker = Substitute.For<IFeatureChecker>();
+        featureChecker.IsEnabledAsync("Unity.AI.Scoring").Returns(true);
+        featureChecker.IsEnabledAsync("Unity.AI.AttachmentSummaries").Returns(false);
+        featureChecker.IsEnabledAsync("Unity.AI.ApplicationAnalysis").Returns(false);
+
+        var scoringService = Substitute.For<IApplicationScoringService>();
+        scoringService.RegenerateAndSaveAsync(Arg.Any<Guid>(), Arg.Any<string?>()).Returns("{}");
+
+        var job = BuildJob(featureChecker, scoringService, settingProvider: settings);
+
+        // Act
+        await job.ExecuteAsync(new RunApplicationAIPipelineJobArgs { ApplicationId = Guid.NewGuid() });
+
+        // Assert - pipeline reached the scoring service
+        await scoringService.Received(1).RegenerateAndSaveAsync(Arg.Any<Guid>(), Arg.Any<string?>());
+    }
 }


### PR DESCRIPTION
- Introduces two independent tenant-level toggles: **Automatically Generate AI Analysis** and **Manually Initiate AI Analysis**
- Gates the automatic AI intake pipeline and AI assessment creation on the `AutomaticGenerationEnabled` setting
- Adds a Settings UI under **Settings > AI Configuration** with Save/Discard change tracking

Notes
- `ManualGenerationEnabled` UI guard (hiding Generate buttons) is wired in **AB#32448**
- Both toggles default to `false `. Existing tenants see no change in behaviour until explicitly enabled