### PR TITLE
bugfix/AB#32699 - Enable default ordering for applicant portal status table

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicantPortalSettings/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicantPortalSettings/Index.js
@@ -11,8 +11,11 @@
 
     let portalStatusTable = new DataTable("#PortalStatusTable", {
         paging: false,
-        ordering: false,
-        info: false
+        info: false,
+        order: {
+            idx: 0,
+            dir: 'asc'
+        }
     });
 
     // Capture original values after DataTable initialization


### PR DESCRIPTION
Enable default ordering for applicant portal status table