### PR TITLE
Bugfix/ab#32583 chefs double line actions

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/ChefsAttachments.css
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/ChefsAttachments.css
@@ -6,12 +6,20 @@
 
 .attachments__title-button-split {
     display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: stretch;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.submission-title-and-actions {
+    display: flex;
     flex-direction: row;
     justify-content: space-between;
-    align-items: flex-start;
-    flex-wrap: wrap;
-    gap: 8px 8px;
-    margin-bottom: 8px;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: nowrap;
 }
 
 .sorting_disabled:before,
@@ -24,18 +32,28 @@
     align-items: center;
     height: 36px;
     padding-top: 0;
+    flex: 0 0 auto;
 }
 
 .submission-button-section {
     display: flex;
-    flex: 1 1 0;
-    margin-left: auto;
-    flex-wrap: wrap;
+    flex: 1 1 auto;
+    flex-wrap: nowrap;
     align-items: center;
     align-content: center;
     justify-content: flex-end;
     gap: 6px;
     min-width: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
+.submission-button-section--top {
+    justify-content: flex-end;
+}
+
+.submission-button-section--bottom {
+    justify-content: flex-end;
 }
 
 .submission-button-section .btn {
@@ -46,6 +64,10 @@
     justify-content: center;
     line-height: 1;
     white-space: nowrap;
+}
+
+.submission-button-section .btn + .btn {
+    margin-left: 0;
 }
 
 .submission-button-section .button-content {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/ChefsAttachments.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/ChefsAttachments.js
@@ -233,9 +233,7 @@ $(function () {
         $toggleAllAISummariesButton.on('click', function () {
             const $button = $(this);
             const $icon = $button.find('i');
-            const $text = $button.contents().filter(function () {
-                return this.nodeType === 3;
-            });
+            const $label = $button.find('.toggle-ai-summaries-label');
 
             // Don't do anything if button is disabled
             if ($button.prop('disabled')) {
@@ -262,7 +260,7 @@ $(function () {
                     }
                 });
                 $icon.removeClass('fa-chevron-up').addClass('fa-chevron-down');
-                $text.replaceWith('Show Summaries');
+                $label.text('Show Summaries');
                 $button.attr('title', 'Show AI Summaries');
                 allAISummariesExpanded = false;
             } else {
@@ -290,7 +288,7 @@ $(function () {
                     }
                 });
                 $icon.removeClass('fa-chevron-down').addClass('fa-chevron-up');
-                $text.replaceWith('Hide Summaries');
+                $label.text('Hide Summaries');
                 $button.attr('title', 'Hide AI Summaries');
                 allAISummariesExpanded = true;
             }
@@ -302,11 +300,9 @@ $(function () {
         if (allAISummariesExpanded) {
             const $button = $('#toggleAllAISummaries');
             const $icon = $button.find('i');
-            const $text = $button.contents().filter(function () {
-                return this.nodeType === 3;
-            });
+            const $label = $button.find('.toggle-ai-summaries-label');
             $icon.removeClass('fa-chevron-up').addClass('fa-chevron-down');
-            $text.replaceWith('Show Summaries');
+            $label.text('Show Summaries');
             $button.attr('title', 'Show AI Summaries');
             allAISummariesExpanded = false;
         }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/Default.cshtml
@@ -3,22 +3,26 @@
 
 @inject IStringLocalizer<GrantManagerResource> L
 <div class="attachments__title-button-split">
-    <div class="submission-title">
-        <h6 class="fw-bold px-3 m-0">Submission Attachments</h6>
+    <div class="submission-title-and-actions">
+        <div class="submission-title">
+            <h6 class="fw-bold px-3 m-0">Submission Attachments</h6>
+        </div>
+        <div class="submission-button-section me-3 submission-button-section--top">
+            <button type="button" class="btn unt-btn-outline-primary btn-outline-primary" id="btn-toggle-filter-submissions" title="Filter">
+                <span>Filter</span>
+            </button>
+            <button type="button" class="btn unt-btn-outline-primary btn-outline-primary" id="downloadSelected">
+                <span class="ai-button-content">
+                    <i class="unt-icon-sm fl fl-download"></i>
+                    <span>Download All</span>
+                </span>
+            </button>
+            <button type="button" class="btn unt-btn-outline-primary btn-outline-primary me-2" id="resyncSubmissionAttachments" abp-tooltip="@L["ApplicationList:ResyncSubmissionAttachmentsButton"].Value">
+                <i class="unt-icon-sm fl fl-synch"></i>
+            </button>
+        </div>
     </div>
-    <div class="submission-button-section me-3">
-        <button type="button" class="btn unt-btn-outline-primary btn-outline-primary" id="btn-toggle-filter-submissions" title="Filter">
-            <span>Filter</span>
-        </button>
-        <button type="button" class="btn unt-btn-outline-primary btn-outline-primary" id="downloadSelected">
-            <span class="ai-button-content">
-                <i class="unt-icon-sm fl fl-download"></i>
-                <span>Download All</span>
-            </span>
-        </button>
-        <button type="button" class="btn unt-btn-outline-primary btn-outline-primary me-2" id="resyncSubmissionAttachments" abp-tooltip="@L["ApplicationList:ResyncSubmissionAttachmentsButton"].Value">
-            <i class="unt-icon-sm fl fl-synch"></i>
-        </button>
+    <div class="submission-button-section me-3 submission-button-section--bottom">
         @if (ViewBag.IsAIAttachmentSummariesGenerateEnabled)
         {
             <button type="button" class="btn unt-btn-outline-primary btn-outline-primary" id="generateAiSummaries" title="Generate AI Summaries">

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/Default.cshtml
@@ -7,24 +7,6 @@
         <h6 class="fw-bold px-3 m-0">Submission Attachments</h6>
     </div>
     <div class="submission-button-section me-3">
-        @if (ViewBag.IsAIAttachmentSummariesGenerateEnabled)
-        {
-            <button type="button" class="btn unt-btn-outline-primary btn-outline-primary" id="generateAiSummaries" title="Generate AI Summaries">
-                <span class="ai-button-content">
-                    <i class="unt-icon-sm fa-solid fa-wand-magic-sparkles"></i>
-                    <span>Generate Summary</span>
-                </span>
-            </button>
-        }
-        @if (ViewBag.IsAIAttachmentSummariesEnabled)
-        {
-            <button type="button" class="btn unt-btn-outline-primary btn-outline-primary me-2" id="toggleAllAISummaries" title="Toggle AI Summaries">
-                <span class="ai-button-content">
-                    <i class="unt-icon-sm fa-solid fa-chevron-down"></i>
-                    <span class="toggle-ai-summaries-label">Show Summaries</span>
-                </span>
-            </button>
-        }
         <button type="button" class="btn unt-btn-outline-primary btn-outline-primary" id="btn-toggle-filter-submissions" title="Filter">
             <span>Filter</span>
         </button>
@@ -34,7 +16,27 @@
                 <span>Download All</span>
             </span>
         </button>
-        <button type="button" class="btn unt-btn-outline-primary btn-outline-primary me-2" id="resyncSubmissionAttachments" abp-tooltip="@L["ApplicationList:ResyncSubmissionAttachmentsButton"].Value"><i class="unt-icon-sm fl fl-synch"></i></button>
+        <button type="button" class="btn unt-btn-outline-primary btn-outline-primary me-2" id="resyncSubmissionAttachments" abp-tooltip="@L["ApplicationList:ResyncSubmissionAttachmentsButton"].Value">
+            <i class="unt-icon-sm fl fl-synch"></i>
+        </button>
+        @if (ViewBag.IsAIAttachmentSummariesGenerateEnabled)
+        {
+            <button type="button" class="btn unt-btn-outline-primary btn-outline-primary" id="generateAiSummaries" title="Generate AI Summaries">
+                <span class="ai-button-content">
+                    <i class="unt-icon-sm fa-solid fa-wand-magic-sparkles"></i>
+                    <span>Generate Summaries</span>
+                </span>
+            </button>
+        }
+        @if (ViewBag.IsAIAttachmentSummariesEnabled)
+        {
+            <button type="button" class="btn unt-btn-outline-primary btn-outline-primary me-2" id="toggleAllAISummaries" title="Show AI Summaries">
+                <span class="ai-button-content">
+                    <i class="unt-icon-sm fa-solid fa-chevron-down"></i>
+                    <span class="toggle-ai-summaries-label">Show Summaries</span>
+                </span>
+            </button>
+        }
     </div>
 </div>
 <div class="px-3">


### PR DESCRIPTION
## Pull request overview

Refined the CHEFS attachments toolbar to keep the layout stable while preserving the AI summary flow introduced in the polling branch. The attachment controls now stay grouped on a fixed top row, while the AI summary actions remain on a fixed second row. The summary toggle also updates its label cleanly without duplicating text when clicked.

**Changes:**
- Moved `Filter`, `Download All`, and `Sync` into the top CHEFS toolbar row
- Moved `Generate Summaries` and `Show Summaries` / `Hide Summaries` into a separate second row
- Kept both rows nowrap so the layout stays consistent across widths
- Updated the summary toggle to change the dedicated label span instead of replacing raw text nodes
- Preserved the application-wide summary generation and polling behavior from the AI branch