### PR TITLE
AB#32299 remove unused OpenAI runtime import

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
@@ -12,7 +12,6 @@ using Unity.AI.Prompts;
 using Unity.AI.Requests;
 using Unity.AI.Responses;
 using Volo.Abp.DependencyInjection;
-using Volo.Abp.MultiTenancy;
 
 namespace Unity.AI.Runtime
 {


### PR DESCRIPTION
## Pull Request Overview

Removed one unused `Volo.Abp.MultiTenancy` import from `OpenAIRuntimeService.cs`.

**Changes:**
- No behavior change
- Sonar cleanup only
