### PR TITLE
Feature/ab#32299 split openaiservice responsibilities

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIPromptRenderer.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIPromptRenderer.cs
@@ -28,12 +28,12 @@ public class OpenAIPromptRenderer : ITransientDependency
     private static readonly ConcurrentDictionary<string, string> PromptTemplateCache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly JsonSerializerOptions JsonLogOptions = new() { WriteIndented = true };
 
-    public string BuildApplicationAnalysisSystemPrompt(string version)
+    public static string BuildApplicationAnalysisSystemPrompt(string version)
     {
         return GetRequiredPromptTemplate(version, ApplicationAnalysisSystemTemplateName);
     }
 
-    public string BuildApplicationAnalysisUserPrompt(string version, string schema, string data, string attachments)
+    public static string BuildApplicationAnalysisUserPrompt(string version, string schema, string data, string attachments)
     {
         var replacements = new Dictionary<string, string>
         {
@@ -45,12 +45,12 @@ public class OpenAIPromptRenderer : ITransientDependency
         return RenderPromptTemplate(version, ApplicationAnalysisUserTemplateName, replacements);
     }
 
-    public string BuildAttachmentSummarySystemPrompt(string version)
+    public static string BuildAttachmentSummarySystemPrompt(string version)
     {
         return GetRequiredPromptTemplate(version, AttachmentSummarySystemTemplateName);
     }
 
-    public string BuildAttachmentSummaryUserPrompt(string version, string attachment)
+    public static string BuildAttachmentSummaryUserPrompt(string version, string attachment)
     {
         return RenderPromptTemplate(version, AttachmentSummaryUserTemplateName, new Dictionary<string, string>
         {
@@ -58,12 +58,12 @@ public class OpenAIPromptRenderer : ITransientDependency
         });
     }
 
-    public string BuildApplicationScoringSystemPrompt(string version)
+    public static string BuildApplicationScoringSystemPrompt(string version)
     {
         return GetRequiredPromptTemplate(version, ApplicationScoringSystemTemplateName);
     }
 
-    public string BuildApplicationScoringUserPrompt(string version, string data, string attachments, string section, string response)
+    public static string BuildApplicationScoringUserPrompt(string version, string data, string attachments, string section, string response)
     {
         return RenderPromptTemplate(version, ApplicationScoringUserTemplateName, new Dictionary<string, string>
         {
@@ -74,7 +74,7 @@ public class OpenAIPromptRenderer : ITransientDependency
         });
     }
 
-    public string BuildApplicationScoringResponseTemplate(string sectionPayloadJson)
+    public static string BuildApplicationScoringResponseTemplate(string sectionPayloadJson)
     {
         try
         {
@@ -119,7 +119,7 @@ public class OpenAIPromptRenderer : ITransientDependency
         }
     }
 
-    public string BuildAliasedApplicationScoringSection(string? sectionName, string sectionJson, out IReadOnlyDictionary<string, string> questionIdAliasMap)
+    public static string BuildAliasedApplicationScoringSection(string? sectionName, string sectionJson, out IReadOnlyDictionary<string, string> questionIdAliasMap)
     {
         questionIdAliasMap = new Dictionary<string, string>(StringComparer.Ordinal);
 
@@ -182,7 +182,7 @@ public class OpenAIPromptRenderer : ITransientDependency
         }
     }
 
-    public string ResolvePromptVersion(string? version)
+    public static string ResolvePromptVersion(string? version)
     {
         if (!string.IsNullOrWhiteSpace(version) &&
             PromptProfiles.TryGetValue(version.Trim(), out var selectedVersion))

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIResponseParser.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIResponseParser.cs
@@ -11,7 +11,7 @@ namespace Unity.AI.Runtime;
 
 public class OpenAIResponseParser : ITransientDependency
 {
-    public ApplicationAnalysisResponse ParseApplicationAnalysisResponse(string raw)
+    public static ApplicationAnalysisResponse ParseApplicationAnalysisResponse(string raw)
     {
         var response = new ApplicationAnalysisResponse();
         if (!TryParseJsonObjectFromResponse(AddIdsToAnalysisItems(raw), out var root))
@@ -107,7 +107,7 @@ public class OpenAIResponseParser : ITransientDependency
         }
     }
 
-    public ApplicationScoringResponse ParseApplicationScoringResponse(string raw, IReadOnlyDictionary<string, string>? questionIdAliasMap = null)
+    public static ApplicationScoringResponse ParseApplicationScoringResponse(string raw, IReadOnlyDictionary<string, string>? questionIdAliasMap = null)
     {
         var response = new ApplicationScoringResponse();
         if (!TryParseJsonObjectFromResponse(raw, out var root))

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
@@ -1,13 +1,10 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
-using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Unity.AI.Extraction;
@@ -27,22 +24,11 @@ namespace Unity.AI.Runtime
         private readonly ILogger<OpenAIRuntimeService> _logger;
         private readonly ITextExtractionService _textExtractionService;
         private readonly OpenAITransportService _openAITransportService;
-        private readonly OpenAIResponseParser _openAIResponseParser;
-        private readonly OpenAIPromptRenderer _openAIPromptRenderer;
         private readonly OpenAIConfigurationResolver _openAIConfigurationResolver;
         private readonly ICurrentTenant _currentTenant;
         private const string ApplicationAnalysisPromptType = AIPromptTypes.ApplicationAnalysis;
         private const string AttachmentSummaryPromptType = AIPromptTypes.AttachmentSummary;
         private const string ApplicationScoringPromptType = AIPromptTypes.ApplicationScoring;
-        private const string PromptVersionV0 = "v0";
-        private const string PromptVersionV1 = "v1";
-        private static readonly string PromptTemplatesFolder = Path.Combine("AI", "Prompts", "Versions");
-        private const string ApplicationAnalysisSystemTemplateName = "application-analysis.system";
-        private const string ApplicationAnalysisUserTemplateName = "application-analysis.user";
-        private const string AttachmentSummarySystemTemplateName = "attachment-summary.system";
-        private const string AttachmentSummaryUserTemplateName = "attachment-summary.user";
-        private const string ApplicationScoringSystemTemplateName = "application-scoring.system";
-        private const string ApplicationScoringUserTemplateName = "application-scoring.user";
         private const string AIServiceNotConfiguredMessage = "AI service not available - service not configured.";
         private const string AIServiceTemporarilyUnavailableMessage = "AI request failed - service temporarily unavailable.";
         private const string AIRequestFailedRetryMessage = "AI request failed - please try again later.";
@@ -65,22 +51,11 @@ namespace Unity.AI.Runtime
 
         private static readonly JsonSerializerOptions JsonLogOptions = new() { WriteIndented = true };
 
-        private static readonly Dictionary<string, string> PromptProfiles =
-            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                [PromptVersionV0] = PromptVersionV0,
-                [PromptVersionV1] = PromptVersionV1
-            };
-        private static readonly ConcurrentDictionary<string, string> PromptTemplateCache = new(StringComparer.OrdinalIgnoreCase);
-
         public OpenAIRuntimeService(
-            HttpClient httpClient,
             IConfiguration configuration,
             ILogger<OpenAIRuntimeService> logger,
             ITextExtractionService textExtractionService,
             OpenAITransportService openAITransportService,
-            OpenAIResponseParser openAIResponseParser,
-            OpenAIPromptRenderer openAIPromptRenderer,
             OpenAIConfigurationResolver openAIConfigurationResolver,
             ICurrentTenant currentTenant)
         {
@@ -88,8 +63,6 @@ namespace Unity.AI.Runtime
             _logger = logger;
             _textExtractionService = textExtractionService;
             _openAITransportService = openAITransportService;
-            _openAIResponseParser = openAIResponseParser;
-            _openAIPromptRenderer = openAIPromptRenderer;
             _openAIConfigurationResolver = openAIConfigurationResolver;
             _currentTenant = currentTenant;
         }
@@ -121,7 +94,7 @@ namespace Unity.AI.Runtime
         public async Task<ApplicationAnalysisResponse> GenerateApplicationAnalysisAsync(ApplicationAnalysisRequest request)
         {
             ArgumentNullException.ThrowIfNull(request);
-            var promptVersion = _openAIPromptRenderer.ResolvePromptVersion(request.PromptVersion ?? ResolvePromptVersionSetting(ApplicationAnalysisPromptType));
+            var promptVersion = OpenAIPromptRenderer.ResolvePromptVersion(request.PromptVersion ?? ResolvePromptVersionSetting(ApplicationAnalysisPromptType));
             var data = JsonSerializer.Serialize(request.Data, JsonLogOptions);
             var schema = JsonSerializer.Serialize(request.Schema, JsonLogOptions);
 
@@ -134,8 +107,8 @@ namespace Unity.AI.Runtime
                 .Cast<object>();
 
             var attachments = JsonSerializer.Serialize(attachmentsPayload, JsonLogOptions);
-            var systemPrompt = _openAIPromptRenderer.BuildApplicationAnalysisSystemPrompt(promptVersion);
-            var applicationAnalysisContent = _openAIPromptRenderer.BuildApplicationAnalysisUserPrompt(
+            var systemPrompt = OpenAIPromptRenderer.BuildApplicationAnalysisSystemPrompt(promptVersion);
+            var applicationAnalysisContent = OpenAIPromptRenderer.BuildApplicationAnalysisUserPrompt(
                 promptVersion,
                 schema,
                 data,
@@ -157,7 +130,7 @@ namespace Unity.AI.Runtime
                 return new ApplicationAnalysisResponse();
             }
 
-            return _openAIResponseParser.ParseApplicationAnalysisResponse(result.Content);
+            return OpenAIResponseParser.ParseApplicationAnalysisResponse(result.Content);
         }
 
         public async Task<AttachmentSummaryResponse> GenerateAttachmentSummaryAsync(AttachmentSummaryRequest request)
@@ -166,12 +139,12 @@ namespace Unity.AI.Runtime
             var fileName = request.FileName ?? string.Empty;
             var fileContent = request.FileContent ?? Array.Empty<byte>();
             var contentType = request.ContentType ?? "application/octet-stream";
-            var promptVersion = _openAIPromptRenderer.ResolvePromptVersion(request.PromptVersion ?? ResolvePromptVersionSetting(AttachmentSummaryPromptType));
+            var promptVersion = OpenAIPromptRenderer.ResolvePromptVersion(request.PromptVersion ?? ResolvePromptVersionSetting(AttachmentSummaryPromptType));
 
             try
             {
                 var extractedText = await _textExtractionService.ExtractTextAsync(fileName, fileContent, contentType);
-                var prompt = _openAIPromptRenderer.BuildAttachmentSummarySystemPrompt(promptVersion);
+                var prompt = OpenAIPromptRenderer.BuildAttachmentSummarySystemPrompt(promptVersion);
 
                 var attachmentText = string.IsNullOrWhiteSpace(extractedText) ? null : extractedText;
                 if (attachmentText != null)
@@ -191,7 +164,7 @@ namespace Unity.AI.Runtime
                     text = attachmentText
                 };
                 var attachment = JsonSerializer.Serialize(attachmentPayload, JsonLogOptions);
-                var contentToAnalyze = _openAIPromptRenderer.BuildAttachmentSummaryUserPrompt(promptVersion, attachment);
+                var contentToAnalyze = OpenAIPromptRenderer.BuildAttachmentSummaryUserPrompt(promptVersion, attachment);
 
                 await LogPromptInputAsync(AttachmentSummaryPromptType, promptVersion, prompt, contentToAnalyze);
             var result = await GenerateWithRetryAsync(
@@ -232,7 +205,7 @@ namespace Unity.AI.Runtime
         public async Task<ApplicationScoringResponse> GenerateApplicationScoringAsync(ApplicationScoringRequest request)
         {
             ArgumentNullException.ThrowIfNull(request);
-            var promptVersion = _openAIPromptRenderer.ResolvePromptVersion(request.PromptVersion ?? ResolvePromptVersionSetting(ApplicationScoringPromptType));
+            var promptVersion = OpenAIPromptRenderer.ResolvePromptVersion(request.PromptVersion ?? ResolvePromptVersionSetting(ApplicationScoringPromptType));
             var dataJson = JsonSerializer.Serialize(request.Data, JsonLogOptions);
             var sectionJson = JsonSerializer.Serialize(request.SectionSchema, JsonLogOptions);
 
@@ -251,8 +224,8 @@ namespace Unity.AI.Runtime
                     ? string.Join("\n- ", attachmentSummaries.Select((summary, index) => $"Attachment {index + 1}: {summary}"))
                     : "No attachments provided.";
 
-                var section = _openAIPromptRenderer.BuildAliasedApplicationScoringSection(request.SectionName, sectionJson, out var questionIdAliasMap);
-                var response = _openAIPromptRenderer.BuildApplicationScoringResponseTemplate(section);
+                var section = OpenAIPromptRenderer.BuildAliasedApplicationScoringSection(request.SectionName, sectionJson, out var questionIdAliasMap);
+                var response = OpenAIPromptRenderer.BuildApplicationScoringResponseTemplate(section);
                 if (response == "{}")
                 {
                     _logger.LogWarning(
@@ -261,13 +234,13 @@ namespace Unity.AI.Runtime
                     return new ApplicationScoringResponse();
                 }
 
-                var applicationScoringContent = _openAIPromptRenderer.BuildApplicationScoringUserPrompt(
+                var applicationScoringContent = OpenAIPromptRenderer.BuildApplicationScoringUserPrompt(
                     promptVersion,
                     dataJson,
                     attachments,
                     section,
                     response);
-                var systemPrompt = _openAIPromptRenderer.BuildApplicationScoringSystemPrompt(promptVersion);
+                var systemPrompt = OpenAIPromptRenderer.BuildApplicationScoringSystemPrompt(promptVersion);
 
                 await LogPromptInputAsync(ApplicationScoringPromptType, promptVersion, systemPrompt, applicationScoringContent);
                 var result = await GenerateWithRetryAsync(
@@ -286,7 +259,7 @@ namespace Unity.AI.Runtime
                     return new ApplicationScoringResponse();
                 }
 
-                return _openAIResponseParser.ParseApplicationScoringResponse(result.Content, questionIdAliasMap);
+                return OpenAIResponseParser.ParseApplicationScoringResponse(result.Content, questionIdAliasMap);
             }
             catch (Exception ex)
             {
@@ -360,38 +333,6 @@ namespace Unity.AI.Runtime
             };
         }
 
-        private static AIOperationResult MapFailureOutcome(HttpStatusCode statusCode, AIProviderResult response)
-        {
-            var statusCodeValue = (int)statusCode;
-
-            if (statusCode == HttpStatusCode.RequestTimeout
-                || statusCode == (HttpStatusCode)429
-                || statusCodeValue >= 500)
-            {
-                return AIOperationResult.TransientFailure(response);
-            }
-
-            return AIOperationResult.PermanentFailure(response);
-        }
-
-        private static AIProviderResult BuildProviderResponseFromMetadata(
-            string content,
-            string? rawResponse,
-            AIProviderResponseMetadata? metadata,
-            int? httpStatusCode = null)
-        {
-            return new AIProviderResult(
-                content,
-                rawResponse ?? string.Empty,
-                metadata?.Model,
-                metadata?.FinishReason,
-                httpStatusCode,
-                metadata?.PromptTokens,
-                metadata?.CompletionTokens,
-                metadata?.TotalTokens,
-                metadata?.ReasoningTokens);
-        }
-
         private static AIProviderResponseMetadata? TryExtractProviderMetadata(string? responseContent)
         {
             if (string.IsNullOrWhiteSpace(responseContent))
@@ -442,53 +383,6 @@ namespace Unity.AI.Runtime
             {
                 return null;
             }
-        }
-
-        private void LogProviderMetadata(
-            string? operationName,
-            string? promptVersion,
-            string? fileName,
-            AIProviderResult response,
-            bool success)
-        {
-            if (string.IsNullOrWhiteSpace(response.Model)
-                && string.IsNullOrWhiteSpace(response.FinishReason)
-                && response.HttpStatusCode == null
-                && response.PromptTokens == null
-                && response.CompletionTokens == null
-                && response.TotalTokens == null
-                && response.ReasoningTokens == null)
-            {
-                return;
-            }
-
-            if (response.PromptTokens != null || response.CompletionTokens != null || response.TotalTokens != null)
-            {
-                _logger.LogInformation(
-                    "AI token usage. OperationName={OperationName}, InputTokens={InputTokens}, CompletionTokens={CompletionTokens}, TotalTokens={TotalTokens}, Environment={Environment}, TenantId={TenantId}, Status={Status}, PromptVersion={PromptVersion}, Model={Model}, HttpStatusCode={HttpStatusCode}, FileName={FileName}",
-                    operationName ?? "completion",
-                    response.PromptTokens,
-                    response.CompletionTokens,
-                    response.TotalTokens,
-                    ResolveEnvironmentName(),
-                    _currentTenant.Id,
-                    success ? "success" : "failed",
-                    promptVersion,
-                    response.Model,
-                    response.HttpStatusCode,
-                    fileName);
-            }
-
-            _logger.LogDebug(
-                "AI provider response metadata for {OperationName}: Model={Model}, FinishReason={FinishReason}, HttpStatusCode={HttpStatusCode}, PromptTokens={PromptTokens}, CompletionTokens={CompletionTokens}, TotalTokens={TotalTokens}, ReasoningTokens={ReasoningTokens}",
-                operationName ?? "completion",
-                response.Model,
-                response.FinishReason,
-                response.HttpStatusCode,
-                response.PromptTokens,
-                response.CompletionTokens,
-                response.TotalTokens,
-                response.ReasoningTokens);
         }
 
         private static int? TryGetInt32(JsonElement element, string propertyName)

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAITransportService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAITransportService.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Unity.AI.Models;
 using Volo.Abp.DependencyInjection;
 
 namespace Unity.AI.Runtime;

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationAnalysisAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationAnalysisAppService.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 using Unity.AI;

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationScoringJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationScoringJob.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Logging;
-using System;
 using System.Threading.Tasks;
 using Unity.GrantManager.GrantApplications;
 using Unity.GrantManager.GrantApplications.Automation.Events;


### PR DESCRIPTION
## Pull Request Overview

This pull request is a small cleanup on top of the already-merged OpenAI runtime split. It applies Sonar-driven simplifications only, with no behavioral change intended.

The cleanup keeps the existing AI flows for attachment summary, application analysis, and application scoring working the same, while trimming dead helpers, redundant usings, and unnecessary instance members.

**Changes:**
- Marked prompt-render and response-parse helpers static where they do not use instance state
- Removed dead runtime helpers and unused imports from the OpenAI runtime files
- Trimmed the runtime service constructor and field set to match the actual call flow
- Kept the existing AI behavior and contracts unchanged
