### PR TITLE
bugfix/AB#32736 Reconciliation Submitter Missing

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/UnityAdmin/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/UnityAdmin/Index.js
@@ -145,7 +145,7 @@ $(function () {
                     },
                     {
                         title: l('Submitter'),
-                        data: 'name',
+                        data: 'createdBy',
                         render: function (data) {
                             return data;
                         }


### PR DESCRIPTION
Updating so the submitter column is using the 'createdBy' data from CHEFs instead of the user name which is usually blank