### PR TITLE
bugfix/AB#31682 - Adjust minimum height for DataTable scroll body

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/table-utils.js
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/table-utils.js
@@ -692,7 +692,7 @@ function createNumberFormatter() {
  */
 function addDataTableFixCSS() {
     if (!$('#dt-column-fix-css').length) {
-        $('<style id="dt-column-fix-css"> table.dataTable { width: 100%; } .dt-loading { visibility: hidden; } .dt-scroll-body { min-height: 200px; } </style>').appendTo('head');
+        $('<style id="dt-column-fix-css"> table.dataTable { width: 100%; } .dt-loading { visibility: hidden; } .dt-scroll-body { min-height: 20px; } </style>').appendTo('head');
     }
 }
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the minimum height of the `.dt-scroll-body` element in the DataTable CSS. The minimum height is reduced from 200px to 20px, likely to improve table rendering in scenarios with little or no data.

* Reduced the minimum height of `.dt-scroll-body` in the injected DataTable CSS from 200px to 20px in `table-utils.js`