### PR TITLE
AB#32770: Move Default SiteId from Applicants to Applications

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application.Contracts/PaymentRequests/IPaymentRequestAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application.Contracts/PaymentRequests/IPaymentRequestAppService.cs
@@ -21,6 +21,7 @@ namespace Unity.Payments.PaymentRequests
         Task<decimal?> GetUserPaymentThresholdAsync();
         Task ManuallyAddPaymentRequestsToReconciliationQueue(List<Guid> paymentRequestIds);
         Task<List<PaymentRequestDto>> GetPaymentPendingListByCorrelationIdAsync(Guid applicationId);
+        Task<List<PaymentRequestDto>> GetPaymentPendingListByCorrelationIdsAsync(IEnumerable<Guid> correlationIds);
         Task<ApplicationPaymentRollupDto> GetApplicationPaymentRollupAsync(Guid applicationId);
         Task<Dictionary<Guid, ApplicationPaymentRollupDto>> GetApplicationPaymentRollupBatchAsync(List<Guid> applicationIds);
     }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application.Contracts/Suppliers/CreateSupplierDto.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application.Contracts/Suppliers/CreateSupplierDto.cs
@@ -5,7 +5,5 @@ namespace Unity.Payments.Suppliers
     [Serializable]
     public class CreateSupplierDto : UpsertSupplierDtoBase
     {
-        public Guid CorrelationId { get; set; }
-        public string CorrelationProvider { get; set; } = null!;        
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application.Contracts/Suppliers/UpdateSupplierDto.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application.Contracts/Suppliers/UpdateSupplierDto.cs
@@ -7,8 +7,6 @@ namespace Unity.Payments.Suppliers
     public class UpdateSupplierDto : UpsertSupplierDtoBase
     {
         public Guid Id { get; set; }
-        public Guid CorrelationId { get; set; }
-        public string CorrelationProvider { get; set; } = null!;
         public List<SiteDto> Sites { get; set; } = new List<SiteDto>();
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application.Contracts/Suppliers/UpsertSupplierEto.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application.Contracts/Suppliers/UpsertSupplierEto.cs
@@ -15,8 +15,7 @@ namespace Unity.Payments.Suppliers
         public string? SupplierProtected { get; set; }
         public string? StandardIndustryClassification { get; set; }
         public DateTime? LastUpdatedInCAS { get; set; }
-        public Guid CorrelationId { get; set; }
-        public string CorrelationProvider { get; set; } = string.Empty;
+        public Guid ApplicantId { get; set; }
         public List<SiteEto> SiteEtos { get; set; } = new List<SiteEto>();
         public Guid? ApplicationId { get; set; }
     }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Domain/PaymentRequests/IPaymentRequestRepository.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Domain/PaymentRequests/IPaymentRequestRepository.cs
@@ -15,6 +15,7 @@ namespace Unity.Payments.Domain.PaymentRequests
         Task<PaymentRequest?> GetPaymentRequestByInvoiceNumber(string invoiceNumber);
         Task<List<PaymentRequest>> GetPaymentRequestsByFailedsStatusAsync();
         Task<List<PaymentRequest>> GetPaymentPendingListByCorrelationIdAsync(Guid correlationId);
+        Task<List<PaymentRequest>> GetPaymentPendingListByCorrelationIdsAsync(IEnumerable<Guid> correlationIds);
         Task<List<ApplicationPaymentRollupDto>> GetBatchPaymentRollupsByCorrelationIdsAsync(List<Guid> correlationIds);
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Domain/Services/IPaymentRequestQueryManager.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Domain/Services/IPaymentRequestQueryManager.cs
@@ -35,6 +35,7 @@ namespace Unity.Payments.Domain.Services
 
         // Pending Payments
         Task<List<PaymentRequestDto>> GetPaymentPendingListByCorrelationIdAsync(Guid applicationId);
+        Task<List<PaymentRequestDto>> GetPaymentPendingListByCorrelationIdsAsync(IEnumerable<Guid> correlationIds);
 
         // Payment Rollups (paid + pending aggregation)
         Task<ApplicationPaymentRollupDto> GetApplicationPaymentRollupAsync(Guid applicationId, List<Guid> childApplicationIds);

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Domain/Services/PaymentRequestQueryManager.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Domain/Services/PaymentRequestQueryManager.cs
@@ -223,6 +223,12 @@ namespace Unity.Payments.Domain.Services
             return objectMapper.Map<List<PaymentRequest>, List<PaymentRequestDto>>(payments);
         }
 
+        public async Task<List<PaymentRequestDto>> GetPaymentPendingListByCorrelationIdsAsync(IEnumerable<Guid> correlationIds)
+        {
+            var payments = await paymentRequestRepository.GetPaymentPendingListByCorrelationIdsAsync(correlationIds);
+            return objectMapper.Map<List<PaymentRequest>, List<PaymentRequestDto>>(payments);
+        }
+
         /// <summary>
         /// Retrieves a payment rollup for the specified application and its associated child applications.
         /// </summary>

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Domain/Suppliers/ISupplierRepository.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Domain/Suppliers/ISupplierRepository.cs
@@ -6,7 +6,6 @@ namespace Unity.Payments.Domain.Suppliers
 {
     public interface ISupplierRepository : IBasicRepository<Supplier, Guid>
     {
-        Task<Supplier?> GetByCorrelationAsync(Guid correlationId, string correlationProvider, bool includeDetails = false);
         Task<Supplier?> GetBySupplierNumberAsync(string supplierNumber, bool includeDetails = false);
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Domain/Suppliers/Supplier.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Domain/Suppliers/Supplier.cs
@@ -2,14 +2,13 @@
 using System.Collections.ObjectModel;
 using System.Linq;
 using Unity.Payments.Enums;
-using Unity.Modules.Shared.Correlation;
 using Volo.Abp.Domain.Entities.Auditing;
 using Volo.Abp.MultiTenancy;
 using Unity.Payments.Domain.Suppliers.ValueObjects;
 
 namespace Unity.Payments.Domain.Suppliers
 {
-    public class Supplier : FullAuditedAggregateRoot<Guid>, IMultiTenant, ICorrelationEntity
+    public class Supplier : FullAuditedAggregateRoot<Guid>, IMultiTenant
     {
         public Guid? TenantId { get; set; }
         public virtual string? Name { get; set; } = string.Empty;
@@ -30,10 +29,6 @@ namespace Unity.Payments.Domain.Suppliers
         public virtual string? Province { get; private set; }
         public virtual string? PostalCode { get; private set; }
 
-        // External Correlation
-        public virtual string CorrelationProvider { get; set; } = string.Empty;
-        public virtual Guid CorrelationId { get; set; }
-
         protected Supplier()
         {
             /* This constructor is for ORMs to be used while getting the entity from the database. */
@@ -43,14 +38,11 @@ namespace Unity.Payments.Domain.Suppliers
         public Supplier(Guid id,
             string? name,
             string? number,
-            Correlation correlation,
             MailingAddress? mailingAddress = default)
            : base(id)
         {
             Name = name;
             Number = number;
-            CorrelationId = correlation.CorrelationId;
-            CorrelationProvider = correlation.CorrelationProvider;
             Sites = [];
             MailingAddress = mailingAddress?.AddressLine;
             City = mailingAddress?.City;
@@ -60,7 +52,6 @@ namespace Unity.Payments.Domain.Suppliers
 
         public Supplier(Guid id,
             SupplierBasicInfo basicInfo,
-            Correlation correlation,
             ProviderInfo? providerInfo = default,
             SupplierStatus? supplierStatus = default,
             CasMetadata? casMetadata = default,
@@ -76,8 +67,6 @@ namespace Unity.Payments.Domain.Suppliers
             SupplierProtected = supplierStatus?.SupplierProtected ?? SupplierProtected;
             StandardIndustryClassification = supplierStatus?.StandardIndustryClassification ?? StandardIndustryClassification;
             LastUpdatedInCAS = casMetadata?.LastUpdatedInCAS ?? LastUpdatedInCAS;
-            CorrelationId = correlation.CorrelationId;
-            CorrelationProvider = correlation.CorrelationProvider;
             Sites = [];
             MailingAddress = mailingAddress?.AddressLine;
             City = mailingAddress?.City;

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/EntityFrameworkCore/Repositories/PaymentRequestRepository.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/EntityFrameworkCore/Repositories/PaymentRequestRepository.cs
@@ -100,6 +100,21 @@ namespace Unity.Payments.Repositories
                         .ToListAsync();
         }
 
+        public async Task<List<PaymentRequest>> GetPaymentPendingListByCorrelationIdsAsync(IEnumerable<Guid> correlationIds)
+        {
+            var idList = correlationIds?.ToList() ?? new List<Guid>();
+            if (idList.Count == 0)
+            {
+                return new List<PaymentRequest>();
+            }
+
+            var dbSet = await GetDbSetAsync();
+            return await dbSet.Where(p => idList.Contains(p.CorrelationId))
+                        .Where(p => p.Status == PaymentRequestStatus.L1Pending || p.Status == PaymentRequestStatus.L2Pending)
+                        .IncludeDetails()
+                        .ToListAsync();
+        }
+
         /// <summary>
         /// Asynchronously retrieves payment rollup information for each specified correlation ID.
         /// </summary>

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/EntityFrameworkCore/Repositories/PaymentRequestRepository.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/EntityFrameworkCore/Repositories/PaymentRequestRepository.cs
@@ -95,7 +95,7 @@ namespace Unity.Payments.Repositories
         {
             var dbSet = await GetDbSetAsync();
             return await dbSet.Where(p => p.CorrelationId.Equals(correlationId))
-                        .Where(p => p.Status == PaymentRequestStatus.L1Pending || p.Status == PaymentRequestStatus.L2Pending)
+                        .Where(p => p.Status == PaymentRequestStatus.L1Pending || p.Status == PaymentRequestStatus.L2Pending || p.Status == PaymentRequestStatus.L3Pending)
                         .IncludeDetails()
                         .ToListAsync();
         }
@@ -110,7 +110,7 @@ namespace Unity.Payments.Repositories
 
             var dbSet = await GetDbSetAsync();
             return await dbSet.Where(p => idList.Contains(p.CorrelationId))
-                        .Where(p => p.Status == PaymentRequestStatus.L1Pending || p.Status == PaymentRequestStatus.L2Pending)
+                        .Where(p => p.Status == PaymentRequestStatus.L1Pending || p.Status == PaymentRequestStatus.L2Pending || p.Status == PaymentRequestStatus.L3Pending)
                         .IncludeDetails()
                         .ToListAsync();
         }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/EntityFrameworkCore/Repositories/SupplierRepository.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/EntityFrameworkCore/Repositories/SupplierRepository.cs
@@ -16,15 +16,6 @@ namespace Unity.Payments.Repositories
         {
         }
 
-        public async Task<Supplier?> GetByCorrelationAsync(Guid correlationId, string correlationProvider, bool includeDetails = false)
-        {
-            var dbSet = await GetDbSetAsync();         
-            return await dbSet
-                    .IncludeDetails(includeDetails)
-                    .FirstOrDefaultAsync(s => s.CorrelationId == correlationId
-                        && s.CorrelationProvider == correlationProvider);
-        }
-
         public async Task<Supplier?> GetBySupplierNumberAsync(string supplierNumber, bool includeDetails = false)
         {
             var dbSet = await GetDbSetAsync();

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Handlers/UpsertSupplierHandler.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Handlers/UpsertSupplierHandler.cs
@@ -39,7 +39,7 @@ namespace Unity.Payments.Handlers
                 new ApplicantSupplierEto
                 {
                     SupplierId = supplierDto.Id,
-                    ApplicantId = eventData.CorrelationId,
+                    ApplicantId = eventData.ApplicantId,
                     ExistingSitesDictionary = existingSitesDictionary,
                     SiteEtos = eventData.SiteEtos
                 }
@@ -106,7 +106,7 @@ namespace Unity.Payments.Handlers
             }
             catch (Exception ex)
             {
-                logger.LogWarning(ex, "Unable to resolve default payment group for correlation {CorrelationId}", eventData.CorrelationId);
+                logger.LogWarning(ex, "Unable to resolve default payment group for applicant {ApplicantId}", eventData.ApplicantId);
             }
 
             return fallbackPaymentGroup;
@@ -146,8 +146,6 @@ namespace Unity.Payments.Handlers
                 SupplierProtected = eventData.SupplierProtected,
                 StandardIndustryClassification = eventData.StandardIndustryClassification,
                 LastUpdatedInCAS = eventData.LastUpdatedInCAS,
-                CorrelationId = eventData.CorrelationId,
-                CorrelationProvider = eventData.CorrelationProvider,
             };
         }
 
@@ -164,8 +162,6 @@ namespace Unity.Payments.Handlers
                 SupplierProtected = eventData.SupplierProtected,
                 StandardIndustryClassification = eventData.StandardIndustryClassification,
                 LastUpdatedInCAS = eventData.LastUpdatedInCAS,
-                CorrelationId = eventData.CorrelationId,
-                CorrelationProvider = eventData.CorrelationProvider,
             };
         }
     }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Integrations/Cas/SupplierService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Integrations/Cas/SupplierService.cs
@@ -10,7 +10,6 @@ using Unity.Modules.Shared.Http;
 using Volo.Abp.EventBus.Local;
 using Unity.GrantManager.Payments;
 using Unity.Payments.Suppliers;
-using Unity.Modules.Shared.Correlation;
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Authorization;
@@ -108,8 +107,7 @@ namespace Unity.Payments.Integrations.Cas
                 if (rootElement.TryGetProperty("code", out JsonElement codeProp) && codeProp.GetString() == "Unauthorized")
                     throw new UserFriendlyException("Unauthorized access to CAS supplier information.");
                 UpsertSupplierEto supplierEto = GetEventDtoFromCasResponse(rootElement);
-                supplierEto.CorrelationId = applicantId;
-                supplierEto.CorrelationProvider = CorrelationConsts.Applicant;
+                supplierEto.ApplicantId = applicantId;
                 supplierEto.ApplicationId = applicationId;
                 await localEventBus.PublishAsync(supplierEto);
             }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/PaymentRequests/PaymentRequestAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/PaymentRequests/PaymentRequestAppService.cs
@@ -331,6 +331,11 @@ namespace Unity.Payments.PaymentRequests
             return await paymentRequestQueryManager.GetPaymentPendingListByCorrelationIdAsync(applicationId);
         }
 
+        public async Task<List<PaymentRequestDto>> GetPaymentPendingListByCorrelationIdsAsync(IEnumerable<Guid> correlationIds)
+        {
+            return await paymentRequestQueryManager.GetPaymentPendingListByCorrelationIdsAsync(correlationIds);
+        }
+
         /// <summary>
         /// Retrieves the payment rollup for the specified application, including any linked child
         /// applications.

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Suppliers/ISupplierAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Suppliers/ISupplierAppService.cs
@@ -8,7 +8,6 @@ namespace Unity.Payments.Suppliers
     public interface ISupplierAppService : IApplicationService
     {
         Task<SupplierDto?> GetAsync(Guid id);
-        Task<SupplierDto?> GetByCorrelationAsync(GetSupplierByCorrelationDto requestDto);
         Task<SupplierDto?> GetBySupplierNumberAsync(string? supplierNumber);
         Task<SupplierDto> CreateAsync(CreateSupplierDto createSupplierDto);
         Task<SupplierDto> UpdateAsync(Guid id, UpdateSupplierDto updateSupplierDto);
@@ -16,6 +15,5 @@ namespace Unity.Payments.Suppliers
         Task<SiteDto> UpdateSiteAsync(Guid id, Guid siteId, UpdateSiteDto updateSiteDto);
         Task<dynamic> GetSitesBySupplierNumberAsync(string? supplierNumber, Guid applicantId, Guid? applicationId = null);
         SiteDto GetSiteDtoFromSiteEto(SiteEto siteEto, Guid supplierId, PaymentGroup? defaultPaymentGroup = null);
-        Task ClearCorrelationAsync(Guid supplierId);
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Suppliers/SupplierAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Suppliers/SupplierAppService.cs
@@ -11,7 +11,6 @@ using Unity.Payments.Domain.Suppliers.ValueObjects;
 using Unity.Payments.Enums;
 using Unity.Payments.Integrations.Cas;
 using Volo.Abp.Features;
-using Unity.Modules.Shared.Correlation;
 
 namespace Unity.Payments.Suppliers
 {
@@ -39,8 +38,6 @@ namespace Unity.Payments.Suppliers
             
             var casMetadata = new CasMetadata(createSupplierDto.LastUpdatedInCAS);
             
-            var correlation = new Correlation(createSupplierDto.CorrelationId, createSupplierDto.CorrelationProvider);
-            
             var mailingAddress = new MailingAddress(
                 createSupplierDto.MailingAddress,
                 createSupplierDto.City,
@@ -49,7 +46,6 @@ namespace Unity.Payments.Suppliers
 
             Supplier supplier = new(Guid.NewGuid(),
                 basicInfo,
-                correlation,
                 providerInfo,
                 supplierStatus,
                 casMetadata,
@@ -79,9 +75,6 @@ namespace Unity.Payments.Suppliers
                 updateSupplierDto.StandardIndustryClassification));
             
             supplier.UpdateCasMetadata(new CasMetadata(updateSupplierDto.LastUpdatedInCAS));
-            
-            supplier.CorrelationId = updateSupplierDto.CorrelationId;
-            supplier.CorrelationProvider = updateSupplierDto.CorrelationProvider;
 
             supplier.SetAddress(updateSupplierDto.MailingAddress,
                 updateSupplierDto.City,
@@ -105,15 +98,6 @@ namespace Unity.Payments.Suppliers
                 Logger.LogError(ex, "Error fetching supplier");
                 return null;
             }
-        }
-
-        public virtual async Task<SupplierDto?> GetByCorrelationAsync(GetSupplierByCorrelationDto requestDto)
-        {
-            var result = await supplierRepository.GetByCorrelationAsync(requestDto.CorrelationId, requestDto.CorrelationProvider, requestDto.IncludeDetails);
-
-            if (result == null) return null;
-
-            return ObjectMapper.Map<Supplier, SupplierDto?>(result);
         }
 
         public virtual async Task<SupplierDto?> GetBySupplierNumberAsync(string? supplierNumber)
@@ -275,14 +259,6 @@ namespace Unity.Payments.Suppliers
                     SiteProtected = siteEto.SiteProtected,
                     LastUpdatedInCas = siteEto.LastUpdated
                 };
-        }
-
-        public async Task ClearCorrelationAsync(Guid supplierId)
-        {
-            var supplier = await supplierRepository.GetAsync(supplierId);
-            supplier.CorrelationId = Guid.Empty;
-            supplier.CorrelationProvider = string.Empty;
-            await supplierRepository.UpdateAsync(supplier);
         }
 
         private async Task<PaymentGroup> ResolveDefaultPaymentGroupForApplicantAsync(Guid applicantId, Guid? applicationId = null)

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CreatePaymentRequests.cshtml.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CreatePaymentRequests.cshtml.cs
@@ -144,7 +144,7 @@ namespace Unity.Payments.Web.Pages.Payments
                 var supplier = await GetSupplierByApplicationAync(application);
                 string supplierNumber = supplier?.Number?? string.Empty;
 
-                Guid siteId = application.Applicant.SiteId;
+                Guid siteId = application.DefaultSiteId ?? Guid.Empty;
                 Site? site = null;
                 if(siteId != Guid.Empty) {
                     site = await siteRepository.GetAsync(siteId);

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CreatePaymentRequests.cshtml.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/CreatePaymentRequests.cshtml.cs
@@ -278,21 +278,12 @@ namespace Unity.Payments.Web.Pages.Payments
 
         private async Task<SupplierDto?> GetSupplierByApplicationAync(GrantApplicationDto application)
         {
-            if(application.Applicant.SupplierId != Guid.Empty)
+            if (application.Applicant.SupplierId != Guid.Empty)
             {
-                SupplierDto? supplierDto =  await iSupplierAppService.GetAsync(application.Applicant.SupplierId);
-                if (supplierDto != null)
-                {
-                    return supplierDto;
-                }
+                return await iSupplierAppService.GetAsync(application.Applicant.SupplierId);
             }
 
-            return await iSupplierAppService.GetByCorrelationAsync(new GetSupplierByCorrelationDto()
-            {
-                CorrelationId = application.Applicant.Id,
-                CorrelationProvider = GrantManager.Payments.PaymentConsts.ApplicantCorrelationProvider,
-                IncludeDetails = true
-            });
+            return null;
         }
 
         private async Task<(List<string> Errors, string? ParentReferenceNo)> ValidateFormHierarchyAndParentLink(

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/PaymentInfo/Default.cshtml
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/PaymentInfo/Default.cshtml
@@ -73,7 +73,7 @@
         @* Zone Section : Payment.Supplier *@
         @if (await PermissionChecker.IsGrantedAsync(UnitySelector.Payment.Supplier.Default))
         {
-            @await Component.InvokeAsync("SupplierInfo", new { applicantId = Model.ApplicantId })
+            @await Component.InvokeAsync("SupplierInfo", new { applicantId = Model.ApplicantId, applicationId = Model.ApplicationId })
         }
 
         @* Zone Section : Payment.Worksheet *@

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/PaymentInfo/Default.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/PaymentInfo/Default.js
@@ -521,7 +521,8 @@ function enablePaymentInfoSaveBtn() {
 
 function refreshSupplierInfoWidget() {
     const applicantId = $('#PaymentInfo_ApplicantId').val();
-    const refreshUrl = `../Payments/Widget/SupplierInfo/Refresh?applicantId=${applicantId}`;
+    const applicationId = $('#PaymentInfoViewApplicationId').val();
+    const refreshUrl = `../Payments/Widget/SupplierInfo/Refresh?applicantId=${applicantId}&applicationId=${applicationId}`;
     fetch(refreshUrl)
         .then((response) => response.text())
         .then((data) => {

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/SupplierInfo/Default.cshtml
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/SupplierInfo/Default.cshtml
@@ -27,8 +27,6 @@
                     <abp-input asp-for="@Model.ApplicantId" type="hidden" />
                     <abp-input asp-for="@Model.ApplicationId" id="SupplierInfo_ApplicationId" type="hidden" />
                     <abp-input asp-for="@Model.SiteId" id="SiteId" type="hidden" />
-                    <abp-input asp-for="@Model.SupplierCorrelationId" id="SupplierCorrelationId" type="hidden" />
-                    <abp-input asp-for="@Model.SupplierCorrelationProvider" id="SupplierCorrelationProvider" type="hidden" />
                     <abp-input asp-for="@Model.SupplierId" id="SupplierId" type="hidden" />
                     <abp-input asp-for="@Model.OriginalSupplierNumber" type="hidden" />
                     <abp-input asp-for="@Model.HasEditSupplierInfo" type="hidden" />

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/SupplierInfo/Default.cshtml
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/SupplierInfo/Default.cshtml
@@ -25,6 +25,7 @@
             <abp-row class="m-0 p-0">
                 <abp-column size="_12" class="px-1">
                     <abp-input asp-for="@Model.ApplicantId" type="hidden" />
+                    <abp-input asp-for="@Model.ApplicationId" id="SupplierInfo_ApplicationId" type="hidden" />
                     <abp-input asp-for="@Model.SiteId" id="SiteId" type="hidden" />
                     <abp-input asp-for="@Model.SupplierCorrelationId" id="SupplierCorrelationId" type="hidden" />
                     <abp-input asp-for="@Model.SupplierCorrelationProvider" id="SupplierCorrelationProvider" type="hidden" />

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/SupplierInfo/SupplierInfo.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/SupplierInfo/SupplierInfo.js
@@ -504,11 +504,11 @@ $(function () {
 });
 
 function saveSiteDefault(siteId) {
-    let applicantId = $('#ApplicantId').val();
+    let applicationId = $('#SupplierInfo_ApplicationId').val();
     $.ajax({
-        url: `/api/app/applicant/${applicantId}/site/${siteId}`,
+        url: `/api/app/application/${applicationId}/site/${siteId}`,
         type: 'POST',
-        data: JSON.stringify({ ApplicantId: applicantId, SiteId: siteId }),
+        data: JSON.stringify({ ApplicationId: applicationId, SiteId: siteId }),
     })
         .then((response) => {
             abp.notify.success(

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/SupplierInfo/SupplierInfo.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/SupplierInfo/SupplierInfo.js
@@ -251,7 +251,6 @@ $(function () {
 
         // Clear hidden fields
         $('#SupplierId').val('');
-        $('#SupplierCorrelationId').val('');
 
         // Hide error message
         supplierOrgInfoErrorDiv.addClass('hidden');

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/SupplierInfo/SupplierInfoController.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/SupplierInfo/SupplierInfoController.cs
@@ -14,17 +14,17 @@ namespace Unity.Payments.Web.Views.Shared.Components.SupplierInfo
 
         [HttpGet]
         [Route("Refresh")]
-        public IActionResult SupplierInfo(Guid applicantId)
+        public IActionResult SupplierInfo(Guid applicantId, Guid applicationId)
         {
             // Check if the model state is valid
             if (!ModelState.IsValid)
-            {       
+            {
                 logger.LogWarning("Invalid model state for SupplierInfoController");
                 return ViewComponent("SupplierInfo");
             }
 
             // If the model state is valid, render the view component
-            return ViewComponent("SupplierInfo", new { applicantId });
+            return ViewComponent("SupplierInfo", new { applicantId, applicationId });
         }
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/SupplierInfo/SupplierInfoViewComponent.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/SupplierInfo/SupplierInfoViewComponent.cs
@@ -21,22 +21,25 @@ namespace Unity.Payments.Web.Views.Shared.Components.SupplierInfo
         StyleTypes = [typeof(SupplierInfosWidgetStyleBundleContributor)],
         AutoInitialize = true)]
     public class SupplierInfoViewComponent(IApplicantSupplierAppService applicantSupplierService,
-                                           IApplicantRepository applicantRepository,
+                                           IApplicationRepository applicationRepository,
                                            IPermissionChecker permissionChecker,
                                            IFeatureChecker featureChecker) : AbpViewComponent
     {
 
-        public async Task<IViewComponentResult> InvokeAsync(Guid applicantId)
+        public async Task<IViewComponentResult> InvokeAsync(Guid applicantId, Guid applicationId)
         {
 
             if (await featureChecker.IsEnabledAsync("Unity.Payments"))
             {
                 SupplierDto? supplier = await GetSupplierByApplicantIdAsync(applicantId);
-                Applicant? applicant = await applicantRepository.GetAsync(applicantId);
+                Application? application = applicationId != Guid.Empty
+                    ? await applicationRepository.GetAsync(applicationId)
+                    : null;
                 return View(new SupplierInfoViewModel()
                 {
                     ApplicantId = applicantId,
-                    SiteId = applicant?.SiteId ?? Guid.Empty,
+                    ApplicationId = applicationId,
+                    SiteId = application?.DefaultSiteId ?? Guid.Empty,
                     SupplierCorrelationId = applicantId,
                     SupplierCorrelationProvider = CorrelationConsts.Applicant,
                     SupplierId = supplier?.Id ?? Guid.Empty,

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/SupplierInfo/SupplierInfoViewComponent.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/SupplierInfo/SupplierInfoViewComponent.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Unity.GrantManager.Applicants;
 using Unity.GrantManager.Applications;
 using Unity.Modules.Shared;
-using Unity.Modules.Shared.Correlation;
 using Unity.Payments.Suppliers;
 using Volo.Abp.AspNetCore.Mvc;
 using Volo.Abp.AspNetCore.Mvc.UI.Bundling;
@@ -40,8 +39,6 @@ namespace Unity.Payments.Web.Views.Shared.Components.SupplierInfo
                     ApplicantId = applicantId,
                     ApplicationId = applicationId,
                     SiteId = application?.DefaultSiteId ?? Guid.Empty,
-                    SupplierCorrelationId = applicantId,
-                    SupplierCorrelationProvider = CorrelationConsts.Applicant,
                     SupplierId = supplier?.Id ?? Guid.Empty,
                     SupplierNumber = supplier?.Number?.ToString(),
                     SupplierName = supplier?.Name?.ToString(),

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/SupplierInfo/SupplierInfoViewModel.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/SupplierInfo/SupplierInfoViewModel.cs
@@ -21,6 +21,7 @@ public class SupplierInfoViewModel
     [HiddenInput]
     public string? OriginalSupplierNumber { get; set; }
     public Guid ApplicantId { get; set; }
+    public Guid ApplicationId { get; set; }
     public Guid SupplierId { get; set; }
     public Guid SiteId { get; set; }
     public Guid SupplierCorrelationId { get; set; }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/SupplierInfo/SupplierInfoViewModel.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/SupplierInfo/SupplierInfoViewModel.cs
@@ -24,7 +24,5 @@ public class SupplierInfoViewModel
     public Guid ApplicationId { get; set; }
     public Guid SupplierId { get; set; }
     public Guid SiteId { get; set; }
-    public Guid SupplierCorrelationId { get; set; }
-    public string SupplierCorrelationProvider { get; set; } = string.Empty;
     public bool HasEditSupplierInfo { get; set; }
 }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/test/Unity.Payments.Application.Tests/BatchPaymentRequests/PaymentRequestAppService_Tests.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/test/Unity.Payments.Application.Tests/BatchPaymentRequests/PaymentRequestAppService_Tests.cs
@@ -36,7 +36,6 @@ public class PaymentRequestAppService_Tests : PaymentsApplicationTestBase
         var newSupplier = new Supplier(Guid.NewGuid(),
             "Supplier",
             "123",
-            new Modules.Shared.Correlation.Correlation(Guid.NewGuid(), "Test"),
             new MailingAddress(
             "Address1",
             "City",
@@ -86,7 +85,7 @@ public class PaymentRequestAppService_Tests : PaymentsApplicationTestBase
     {
         // Arrange
         using var uow = _unitOfWorkManager.Begin();
-        var supplier = new Supplier(Guid.NewGuid(), "supp", "123", new Modules.Shared.Correlation.Correlation(Guid.NewGuid(), "A"));
+        var supplier = new Supplier(Guid.NewGuid(), "supp", "123");
         supplier.AddSite(new Site(Guid.NewGuid(), "123", PaymentGroup.EFT));
         var addedSupplier = await _supplierRepository.InsertAsync(supplier);
         CreatePaymentRequestDto paymentRequestDto = new()
@@ -121,7 +120,7 @@ public class PaymentRequestAppService_Tests : PaymentsApplicationTestBase
     {
         // Arrange
         using var uow = _unitOfWorkManager.Begin();
-        var supplier = new Supplier(Guid.NewGuid(), "supp", "123", new Modules.Shared.Correlation.Correlation(Guid.NewGuid(), "A"));
+        var supplier = new Supplier(Guid.NewGuid(), "supp", "123");
         supplier.AddSite(new Site(Guid.NewGuid(), "123", PaymentGroup.EFT));
         var addedSupplier = await _supplierRepository.InsertAsync(supplier);
         CreatePaymentRequestDto paymentRequestDto = new()

--- a/applications/Unity.GrantManager/modules/Unity.Payments/test/Unity.Payments.Application.Tests/Domain/PaymentRequests/PaymentRequestRepository_PaymentRollup_Tests.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/test/Unity.Payments.Application.Tests/Domain/PaymentRequests/PaymentRequestRepository_PaymentRollup_Tests.cs
@@ -2,7 +2,6 @@ using Shouldly;
 using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
-using Unity.Modules.Shared.Correlation;
 using Unity.Payments.Domain.Suppliers;
 using Unity.Payments.Enums;
 using Unity.Payments.PaymentRequests;
@@ -385,8 +384,7 @@ public class PaymentRequestRepository_PaymentRollup_Tests : PaymentsApplicationT
     {
         using var uow = _unitOfWorkManager.Begin();
         var siteId = Guid.NewGuid();
-        var supplier = new Supplier(Guid.NewGuid(), "TestSupplier", "SUP-001",
-            new Correlation(Guid.NewGuid(), "Test"));
+        var supplier = new Supplier(Guid.NewGuid(), "TestSupplier", "SUP-001");
         supplier.AddSite(new Site(siteId, "001", PaymentGroup.EFT));
         await _supplierRepository.InsertAsync(supplier, true);
         await uow.CompleteAsync();

--- a/applications/Unity.GrantManager/modules/Unity.Payments/test/Unity.Payments.Application.Tests/Domain/PaymentRequests/PaymentRequestRepository_Tests.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/test/Unity.Payments.Application.Tests/Domain/PaymentRequests/PaymentRequestRepository_Tests.cs
@@ -3,7 +3,6 @@ using System;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
-using Unity.Modules.Shared.Correlation;
 using Unity.Payments.Codes;
 using Unity.Payments.Domain.Suppliers;
 using Unity.Payments.Enums;
@@ -779,8 +778,7 @@ public class PaymentRequestRepository_Tests : PaymentsApplicationTestBase
     {
         using var uow = _unitOfWorkManager.Begin();
         var siteId = Guid.NewGuid();
-        var supplier = new Supplier(Guid.NewGuid(), "TestSupplier", "SUP-001",
-            new Correlation(Guid.NewGuid(), "Test"));
+        var supplier = new Supplier(Guid.NewGuid(), "TestSupplier", "SUP-001");
         supplier.AddSite(new Site(siteId, "001", PaymentGroup.EFT));
         await _supplierRepository.InsertAsync(supplier, true);
         await uow.CompleteAsync();

--- a/applications/Unity.GrantManager/modules/Unity.Payments/test/Unity.Payments.Application.Tests/Domain/PaymentRequests/PaymentRequestRepository_Tests.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/test/Unity.Payments.Application.Tests/Domain/PaymentRequests/PaymentRequestRepository_Tests.cs
@@ -733,22 +733,21 @@ public class PaymentRequestRepository_Tests : PaymentsApplicationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task GetPaymentPendingListByCorrelationIdAsync_Should_Not_Return_L3Pending()
+    public async Task GetPaymentPendingListByCorrelationIdAsync_Should_Return_L3Pending()
     {
-        // Arrange - The method only returns L1 and L2 pending
+        // Arrange
         var correlationId = Guid.NewGuid();
         var siteId = await CreateSupplierAndSiteAsync();
 
         using var uow = _unitOfWorkManager.Begin();
-        await InsertPaymentRequestAsync(siteId, correlationId, 1000m, PaymentRequestStatus.L3Pending);
-        await InsertPaymentRequestAsync(siteId, correlationId, 2000m, PaymentRequestStatus.L1Pending);
+        await InsertPaymentRequestAsync(siteId, correlationId, 1000m, PaymentRequestStatus.L3Pending);        
 
         // Act
         var payments = await _paymentRequestRepository.GetPaymentPendingListByCorrelationIdAsync(correlationId);
 
         // Assert
         payments.Count.ShouldBe(1);
-        payments[0].Status.ShouldBe(PaymentRequestStatus.L1Pending);
+        payments[0].Status.ShouldBe(PaymentRequestStatus.L3Pending);
     }
 
     [Fact]

--- a/applications/Unity.GrantManager/modules/Unity.Payments/test/Unity.Payments.Application.Tests/Domain/Suppliers/Supplier_ValueObject_Refactoring_Integration_Tests.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/test/Unity.Payments.Application.Tests/Domain/Suppliers/Supplier_ValueObject_Refactoring_Integration_Tests.cs
@@ -1,6 +1,5 @@
 using System;
 using Shouldly;
-using Unity.Modules.Shared.Correlation;
 using Unity.Payments.Domain.Suppliers;
 using Unity.Payments.Domain.Suppliers.ValueObjects;
 using Xunit;
@@ -34,8 +33,6 @@ public class Supplier_ValueObject_Refactoring_Integration_Tests
         var supplierProtected = "No";
         var standardIndustryClassification = "NAICS789";
         var lastUpdatedInCAS = DateTime.UtcNow;
-        var correlationId = Guid.NewGuid();
-        var correlationProvider = "DemoProvider";
         var mailingAddress = "123 Demo Street";
         var city = "Demo City";
         var province = "BC";
@@ -46,10 +43,9 @@ public class Supplier_ValueObject_Refactoring_Integration_Tests
         var providerInfo = new ProviderInfo(providerId, businessNumber);
         var supplierStatus = new SupplierStatus(status, supplierProtected, standardIndustryClassification);
         var casMetadata = new CasMetadata(lastUpdatedInCAS);
-        var correlation = new Correlation(correlationId, correlationProvider);
         var mailingAddressVO = new MailingAddress(mailingAddress, city, province, postalCode);
 
-        var supplier = new Supplier(id, basicInfo, correlation, providerInfo, supplierStatus, casMetadata, mailingAddressVO);
+        var supplier = new Supplier(id, basicInfo, providerInfo, supplierStatus, casMetadata, mailingAddressVO);
 
         // Assert - Verify all data is correctly set
         supplier.Id.ShouldBe(id);
@@ -62,8 +58,6 @@ public class Supplier_ValueObject_Refactoring_Integration_Tests
         supplier.SupplierProtected.ShouldBe(supplierProtected);
         supplier.StandardIndustryClassification.ShouldBe(standardIndustryClassification);
         supplier.LastUpdatedInCAS.ShouldBe(lastUpdatedInCAS);
-        supplier.CorrelationId.ShouldBe(correlationId);
-        supplier.CorrelationProvider.ShouldBe(correlationProvider);
         supplier.MailingAddress.ShouldBe(mailingAddress);
         supplier.City.ShouldBe(city);
         supplier.Province.ShouldBe(province);
@@ -96,20 +90,17 @@ public class Supplier_ValueObject_Refactoring_Integration_Tests
             SupplierProtected = "No",
             StandardIndustryClassification = "COMP_NAICS",
             LastUpdatedInCAS = DateTime.UtcNow,
-            CorrelationId = Guid.NewGuid(),
-            CorrelationProvider = "CompatTest",
             MailingAddress = "456 Compat Ave",
             City = "Compat City",
             Province = "AB",
             PostalCode = "COMP456"
         };
 
-        // Act - Create using legacy constructor
+        // Act - Create using simple constructor
         var legacySupplier = new Supplier(
             id1,
             testData.Name,
             testData.Number,
-            new Correlation(testData.CorrelationId, testData.CorrelationProvider),
             new MailingAddress(testData.MailingAddress, testData.City, testData.Province, testData.PostalCode));
         
         // Manually set properties that weren't in legacy constructor
@@ -125,7 +116,6 @@ public class Supplier_ValueObject_Refactoring_Integration_Tests
         var newSupplier = new Supplier(
             id2,
             new SupplierBasicInfo(testData.Name, testData.Number, testData.Subcategory),
-            new Correlation(testData.CorrelationId, testData.CorrelationProvider),
             new ProviderInfo(testData.ProviderId, testData.BusinessNumber),
             new SupplierStatus(testData.Status, testData.SupplierProtected, testData.StandardIndustryClassification),
             new CasMetadata(testData.LastUpdatedInCAS),
@@ -141,8 +131,6 @@ public class Supplier_ValueObject_Refactoring_Integration_Tests
         legacySupplier.SupplierProtected.ShouldBe(newSupplier.SupplierProtected);
         legacySupplier.StandardIndustryClassification.ShouldBe(newSupplier.StandardIndustryClassification);
         legacySupplier.LastUpdatedInCAS.ShouldBe(newSupplier.LastUpdatedInCAS);
-        legacySupplier.CorrelationId.ShouldBe(newSupplier.CorrelationId);
-        legacySupplier.CorrelationProvider.ShouldBe(newSupplier.CorrelationProvider);
         legacySupplier.MailingAddress.ShouldBe(newSupplier.MailingAddress);
         legacySupplier.City.ShouldBe(newSupplier.City);
         legacySupplier.Province.ShouldBe(newSupplier.Province);
@@ -168,9 +156,8 @@ public class Supplier_ValueObject_Refactoring_Integration_Tests
         // After: Impossible to swap because each value object has distinct type
         var supplier = new Supplier(
             Guid.NewGuid(),
-            basicInfo,     // Can't pass providerInfo here - compiler error
-            new Correlation(Guid.NewGuid(), "Provider"),
-            providerInfo,  // Can't pass basicInfo here - compiler error
+            basicInfo,
+            providerInfo,
             supplierStatus,
             new CasMetadata(DateTime.UtcNow),
             new MailingAddress("Address", "City", "Province", "PostalCode"));
@@ -190,8 +177,7 @@ public class Supplier_ValueObject_Refactoring_Integration_Tests
         // Arrange
         var supplier = new Supplier(
             Guid.NewGuid(),
-            new SupplierBasicInfo("Original Name", "ORIG001", "Original Category"),
-            new Correlation(Guid.NewGuid(), "Original"));
+            new SupplierBasicInfo("Original Name", "ORIG001", "Original Category"));
 
         // Act - Update using value object methods
         supplier.UpdateBasicInfo(new SupplierBasicInfo("Updated Name", "UPD001", "Updated Category"));
@@ -221,8 +207,7 @@ public class Supplier_ValueObject_Refactoring_Integration_Tests
         // Arrange & Act - Create supplier with only required data
         var supplier = new Supplier(
             Guid.NewGuid(),
-            new SupplierBasicInfo("Minimal Supplier", "MIN001"),
-            new Correlation(Guid.NewGuid(), "MinimalProvider"));
+            new SupplierBasicInfo("Minimal Supplier", "MIN001"));
         // Optional parameters: providerInfo, supplierStatus, casMetadata, mailingAddress all default to null
 
         // Assert - Required data set, optional data has appropriate defaults
@@ -319,8 +304,6 @@ public class Supplier_ValueObject_Refactoring_Integration_Tests
             supplierprotected = "N",
             standardindustryclassification = "CAS_NAICS_456",
             lastupdated = DateTime.UtcNow.AddDays(-1),
-            correlationid = Guid.NewGuid(),
-            correlationprovider = "CAS",
             mailingaddress = "789 CAS Boulevard",
             city = "CAS City",
             province = "BC",
@@ -344,10 +327,6 @@ public class Supplier_ValueObject_Refactoring_Integration_Tests
 
         var casMetadata = new CasMetadata(casSupplierData.lastupdated);
 
-        var correlation = new Correlation(
-            casSupplierData.correlationid,
-            casSupplierData.correlationprovider);
-
         var mailingAddress = new MailingAddress(
             casSupplierData.mailingaddress,
             casSupplierData.city,
@@ -358,7 +337,6 @@ public class Supplier_ValueObject_Refactoring_Integration_Tests
         var supplier = new Supplier(
             Guid.NewGuid(),
             basicInfo,
-            correlation,
             providerInfo,
             supplierStatus,
             casMetadata,
@@ -374,8 +352,6 @@ public class Supplier_ValueObject_Refactoring_Integration_Tests
         supplier.SupplierProtected.ShouldBe(casSupplierData.supplierprotected);
         supplier.StandardIndustryClassification.ShouldBe(casSupplierData.standardindustryclassification);
         supplier.LastUpdatedInCAS.ShouldBe(casSupplierData.lastupdated);
-        supplier.CorrelationId.ShouldBe(casSupplierData.correlationid);
-        supplier.CorrelationProvider.ShouldBe(casSupplierData.correlationprovider);
 
         // Value objects work seamlessly with external integrations ?
     }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/test/Unity.Payments.Application.Tests/Domain/Suppliers/Supplier_ValueObjects_Tests.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/test/Unity.Payments.Application.Tests/Domain/Suppliers/Supplier_ValueObjects_Tests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Shouldly;
-using Unity.Modules.Shared.Correlation;
 using Unity.Payments.Domain.Suppliers;
 using Unity.Payments.Domain.Suppliers.ValueObjects;
 using Xunit;
@@ -118,11 +117,10 @@ public class Supplier_ValueObjects_Tests : PaymentsApplicationTestBase
         var providerInfo = new ProviderInfo("PROV123", "BN123456789");
         var supplierStatus = new SupplierStatus("Active", "No", "NAICS123");
         var casMetadata = new CasMetadata(DateTime.UtcNow);
-        var correlation = new Correlation(Guid.NewGuid(), "CAS");
         var mailingAddress = new MailingAddress("123 Main St", "Victoria", "BC", "V8V1A1");
 
         // Act
-        var supplier = new Supplier(id, basicInfo, correlation, providerInfo, supplierStatus, casMetadata, mailingAddress);
+        var supplier = new Supplier(id, basicInfo, providerInfo, supplierStatus, casMetadata, mailingAddress);
 
         // Assert
         supplier.Id.ShouldBe(id);
@@ -135,8 +133,6 @@ public class Supplier_ValueObjects_Tests : PaymentsApplicationTestBase
         supplier.SupplierProtected.ShouldBe(supplierStatus.SupplierProtected);
         supplier.StandardIndustryClassification.ShouldBe(supplierStatus.StandardIndustryClassification);
         supplier.LastUpdatedInCAS.ShouldBe(casMetadata.LastUpdatedInCAS);
-        supplier.CorrelationId.ShouldBe(correlation.CorrelationId);
-        supplier.CorrelationProvider.ShouldBe(correlation.CorrelationProvider);
         supplier.MailingAddress.ShouldBe(mailingAddress.AddressLine);
         supplier.City.ShouldBe(mailingAddress.City);
         supplier.Province.ShouldBe(mailingAddress.Province);
@@ -151,10 +147,9 @@ public class Supplier_ValueObjects_Tests : PaymentsApplicationTestBase
         // Arrange
         var id = Guid.NewGuid();
         var basicInfo = new SupplierBasicInfo("Test Supplier", "SUP001");
-        var correlation = new Correlation(Guid.NewGuid(), "CAS");
 
         // Act
-        var supplier = new Supplier(id, basicInfo, correlation);
+        var supplier = new Supplier(id, basicInfo);
 
         // Assert
         supplier.Id.ShouldBe(id);
@@ -180,10 +175,9 @@ public class Supplier_ValueObjects_Tests : PaymentsApplicationTestBase
         var id = Guid.NewGuid();
         var basicInfo = new SupplierBasicInfo("Test Supplier", "SUP001", "Category");
         var providerInfo = new ProviderInfo("PROV123", null); // Only ProviderId, no BusinessNumber
-        var correlation = new Correlation(Guid.NewGuid(), "CAS");
 
         // Act
-        var supplier = new Supplier(id, basicInfo, correlation, providerInfo: providerInfo);
+        var supplier = new Supplier(id, basicInfo, providerInfo: providerInfo);
 
         // Assert
         supplier.Name.ShouldBe("Test Supplier");
@@ -278,37 +272,29 @@ public class Supplier_ValueObjects_Tests : PaymentsApplicationTestBase
     #region Backward Compatibility Tests
 
     [Fact]
-    public void Supplier_LegacyConstructor_ShouldStillWork()
+    public void Supplier_SimpleConstructor_ShouldSetNameNumberAndAddress()
     {
         // Arrange
         var id = Guid.NewGuid();
-        var name = "Legacy Supplier";
-        var number = "LEG001";
-        var correlation = new Correlation(Guid.NewGuid(), "Legacy");
-        var mailingAddress = new MailingAddress("Legacy Address", "Legacy City", "BC", "L3G4CY");
+        var name = "Simple Supplier";
+        var number = "SIM001";
+        var mailingAddress = new MailingAddress("Simple Address", "Simple City", "BC", "S1M4LE");
 
         // Act
-        var supplier = new Supplier(id, name, number, correlation, mailingAddress);
+        var supplier = new Supplier(id, name, number, mailingAddress);
 
         // Assert
         supplier.Id.ShouldBe(id);
         supplier.Name.ShouldBe(name);
         supplier.Number.ShouldBe(number);
-        supplier.CorrelationId.ShouldBe(correlation.CorrelationId);
-        supplier.CorrelationProvider.ShouldBe(correlation.CorrelationProvider);
         supplier.MailingAddress.ShouldBe(mailingAddress.AddressLine);
         supplier.City.ShouldBe(mailingAddress.City);
         supplier.Province.ShouldBe(mailingAddress.Province);
         supplier.PostalCode.ShouldBe(mailingAddress.PostalCode);
-        
-        // Properties not set in legacy constructor should have default values (string.Empty, not null)
-        supplier.Subcategory.ShouldBe(string.Empty);
         supplier.ProviderId.ShouldBe(string.Empty);
         supplier.BusinessNumber.ShouldBe(string.Empty);
         supplier.Status.ShouldBe(string.Empty);
-        supplier.SupplierProtected.ShouldBe(string.Empty);
-        supplier.StandardIndustryClassification.ShouldBe(string.Empty);
-        supplier.LastUpdatedInCAS.ShouldBeNull(); // This one is nullable DateTime, so remains null
+        supplier.LastUpdatedInCAS.ShouldBeNull();
     }
 
     #endregion
@@ -364,10 +350,9 @@ public class Supplier_ValueObjects_Tests : PaymentsApplicationTestBase
         var providerInfo = new ProviderInfo("PROV123", "BN123456789");
         var supplierStatus = new SupplierStatus("Active", "No", "NAICS123");
         var casMetadata = new CasMetadata(DateTime.UtcNow);
-        var correlation = new Correlation(Guid.NewGuid(), "Test");
         var mailingAddress = new MailingAddress("123 Test St", "Test City", "BC", "T3ST1NG");
 
-        return new Supplier(id, basicInfo, correlation, providerInfo, supplierStatus, casMetadata, mailingAddress);
+        return new Supplier(id, basicInfo, providerInfo, supplierStatus, casMetadata, mailingAddress);
     }
 
     #endregion

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Applicants/ApplicantListDto.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Applicants/ApplicantListDto.cs
@@ -29,7 +29,6 @@ public class ApplicantListDto : AuditedEntityDto<Guid>
     public int? FiscalDay { get; set; }
     public DateTime? StartedOperatingDate { get; set; }
     public string? SupplierId { get; set; }
-    public Guid? SiteId { get; set; }
     public decimal? MatchPercentage { get; set; }
     public bool IsDuplicated { get; set; }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/GrantApplicationDto.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/GrantApplicationDto.cs
@@ -84,6 +84,7 @@ public class GrantApplicationDto : AuditedEntityDto<Guid>
     public string? UnityApplicationId { get; set; }
     public string? ApplicantElectoralDistrict { get; set; }
     public string? AIAnalysis { get; set; }
+    public Guid? DefaultSiteId { get; set; }
     public ApplicationAnalysisResponse? AIAnalysisData { get; set; }
     public string? AIScoresheetAnswers { get; set; }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Applicants/ApplicantAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Applicants/ApplicantAppService.cs
@@ -80,18 +80,28 @@ public class ApplicantAppService(IApplicantRepository applicantRepository,
         Applicant? applicant = await applicantRepository.GetAsync(applicantSupplierEto.ApplicantId);
         ArgumentNullException.ThrowIfNull(applicant);
         applicant.SupplierId = applicantSupplierEto.SupplierId;
-        applicant.SiteId = null; // Reset site id to null
-        // lookup sites if there is only one then set it as default
+        await applicantRepository.UpdateAsync(applicant);
+
+        // Per-application cascade: if the new supplier has exactly one site,
+        // auto-pick it for every application of this applicant; otherwise clear
+        // DefaultSiteId so users repick per application on the Payment Info tab.
+        Guid? newDefaultSiteId = null;
         if (applicant.SupplierId != null)
         {
             List<Site> sites = await siteAppService.GetSitesBySupplierIdAsync(applicant.SupplierId.Value);
             if (sites.Count == 1)
             {
-                applicant.SiteId = sites.FirstOrDefault()?.Id;
+                newDefaultSiteId = sites[0].Id;
             }
         }
 
-        await applicantRepository.UpdateAsync(applicant);
+        var applications = await applicationRepository.GetListAsync(a => a.ApplicantId == applicant.Id);
+        foreach (var application in applications)
+        {
+            application.DefaultSiteId = newDefaultSiteId;
+            await applicationRepository.UpdateAsync(application);
+        }
+
         return applicant;
     }
 
@@ -504,11 +514,6 @@ public class ApplicantAppService(IApplicantRepository applicantRepository,
         }
     }
 
-    public async Task<List<Applicant>> GetApplicantsBySiteIdAsync(Guid siteId)
-    {
-        List<Applicant> applicants = await applicantRepository.GetApplicantsBySiteIdAsync(siteId);
-        return applicants;
-    }
     [RemoteService(true)]
     public async Task<JsonDocument> GetApplicantLookUpAutocompleteQueryAsync(string? applicantLookUpQuery)
     {
@@ -700,7 +705,6 @@ public class ApplicantAppService(IApplicantRepository applicantRepository,
                     ? applicant.StartedOperatingDate.Value.ToDateTime(TimeOnly.MinValue) 
                     : null,
                 SupplierId = applicant.SupplierId?.ToString(),
-                SiteId = applicant.SiteId,
                 MatchPercentage = applicant.MatchPercentage,
                 IsDuplicated = applicant.IsDuplicated,
                 CreationTime = applicant.CreationTime,

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Applicants/ApplicantSupplierAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Applicants/ApplicantSupplierAppService.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Payments;
 using Unity.Modules.Shared;
-using Unity.Modules.Shared.Correlation;
 using Unity.Payments.Domain.Suppliers;
 using Unity.Payments.Integrations.Cas;
 using Unity.Payments.PaymentRequests;
@@ -80,14 +79,11 @@ public class ApplicantSupplierAppService(ISiteRepository siteRepository,
             await applicantRepository.EnsureExistsAsync(applicantId);
 
             var applicant = await applicantRepository.GetAsync(applicantId);
-            var supplierId = applicant.SupplierId;
-
-            // Clear the applicant-level supplier reference first.
             applicant.SupplierId = null;
             await applicantRepository.UpdateAsync(applicant);
 
-            // Cascade: clear DefaultSiteId on every application of this applicant.
-            // Sites belong to the cleared supplier, so the references are no longer valid.
+            // Cascade: clear DefaultSiteId on every application — sites belong to the
+            // cleared supplier so their references are no longer valid.
             var applications = await applicationRepository
                 .GetListAsync(a => a.ApplicantId == applicantId);
             foreach (var application in applications)
@@ -95,29 +91,6 @@ public class ApplicantSupplierAppService(ISiteRepository siteRepository,
                 application.DefaultSiteId = null;
                 await applicationRepository.UpdateAsync(application);
             }
-
-            if (supplierId.HasValue)
-            {
-                await supplierAppService.ClearCorrelationAsync(supplierId.Value);
-            }
-            else
-            {
-                // Handle existing data where SupplierId was already cleared
-                // but the supplier's correlation was never removed
-                var supplier = await supplierAppService.GetByCorrelationAsync(
-                    new GetSupplierByCorrelationDto()
-                    {
-                        CorrelationId = applicantId,
-                        CorrelationProvider = CorrelationConsts.Applicant,
-                        IncludeDetails = false
-                    });
-
-                if (supplier != null)
-                {
-                    await supplierAppService.ClearCorrelationAsync(supplier.Id);
-                }
-            }
-
         }
     }
 
@@ -171,22 +144,8 @@ public class ApplicantSupplierAppService(ISiteRepository siteRepository,
 
     public async Task<SupplierDto?> GetSupplierByApplicantIdAsync(Guid applicantId)
     {
-
         Applicant applicant = await applicantRepository.GetAsync(applicantId);
-
-        //If SupplierId is available, use it to get the supplier
-        if (applicant.SupplierId.HasValue)
-        {
-            Guid supplierId = applicant.SupplierId.Value;
-            return await supplierAppService.GetAsync(supplierId);
-        }
-
-        // If no SupplierId, fetch the supplier using the correlation
-        return await supplierAppService.GetByCorrelationAsync(new GetSupplierByCorrelationDto()
-        {
-            CorrelationId = applicantId,
-            CorrelationProvider = CorrelationConsts.Applicant,
-            IncludeDetails = true
-        });
+        if (!applicant.SupplierId.HasValue) return null;
+        return await supplierAppService.GetAsync(applicant.SupplierId.Value);
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Applicants/ApplicantSupplierAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Applicants/ApplicantSupplierAppService.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Payments;
@@ -9,7 +10,9 @@ using Unity.Modules.Shared;
 using Unity.Modules.Shared.Correlation;
 using Unity.Payments.Domain.Suppliers;
 using Unity.Payments.Integrations.Cas;
+using Unity.Payments.PaymentRequests;
 using Unity.Payments.Suppliers;
+using Volo.Abp;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Repositories;
 
@@ -20,8 +23,10 @@ namespace Unity.GrantManager.Applicants;
 [ExposeServices(typeof(ApplicantSupplierAppService), typeof(IApplicantSupplierAppService))]
 public class ApplicantSupplierAppService(ISiteRepository siteRepository,
                                  IApplicantRepository applicantRepository,
+                                 IApplicationRepository applicationRepository,
                                  ISupplierService supplierService,
-                                 ISupplierAppService supplierAppService) : GrantManagerAppService, IApplicantSupplierAppService
+                                 ISupplierAppService supplierAppService,
+                                 IPaymentRequestAppService paymentRequestService) : GrantManagerAppService, IApplicantSupplierAppService
 {
 
     public async Task<List<Site>> GetSitesBySupplierIdAsync(Guid supplierId)
@@ -77,10 +82,19 @@ public class ApplicantSupplierAppService(ISiteRepository siteRepository,
             var applicant = await applicantRepository.GetAsync(applicantId);
             var supplierId = applicant.SupplierId;
 
-            // Clear the applicant references first
+            // Clear the applicant-level supplier reference first.
             applicant.SupplierId = null;
-            applicant.SiteId = null;
             await applicantRepository.UpdateAsync(applicant);
+
+            // Cascade: clear DefaultSiteId on every application of this applicant.
+            // Sites belong to the cleared supplier, so the references are no longer valid.
+            var applications = await applicationRepository
+                .GetListAsync(a => a.ApplicantId == applicantId);
+            foreach (var application in applications)
+            {
+                application.DefaultSiteId = null;
+                await applicationRepository.UpdateAsync(application);
+            }
 
             if (supplierId.HasValue)
             {
@@ -110,15 +124,49 @@ public class ApplicantSupplierAppService(ISiteRepository siteRepository,
     [HttpPut("api/app/applicant/{applicantId}/bn9/{bn9}")]
     public async Task<dynamic> UpdateAplicantSupplierByBn9Async(Guid applicantId, string bn9)
     {
+        await EnsureNoPendingPaymentsForApplicantAsync(applicantId);
         return await supplierService.UpdateApplicantSupplierInfoByBn9(bn9, applicantId);
     }
 
-    [HttpPost("api/app/applicant/{applicantId}/site/{siteId}")]
-    public async Task DefaultApplicantSite(Guid applicantId, Guid siteId)
+    [HttpPost("api/app/application/{applicationId}/site/{siteId}")]
+    public async Task DefaultApplicationSite(Guid applicationId, Guid siteId)
     {
-        Applicant applicant = await applicantRepository.GetAsync(applicantId);
-        applicant.SiteId = siteId;
-        await applicantRepository.UpdateAsync(applicant);
+        Application application = await applicationRepository.GetAsync(applicationId);
+        application.DefaultSiteId = siteId;
+        await applicationRepository.UpdateAsync(application);
+    }
+
+    /// <summary>
+    /// Throws UserFriendlyException if the applicant has any outstanding (L1Pending / L2Pending)
+    /// payment request across any of their applications. No-op when the Unity Payments feature
+    /// is disabled. Call this immediately before any supplier-number-mutating operation.
+    /// </summary>
+    public async Task EnsureNoPendingPaymentsForApplicantAsync(Guid applicantId)
+    {
+        if (!await FeatureChecker.IsEnabledAsync(PaymentConsts.UnityPaymentsFeature))
+        {
+            return;
+        }
+
+        var applicationIds = (await applicationRepository
+            .GetListAsync(a => a.ApplicantId == applicantId))
+            .Select(a => a.Id)
+            .ToList();
+
+        if (applicationIds.Count == 0)
+        {
+            return;
+        }
+
+        var pendingPayments = await paymentRequestService
+            .GetPaymentPendingListByCorrelationIdsAsync(applicationIds);
+
+        if (pendingPayments != null && pendingPayments.Count > 0)
+        {
+            throw new UserFriendlyException(
+                "This applicant has outstanding payment requests on one or more applications. " +
+                "Please decline or approve them before changing the Supplier Number.");
+        }
     }
 
     public async Task<SupplierDto?> GetSupplierByApplicantIdAsync(Guid applicantId)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Applicants/IApplicantAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Applicants/IApplicantAppService.cs
@@ -21,7 +21,6 @@ public interface IApplicantAppService : IApplicationService
     Task<Applicant> UpdateApplicantOrgMatchAsync(Applicant applicant);
     Task<int> GetNextUnityApplicantIdAsync();
     Task<bool> IsUnityApplicantIdAvailableAsync(string unityApplicantId, Guid currentApplicantId);
-    Task<List<Applicant>> GetApplicantsBySiteIdAsync(Guid siteId);
     Task<JsonDocument> GetApplicantLookUpAutocompleteQueryAsync(string? applicantLookUpQuery);
     Task<PagedResultDto<ApplicantListDto>> GetListAsync(ApplicantListRequestDto input);
     Task<Applicant> PartialUpdateApplicantSummaryAsync(Guid applicantId, PartialUpdateDto<UpdateApplicantSummaryDto> input);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Applicants/IApplicantSupplierAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Applicants/IApplicantSupplierAppService.cs
@@ -15,4 +15,5 @@ public interface IApplicantSupplierAppService : IApplicationService
     Task ClearApplicantSupplierAsync(Guid applicantId);
     Task UpdateApplicantSupplierNumberAsync(Guid applicantId, string supplierNumber, Guid? applicationId = null);
     Task<dynamic> UpdateAplicantSupplierByBn9Async(Guid applicantId, string bn9);
+    Task EnsureNoPendingPaymentsForApplicantAsync(Guid applicantId);
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/GrantApplicationAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/GrantApplicationAppService.cs
@@ -634,11 +634,8 @@ public class GrantApplicationAppService(
         var application = await applicationRepository.GetAsync(applicationId);
         if (await FeatureChecker.IsEnabledAsync(PaymentConsts.UnityPaymentsFeature) && application != null)
         {
-            var pendingPayments = await paymentRequestService.GetPaymentPendingListByCorrelationIdAsync(applicationId);
-            if (pendingPayments != null && pendingPayments.Count > 0)
-            {
-                throw new UserFriendlyException("There are outstanding payment requests with the current Supplier. Please decline or approve the outstanding payments before changing the Supplier Number");
-            }
+            await applicantSupplierService.EnsureNoPendingPaymentsForApplicantAsync(application.ApplicantId);
+
             // Handle both clearing (null/empty) and updating supplier number
             if (string.IsNullOrWhiteSpace(supplierNumber))
             {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Handlers/UpsertSupplierHandler.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Handlers/UpsertSupplierHandler.cs
@@ -14,6 +14,7 @@ using Volo.Abp.EventBus;
 namespace Unity.GrantManager.Handlers
 {
     public class SupplierCreatedHandler(IApplicantAppService applicantsService,
+                                        IApplicationRepository applicationRepository,
                                         ISiteAppService siteAppService,
                                         IPaymentRequestAppService paymentRequestAppService) :
                                         ILocalEventHandler<ApplicantSupplierEto>, ITransientDependency
@@ -32,14 +33,14 @@ namespace Unity.GrantManager.Handlers
                 if (existingSitesDictionary == null) continue;
                 Guid siteId = existingSitesDictionary[siteNumber].Id;
                 // First check if the site is being used
-                // Get all Applicants with the site id
-                List<Applicant> applicants = existingSitesDictionary != null
-                    ? await applicantsService.GetApplicantsBySiteIdAsync(siteId)
-                    : new List<Applicant>();
+                // Get all Applications referencing this site via DefaultSiteId
+                List<Application> applications = existingSitesDictionary != null
+                    ? await applicationRepository.GetApplicationsBySiteIdAsync(siteId)
+                    : new List<Application>();
 
-                if (applicants.Count > 0)
+                if (applications.Count > 0)
                 {
-                    // The site should be deleted but is associate with an applicant as the default site
+                    // The site should be deleted but is referenced by at least one application as the default site
                     // Mark the site as should be deleted MarkDeletedInUse
                     await siteAppService.MarkDeletedInUseAsync(siteId);
                     continue;

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/Applicant.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/Applicant.cs
@@ -28,7 +28,6 @@ public class Applicant : AuditedAggregateRoot<Guid>, IMultiTenant
     public DateOnly? StartedOperatingDate { get; set; }
     public Guid? TenantId { get; set; }
     public Guid? SupplierId { get; set; }
-    public Guid? SiteId { get; set; }
     public virtual Collection<ApplicantAddress>? ApplicantAddresses { get; set; }
     public decimal? MatchPercentage { get; set; }
     public string? NonRegOrgName { get; set; }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/Application.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/Application.cs
@@ -122,6 +122,8 @@ public class Application : FullAuditedAggregateRoot<Guid>, IMultiTenant
 
     public Guid? TenantId { get; set; }
 
+    public Guid? DefaultSiteId { get; set; }
+
     public Guid? OwnerId { get; set; }
     // Navigation Property - Application Status
     public virtual Person? Owner { get; set; }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/IApplicantRepository.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/IApplicantRepository.cs
@@ -12,6 +12,5 @@ public interface IApplicantRepository : IRepository<Applicant, Guid>
     Task<Applicant?> GetByUnityApplicantIdAsync(string unityApplicantId);
     Task<Applicant?> GetByUnityApplicantNameAsync(string unityApplicantName);
     Task<List<Applicant>> GetApplicantsWithUnityApplicantIdAsync();
-    Task<List<Applicant>> GetApplicantsBySiteIdAsync(Guid siteId);
     Task<JsonDocument> GetApplicantAutocompleteQueryAsync(string? applicantLookUpQuery);
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/IApplicationRepository.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/IApplicationRepository.cs
@@ -29,5 +29,8 @@ namespace Unity.GrantManager.Applications
 
         // Get applications by applicant ID
         Task<List<Application>> GetByApplicantIdAsync(Guid applicantId);
+
+        // Get applications whose DefaultSiteId matches the given site id
+        Task<List<Application>> GetApplicationsBySiteIdAsync(Guid siteId);
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Migrations/TenantMigrations/20260424031702_AddApplicationDefaultSiteIdAndCopyFromApplicant.Designer.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Migrations/TenantMigrations/20260424031702_AddApplicationDefaultSiteIdAndCopyFromApplicant.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unity.GrantManager.EntityFrameworkCore;
@@ -12,9 +13,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace Unity.GrantManager.Migrations.TenantMigrations
 {
     [DbContext(typeof(GrantTenantDbContext))]
-    partial class GrantTenantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260424031702_AddApplicationDefaultSiteIdAndCopyFromApplicant")]
+    partial class AddApplicationDefaultSiteIdAndCopyFromApplicant
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Migrations/TenantMigrations/20260424031702_AddApplicationDefaultSiteIdAndCopyFromApplicant.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Migrations/TenantMigrations/20260424031702_AddApplicationDefaultSiteIdAndCopyFromApplicant.cs
@@ -1,0 +1,93 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unity.GrantManager.Migrations.TenantMigrations
+{
+    /// <inheritdoc />
+    public partial class AddApplicationDefaultSiteIdAndCopyFromApplicant : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // 1. Add the new column on Applications (nullable to accept existing rows).
+            migrationBuilder.AddColumn<Guid>(
+                name: "DefaultSiteId",
+                table: "Applications",
+                type: "uuid",
+                nullable: true);
+
+            // 2. Copy Applicant.SiteId to every Application via the ApplicantId FK.
+            migrationBuilder.Sql(@"
+                UPDATE public.""Applications"" app
+                SET ""DefaultSiteId"" = ap.""SiteId""
+                FROM public.""Applicants"" ap
+                WHERE app.""ApplicantId"" = ap.""Id""
+                  AND ap.""SiteId"" IS NOT NULL;
+            ");
+
+            // 3. Safety: null out any DefaultSiteId that does not resolve to a real
+            //    Site row. Protects the FK creation below from failing on orphaned
+            //    references (shouldn't exist in practice, but defend anyway).
+            migrationBuilder.Sql(@"
+                UPDATE public.""Applications"" app
+                SET ""DefaultSiteId"" = NULL
+                WHERE ""DefaultSiteId"" IS NOT NULL
+                  AND NOT EXISTS (
+                      SELECT 1 FROM ""Payments"".""Sites"" s
+                      WHERE s.""Id"" = app.""DefaultSiteId""
+                  );
+            ");
+
+            // 4. Supporting index on the FK column.
+            migrationBuilder.CreateIndex(
+                name: "IX_Applications_DefaultSiteId",
+                table: "Applications",
+                column: "DefaultSiteId");
+
+            // 5. Cross-schema FK: Applications.DefaultSiteId -> Payments.Sites.Id.
+            //    ON DELETE NO ACTION matches EF's default and keeps the existing
+            //    in-app "site in use" check as defence-in-depth.
+            migrationBuilder.AddForeignKey(
+                name: "FK_Applications_Sites_DefaultSiteId",
+                table: "Applications",
+                column: "DefaultSiteId",
+                principalSchema: "Payments",
+                principalTable: "Sites",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.NoAction);
+
+            // NOTE: Applicants."SiteId" is intentionally LEFT IN PLACE.
+            //       It is no longer mapped in the EF model (see Applicant.cs change)
+            //       so no code can read/write it, but the data stays untouched
+            //       to keep rollback of this PR trivial. A follow-up cleanup
+            //       migration (handled separately) will drop the column once
+            //       stability is confirmed in PROD.
+            //       The auto-generated `DropColumn("SiteId", "Applicants")` has
+            //       been deleted by hand.
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Drop FK, index, then column — reverse order of Up(). No need to
+            // re-populate Applicants.SiteId — it was never dropped in Up(), so it
+            // still holds the original values.
+            migrationBuilder.DropForeignKey(
+                name: "FK_Applications_Sites_DefaultSiteId",
+                table: "Applications");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Applications_DefaultSiteId",
+                table: "Applications");
+
+            migrationBuilder.DropColumn(
+                name: "DefaultSiteId",
+                table: "Applications");
+
+            // NOTE: The auto-generated `AddColumn("SiteId", "Applicants", ...)`
+            //       has been deleted by hand (the DB column was never dropped).
+        }
+    }
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Migrations/TenantMigrations/20260425041028_DropSupplierCorrelationFields.Designer.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Migrations/TenantMigrations/20260425041028_DropSupplierCorrelationFields.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unity.GrantManager.EntityFrameworkCore;
@@ -12,9 +13,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace Unity.GrantManager.Migrations.TenantMigrations
 {
     [DbContext(typeof(GrantTenantDbContext))]
-    partial class GrantTenantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260425041028_DropSupplierCorrelationFields")]
+    partial class DropSupplierCorrelationFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Migrations/TenantMigrations/20260425041028_DropSupplierCorrelationFields.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Migrations/TenantMigrations/20260425041028_DropSupplierCorrelationFields.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unity.GrantManager.Migrations.TenantMigrations
+{
+    /// <inheritdoc />
+    public partial class DropSupplierCorrelationFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CorrelationId",
+                schema: "Payments",
+                table: "Suppliers");
+
+            migrationBuilder.DropColumn(
+                name: "CorrelationProvider",
+                schema: "Payments",
+                table: "Suppliers");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "CorrelationId",
+                schema: "Payments",
+                table: "Suppliers",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<string>(
+                name: "CorrelationProvider",
+                schema: "Payments",
+                table: "Suppliers",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/ApplicantRepository.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/ApplicantRepository.cs
@@ -58,14 +58,6 @@ namespace Unity.GrantManager.Repositories
                 .ToListAsync();
         }
 
-        public async Task<List<Applicant>> GetApplicantsBySiteIdAsync(Guid siteId)
-        {
-            var dbContext = await GetDbContextAsync();
-            return await dbContext.Applicants
-                .Where(x => x.SiteId == siteId)
-                .ToListAsync();
-        }
-
         public async Task<JsonDocument> GetApplicantAutocompleteQueryAsync(string? applicantLookUpQuery)
         {
             if (string.IsNullOrWhiteSpace(applicantLookUpQuery))

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/ApplicationRepository.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/ApplicationRepository.cs
@@ -197,6 +197,14 @@ public class ApplicationRepository
             .ToListAsync();
     }
 
+    public async Task<List<Application>> GetApplicationsBySiteIdAsync(Guid siteId)
+    {
+        return await (await GetQueryableAsync())
+            .AsNoTracking()
+            .Where(a => a.DefaultSiteId == siteId)
+            .ToListAsync();
+    }
+
     private static IQueryable<Application> ApplySorting(
         IQueryable<Application> query,
         string? sorting)


### PR DESCRIPTION
- Moved default Site from Applicant to Application
- Implement Applicant-wide pending-payments guard when changing Supplier
- Removed the Supplier Correlation fields to avoid confusion with Supplier-Applicant relationships.  The correlation fields gives a 1:1 Supplier-Applicant relationships while the Applicant.SupplierId gives a 1:many Supplier-Applicant relationships