### PR TITLE
Feature/ab#32302 stream attachments lower memory ai processing

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/AI/Extraction/ITextExtractionService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/AI/Extraction/ITextExtractionService.cs
@@ -1,9 +1,10 @@
+using System.IO;
 using System.Threading.Tasks;
 
 namespace Unity.AI.Extraction
 {
     public interface ITextExtractionService
     {
-        Task<string> ExtractTextAsync(string fileName, byte[] fileContent, string contentType);
+        Task<string> ExtractTextAsync(string fileName, Stream fileContent, string contentType);
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/AI/Requests/AttachmentSummaryRequest.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/AI/Requests/AttachmentSummaryRequest.cs
@@ -7,11 +7,11 @@ namespace Unity.AI.Requests
         [JsonPropertyName("fileName")]
         public string FileName { get; set; } = string.Empty;
 
-        [JsonPropertyName("fileContent")]
-        public byte[] FileContent { get; set; } = System.Array.Empty<byte>();
-
         [JsonPropertyName("contentType")]
         public string ContentType { get; set; } = "application/octet-stream";
+
+        [JsonPropertyName("extractedText")]
+        public string? ExtractedText { get; set; }
 
         [JsonPropertyName("promptVersion")]
         public string? PromptVersion { get; set; }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Extraction/TextExtractionService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Extraction/TextExtractionService.cs
@@ -26,30 +26,17 @@ namespace Unity.AI.Extraction
         private const int MaxDocxTableCellsPerRow = 50;
         private const int MaxPowerPointSlides = 200;
         private readonly ILogger<TextExtractionService> _logger;
-        private readonly Dictionary<string, Func<string, byte[], string>> _extractorsByExtension;
 
         public TextExtractionService(ILogger<TextExtractionService> logger)
         {
             _logger = logger;
-            _extractorsByExtension = new Dictionary<string, Func<string, byte[], string>>(StringComparer.OrdinalIgnoreCase)
-            {
-                [".txt"] = (_, content) => ExtractTextFromTextFile(content),
-                [".csv"] = (_, content) => ExtractTextFromTextFile(content),
-                [".json"] = (_, content) => ExtractTextFromTextFile(content),
-                [".xml"] = (_, content) => ExtractTextFromTextFile(content),
-                [".pdf"] = ExtractTextFromPdfFile,
-                [".docx"] = ExtractTextFromWordDocx,
-                [".xls"] = ExtractTextFromExcelFile,
-                [".xlsx"] = ExtractTextFromExcelFile,
-                [".pptx"] = ExtractTextFromPowerPointFile
-            };
         }
 
-        public Task<string> ExtractTextAsync(string fileName, byte[] fileContent, string contentType)
+        public Task<string> ExtractTextAsync(string fileName, Stream fileContent, string contentType)
         {
-            if (fileContent == null || fileContent.Length == 0)
+            if (fileContent == null)
             {
-                _logger.LogDebug("File content is empty for {FileName}", fileName);
+                _logger.LogDebug("File content stream is null for {FileName}", fileName);
                 return Task.FromResult(string.Empty);
             }
 
@@ -64,48 +51,23 @@ namespace Unity.AI.Extraction
                     return Task.FromResult(string.Empty);
                 }
 
-                if (_extractorsByExtension.TryGetValue(extension, out var extractor))
+                var rawText = extension switch
                 {
-                    var rawText = extractor(fileName, fileContent);
-                    return Task.FromResult(NormalizeAndLimitText(rawText, fileName));
+                    ".txt" or ".csv" or ".json" or ".xml" => ExtractTextFromTextFile(fileContent),
+                    ".pdf" => ExtractTextFromPdfFile(fileName, fileContent),
+                    ".docx" => ExtractTextFromWordDocx(fileName, fileContent),
+                    ".xls" or ".xlsx" => ExtractTextFromExcelFile(fileName, fileContent),
+                    ".pptx" => ExtractTextFromPowerPointFile(fileName, fileContent),
+                    _ => ExtractByContentType(fileName, fileContent, normalizedContentType)
+                };
+
+                if (string.IsNullOrEmpty(rawText))
+                {
+                    _logger.LogDebug("No text extraction available for content type {ContentType} with extension {Extension}",
+                        contentType, extension);
                 }
 
-                if (normalizedContentType.Contains("text/"))
-                {
-                    var rawText = ExtractTextFromTextFile(fileContent);
-                    return Task.FromResult(NormalizeAndLimitText(rawText, fileName));
-                }
-
-                if (normalizedContentType.Contains("pdf"))
-                {
-                    var rawText = ExtractTextFromPdfFile(fileName, fileContent);
-                    return Task.FromResult(NormalizeAndLimitText(rawText, fileName));
-                }
-
-                if (normalizedContentType.Contains("word") ||
-                    normalizedContentType.Contains("msword") ||
-                    normalizedContentType.Contains("officedocument.wordprocessingml"))
-                {
-                    var rawText = ExtractTextFromWordDocx(fileName, fileContent);
-                    return Task.FromResult(NormalizeAndLimitText(rawText, fileName));
-                }
-
-                if (normalizedContentType.Contains("excel") || normalizedContentType.Contains("spreadsheet"))
-                {
-                    var rawText = ExtractTextFromExcelFile(fileName, fileContent);
-                    return Task.FromResult(NormalizeAndLimitText(rawText, fileName));
-                }
-
-                if (normalizedContentType.Contains("presentation") ||
-                    normalizedContentType.Contains("powerpoint"))
-                {
-                    var rawText = ExtractTextFromPowerPointFile(fileName, fileContent);
-                    return Task.FromResult(NormalizeAndLimitText(rawText, fileName));
-                }
-
-                _logger.LogDebug("No text extraction available for content type {ContentType} with extension {Extension}",
-                    contentType, extension);
-                return Task.FromResult(string.Empty);
+                return Task.FromResult(NormalizeAndLimitText(rawText, fileName));
             }
             catch (Exception ex)
             {
@@ -114,25 +76,64 @@ namespace Unity.AI.Extraction
             }
         }
 
-        private string ExtractTextFromTextFile(byte[] fileContent)
+        private string ExtractByContentType(string fileName, Stream fileContent, string normalizedContentType)
+        {
+            if (normalizedContentType.Contains("text/"))
+            {
+                return ExtractTextFromTextFile(fileContent);
+            }
+            if (normalizedContentType.Contains("pdf"))
+            {
+                return ExtractTextFromPdfFile(fileName, fileContent);
+            }
+            if (normalizedContentType.Contains("word") ||
+                normalizedContentType.Contains("msword") ||
+                normalizedContentType.Contains("officedocument.wordprocessingml"))
+            {
+                return ExtractTextFromWordDocx(fileName, fileContent);
+            }
+            if (normalizedContentType.Contains("excel") || normalizedContentType.Contains("spreadsheet"))
+            {
+                return ExtractTextFromExcelFile(fileName, fileContent);
+            }
+            if (normalizedContentType.Contains("presentation") || normalizedContentType.Contains("powerpoint"))
+            {
+                return ExtractTextFromPowerPointFile(fileName, fileContent);
+            }
+            return string.Empty;
+        }
+
+        private static void RewindIfPossible(Stream stream)
+        {
+            if (stream.CanSeek)
+            {
+                stream.Position = 0;
+            }
+        }
+
+        private string ExtractTextFromTextFile(Stream fileContent)
         {
             try
             {
-                var text = Encoding.UTF8.GetString(fileContent);
-
-                if (text.Contains('\uFFFD'))
+                RewindIfPossible(fileContent);
+                using var reader = new StreamReader(fileContent, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 4096, leaveOpen: true);
+                var buffer = new char[Math.Min(MaxExtractedTextLength, 8192)];
+                var builder = new StringBuilder(capacity: Math.Min(MaxExtractedTextLength, 8192));
+                int read;
+                while ((read = reader.Read(buffer, 0, buffer.Length)) > 0)
                 {
-                    text = Encoding.ASCII.GetString(fileContent);
+                    var remaining = MaxExtractedTextLength - builder.Length;
+                    if (remaining <= 0) break;
+                    builder.Append(buffer, 0, Math.Min(read, remaining));
+                    if (builder.Length >= MaxExtractedTextLength)
+                    {
+                        _logger.LogDebug("Truncated text content to {MaxLength} characters", MaxExtractedTextLength);
+                        break;
+                    }
                 }
 
-                if (text.Length > MaxExtractedTextLength)
-                {
-                    text = text.Substring(0, MaxExtractedTextLength);
-                    _logger.LogDebug("Truncated text content to {MaxLength} characters", MaxExtractedTextLength);
-                }
-
-                _logger.LogDebug("Extracted {CharacterCount} characters from text-based content.", text.Length);
-                return text;
+                _logger.LogDebug("Extracted {CharacterCount} characters from text-based content.", builder.Length);
+                return builder.ToString();
             }
             catch (Exception ex)
             {
@@ -141,12 +142,12 @@ namespace Unity.AI.Extraction
             }
         }
 
-        private string ExtractTextFromPdfFile(string fileName, byte[] fileContent)
+        private string ExtractTextFromPdfFile(string fileName, Stream fileContent)
         {
             try
             {
-                using var stream = new MemoryStream(fileContent, writable: false);
-                using var document = PdfDocument.Open(stream);
+                RewindIfPossible(fileContent);
+                using var document = PdfDocument.Open(fileContent);
                 var builder = new StringBuilder();
                 var processedPageCount = 0;
                 var pageTexts = document.GetPages()
@@ -177,12 +178,12 @@ namespace Unity.AI.Extraction
             }
         }
 
-        private string ExtractTextFromWordDocx(string fileName, byte[] fileContent)
+        private string ExtractTextFromWordDocx(string fileName, Stream fileContent)
         {
             try
             {
-                using var stream = new MemoryStream(fileContent, writable: false);
-                using var document = new XWPFDocument(stream);
+                RewindIfPossible(fileContent);
+                using var document = new XWPFDocument(fileContent);
                 var builder = new StringBuilder();
                 var processedParagraphCount = AppendDocxParagraphText(document, builder);
                 var processedTableRowCount = AppendDocxTableText(document, builder);
@@ -268,12 +269,12 @@ namespace Unity.AI.Extraction
             return processedTableRowCount;
         }
 
-        private string ExtractTextFromExcelFile(string fileName, byte[] fileContent)
+        private string ExtractTextFromExcelFile(string fileName, Stream fileContent)
         {
             try
             {
-                using var stream = new MemoryStream(fileContent, writable: false);
-                using var workbook = WorkbookFactory.Create(stream);
+                RewindIfPossible(fileContent);
+                using var workbook = WorkbookFactory.Create(fileContent);
                 var builder = new StringBuilder();
                 var sheetCount = Math.Min(workbook.NumberOfSheets, MaxExcelSheets);
                 var processedSheetCount = 0;
@@ -314,12 +315,12 @@ namespace Unity.AI.Extraction
             }
         }
 
-        private string ExtractTextFromPowerPointFile(string fileName, byte[] fileContent)
+        private string ExtractTextFromPowerPointFile(string fileName, Stream fileContent)
         {
             try
             {
-                using var stream = new MemoryStream(fileContent, writable: false);
-                using var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: false);
+                RewindIfPossible(fileContent);
+                using var archive = new ZipArchive(fileContent, ZipArchiveMode.Read, leaveOpen: true);
                 var builder = new StringBuilder();
                 var slideEntries = GetOrderedPowerPointSlideEntries(archive)
                     .Take(MaxPowerPointSlides);

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AttachmentSummaryService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AttachmentSummaryService.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Unity.AI.Extraction;
 using Unity.AI.Requests;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Intakes;
@@ -13,23 +14,25 @@ namespace Unity.AI.Operations;
 public class AttachmentSummaryService(
     IApplicationChefsFileAttachmentRepository applicationChefsFileAttachmentRepository,
     ISubmissionAppService submissionAppService,
+    ITextExtractionService textExtractionService,
     IAIService aiService,
     ILogger<AttachmentSummaryService> logger) : IAttachmentSummaryService, ITransientDependency
 {
-    private const string DefaultContentType = "application/octet-stream";
     private const string SummaryGenerationFailedMessage = "AI summary generation failed.";
 
     public async Task<string> GenerateAndSaveAsync(Guid attachmentId, string? promptVersion = null)
     {
         var attachment = await applicationChefsFileAttachmentRepository.GetAsync(attachmentId);
         var fileName = string.IsNullOrWhiteSpace(attachment.FileName) ? "unknown" : attachment.FileName;
-        var (fileContent, contentType) = await GetAttachmentContentForSummaryAsync(attachment, fileName);
+
+        await using var attachmentStream = await OpenAttachmentStreamAsync(attachment, fileName);
+        var extractedText = await textExtractionService.ExtractTextAsync(fileName, attachmentStream.Content, attachmentStream.ContentType);
 
         var summaryResponse = await aiService.GenerateAttachmentSummaryAsync(new AttachmentSummaryRequest
         {
             FileName = fileName,
-            FileContent = fileContent,
-            ContentType = contentType,
+            ContentType = attachmentStream.ContentType,
+            ExtractedText = extractedText,
             PromptVersion = promptVersion,
         });
 
@@ -68,7 +71,7 @@ public class AttachmentSummaryService(
         return await GenerateAndSaveAsync(attachmentIds, promptVersion);
     }
 
-    private async Task<(byte[] Content, string ContentType)> GetAttachmentContentForSummaryAsync(ApplicationChefsFileAttachment attachment, string fileName)
+    private async Task<ChefsFileAttachmentStream> OpenAttachmentStreamAsync(ApplicationChefsFileAttachment attachment, string fileName)
     {
         if (!Guid.TryParse(attachment.ChefsSubmissionId, out var submissionId) ||
             !Guid.TryParse(attachment.ChefsFileId, out var fileId))
@@ -76,21 +79,13 @@ public class AttachmentSummaryService(
             logger.LogWarning(
                 "Attachment {AttachmentId} has invalid CHEFS IDs. Falling back to metadata-only summary generation.",
                 attachment.Id);
-            return (Array.Empty<byte>(), DefaultContentType);
+            return ChefsFileAttachmentStream.Empty;
         }
 
         try
         {
-            var fileDto = await submissionAppService.GetChefsFileAttachment(submissionId, fileId, fileName);
-            if (fileDto?.Content == null)
-            {
-                logger.LogWarning(
-                    "Attachment {AttachmentId} has no retrievable content. Falling back to metadata-only summary generation.",
-                    attachment.Id);
-                return (Array.Empty<byte>(), DefaultContentType);
-            }
-
-            return (fileDto.Content, string.IsNullOrWhiteSpace(fileDto.ContentType) ? DefaultContentType : fileDto.ContentType);
+            var stream = await submissionAppService.GetChefsFileAttachmentStream(submissionId, fileId, fileName);
+            return stream ?? ChefsFileAttachmentStream.Empty;
         }
         catch (Exception ex)
         {
@@ -98,7 +93,7 @@ public class AttachmentSummaryService(
                 ex,
                 "Failed retrieving CHEFS content for attachment {AttachmentId}. Falling back to metadata-only summary generation.",
                 attachment.Id);
-            return (Array.Empty<byte>(), DefaultContentType);
+            return ChefsFileAttachmentStream.Empty;
         }
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AttachmentSummaryService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AttachmentSummaryService.cs
@@ -13,7 +13,7 @@ namespace Unity.AI.Operations;
 
 public class AttachmentSummaryService(
     IApplicationChefsFileAttachmentRepository applicationChefsFileAttachmentRepository,
-    ISubmissionAppService submissionAppService,
+    IChefsFileAttachmentStreamProvider chefsFileAttachmentStreamProvider,
     ITextExtractionService textExtractionService,
     IAIService aiService,
     ILogger<AttachmentSummaryService> logger) : IAttachmentSummaryService, ITransientDependency
@@ -84,7 +84,7 @@ public class AttachmentSummaryService(
 
         try
         {
-            var stream = await submissionAppService.GetChefsFileAttachmentStream(submissionId, fileId, fileName);
+            var stream = await chefsFileAttachmentStreamProvider.OpenAsync(submissionId, fileId, fileName);
             return stream ?? ChefsFileAttachmentStream.Empty;
         }
         catch (Exception ex)

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Unity.AI.Extraction;
 using Unity.AI.Models;
 using Unity.AI.Prompts;
 using Unity.AI.Requests;
@@ -20,7 +19,6 @@ namespace Unity.AI.Runtime
     {
         private readonly IConfiguration _configuration;
         private readonly ILogger<OpenAIRuntimeService> _logger;
-        private readonly ITextExtractionService _textExtractionService;
         private readonly OpenAITransportService _openAITransportService;
         private readonly OpenAIConfigurationResolver _openAIConfigurationResolver;
         private const string ApplicationAnalysisPromptType = AIPromptTypes.ApplicationAnalysis;
@@ -51,13 +49,11 @@ namespace Unity.AI.Runtime
         public OpenAIRuntimeService(
             IConfiguration configuration,
             ILogger<OpenAIRuntimeService> logger,
-            ITextExtractionService textExtractionService,
             OpenAITransportService openAITransportService,
             OpenAIConfigurationResolver openAIConfigurationResolver)
         {
             _configuration = configuration;
             _logger = logger;
-            _textExtractionService = textExtractionService;
             _openAITransportService = openAITransportService;
             _openAIConfigurationResolver = openAIConfigurationResolver;
         }
@@ -132,19 +128,18 @@ namespace Unity.AI.Runtime
         {
             ArgumentNullException.ThrowIfNull(request);
             var fileName = request.FileName ?? string.Empty;
-            var fileContent = request.FileContent ?? Array.Empty<byte>();
             var contentType = request.ContentType ?? "application/octet-stream";
             var promptVersion = OpenAIPromptRenderer.ResolvePromptVersion(request.PromptVersion ?? ResolvePromptVersionSetting(AttachmentSummaryPromptType));
 
             try
             {
-                var extractedText = await _textExtractionService.ExtractTextAsync(fileName, fileContent, contentType);
+                var extractedText = request.ExtractedText;
                 var prompt = OpenAIPromptRenderer.BuildAttachmentSummarySystemPrompt(promptVersion);
 
                 var attachmentText = string.IsNullOrWhiteSpace(extractedText) ? null : extractedText;
                 if (attachmentText != null)
                 {
-                    _logger.LogDebug("Extracted {TextLength} characters from {FileName}", extractedText.Length, fileName);
+                    _logger.LogDebug("Received {TextLength} extracted characters for {FileName}", attachmentText.Length, fileName);
                 }
                 else
                 {
@@ -155,21 +150,20 @@ namespace Unity.AI.Runtime
                 {
                     name = fileName,
                     contentType,
-                    sizeBytes = fileContent.Length,
                     text = attachmentText
                 };
                 var attachment = JsonSerializer.Serialize(attachmentPayload, JsonLogOptions);
                 var contentToAnalyze = OpenAIPromptRenderer.BuildAttachmentSummaryUserPrompt(promptVersion, attachment);
 
                 await LogPromptInputAsync(AttachmentSummaryPromptType, promptVersion, prompt, contentToAnalyze);
-            var result = await GenerateWithRetryAsync(
-                () => _openAITransportService.GenerateSummaryAsync(
-                    contentToAnalyze,
-                    prompt,
-                    AttachmentSummaryCompletionTokens,
-                    operationName: AttachmentSummaryPromptType,
-                    promptVersion: promptVersion,
-                    fileName: fileName),
+                var result = await GenerateWithRetryAsync(
+                    () => _openAITransportService.GenerateSummaryAsync(
+                        contentToAnalyze,
+                        prompt,
+                        AttachmentSummaryCompletionTokens,
+                        operationName: AttachmentSummaryPromptType,
+                        promptVersion: promptVersion,
+                        fileName: fileName),
                     AIProviderPayloadValidator.IsValidAttachmentSummaryText,
                     "attachment summary");
                 await LogPromptOutputAsync(AttachmentSummaryPromptType, promptVersion, result.CaptureOutput);

--- a/applications/Unity.GrantManager/modules/Unity.SharedKernel/Http/IResilientHttpRequest.cs
+++ b/applications/Unity.GrantManager/modules/Unity.SharedKernel/Http/IResilientHttpRequest.cs
@@ -17,6 +17,7 @@ namespace Unity.Modules.Shared.Http
             object? body = null,
             string? authToken = null,
             (string username, string password)? basicAuth = null,
+            HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead,
             CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/applications/Unity.GrantManager/modules/Unity.SharedKernel/Http/ResilientHttpRequest.cs
+++ b/applications/Unity.GrantManager/modules/Unity.SharedKernel/Http/ResilientHttpRequest.cs
@@ -113,10 +113,11 @@ namespace Unity.Modules.Shared.Http
             object? body = null,
             string? authToken = null,
             (string username, string password)? basicAuth = null,
+            HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead,
             CancellationToken cancellationToken = default)
         {
             return await SendWithClientAsync(
-                _httpClient, httpVerb, resource, body, authToken, basicAuth, cancellationToken);
+                _httpClient, httpVerb, resource, body, authToken, basicAuth, completionOption, cancellationToken);
         }
 
 
@@ -137,7 +138,7 @@ namespace Unity.Modules.Shared.Http
             EnsureMutualTlsClient(certPath, certPassword);
 
             return SendWithClientAsync(
-                _mtlsClient!, httpVerb, resource, body, authToken, basicAuth, cancellationToken);
+                _mtlsClient!, httpVerb, resource, body, authToken, basicAuth, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
 
@@ -191,6 +192,7 @@ namespace Unity.Modules.Shared.Http
             object? body,
             string? authToken,
             (string username, string password)? basicAuth,
+            HttpCompletionOption completionOption,
             CancellationToken cancellationToken)
         {
             // Build final URL
@@ -208,7 +210,7 @@ namespace Unity.Modules.Shared.Http
                 using var requestMessage =
                     BuildRequestMessage(httpVerb, fullUrl, body, authToken, basicAuth);
 
-                return await client.SendAsync(requestMessage, ct)
+                return await client.SendAsync(requestMessage, completionOption, ct)
                                    .ConfigureAwait(false);
 
             }, cancellationToken);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Intakes/ChefsFileAttachmentStream.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Intakes/ChefsFileAttachmentStream.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Unity.GrantManager.Intakes;
+
+/// <summary>
+/// Stream of a CHEFS file attachment plus its content type.
+/// The Content stream owns its underlying temp file; dispose to release.
+/// </summary>
+public sealed class ChefsFileAttachmentStream : IDisposable, IAsyncDisposable
+{
+    public Stream Content { get; }
+    public string ContentType { get; }
+
+    public ChefsFileAttachmentStream(Stream content, string contentType)
+    {
+        Content = content ?? throw new ArgumentNullException(nameof(content));
+        ContentType = string.IsNullOrWhiteSpace(contentType) ? "application/octet-stream" : contentType;
+    }
+
+    public static ChefsFileAttachmentStream Empty { get; } =
+        new(Stream.Null, "application/octet-stream");
+
+    public void Dispose() => Content.Dispose();
+
+    public ValueTask DisposeAsync() => Content.DisposeAsync();
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Intakes/IChefsFileAttachmentStreamProvider.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Intakes/IChefsFileAttachmentStreamProvider.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Unity.GrantManager.Intakes;
+
+public interface IChefsFileAttachmentStreamProvider
+{
+    Task<ChefsFileAttachmentStream> OpenAsync(Guid formSubmissionId, Guid chefsFileAttachmentId, string name);
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Intakes/ISubmissionAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Intakes/ISubmissionAppService.cs
@@ -33,4 +33,10 @@ public interface ISubmissionAppService : IApplicationService
     /// <param name="name">File name of the chefs attachment</param>
     /// <returns>BlobDto</returns>
     Task<BlobDto> GetChefsFileAttachment(Guid? formSubmissionId, Guid? chefsFileAttachmentId, string name);
+
+    /// <summary>
+    /// Get a CHEFS file attachment as a Stream backed by a temp file (deleted on close).
+    /// Avoids buffering the full file in managed memory.
+    /// </summary>
+    Task<ChefsFileAttachmentStream> GetChefsFileAttachmentStream(Guid? formSubmissionId, Guid? chefsFileAttachmentId, string name);
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Intakes/ISubmissionAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Intakes/ISubmissionAppService.cs
@@ -34,9 +34,4 @@ public interface ISubmissionAppService : IApplicationService
     /// <returns>BlobDto</returns>
     Task<BlobDto> GetChefsFileAttachment(Guid? formSubmissionId, Guid? chefsFileAttachmentId, string name);
 
-    /// <summary>
-    /// Get a CHEFS file attachment as a Stream backed by a temp file (deleted on close).
-    /// Avoids buffering the full file in managed memory.
-    /// </summary>
-    Task<ChefsFileAttachmentStream> GetChefsFileAttachmentStream(Guid? formSubmissionId, Guid? chefsFileAttachmentId, string name);
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/ChefsFileAttachmentStreamProvider.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/ChefsFileAttachmentStreamProvider.cs
@@ -1,0 +1,102 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Unity.GrantManager.Applications;
+using Unity.GrantManager.Integrations;
+using Unity.Modules.Shared.Http;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.Security.Encryption;
+
+namespace Unity.GrantManager.Intakes;
+
+public class ChefsFileAttachmentStreamProvider(
+    IApplicationFormSubmissionRepository applicationFormSubmissionRepository,
+    IRepository<ApplicationForm, Guid> applicationFormRepository,
+    IEndpointManagementAppService endpointManagementAppService,
+    IResilientHttpRequest resilientRestClient,
+    IStringEncryptionService stringEncryptionService)
+    : IChefsFileAttachmentStreamProvider, ITransientDependency
+{
+    public async Task<ChefsFileAttachmentStream> OpenAsync(Guid formSubmissionId, Guid chefsFileAttachmentId, string name)
+    {
+        var applicationForm = await GetApplicationFormBySubmissionId(formSubmissionId)
+            ?? throw new ApiException(400, "Missing Form configuration");
+
+        if (applicationForm.ChefsApplicationFormGuid == null)
+        {
+            throw new ApiException(400, "Missing CHEFS form Id");
+        }
+
+        if (applicationForm.ApiKey == null)
+        {
+            throw new ApiException(400, "Missing CHEFS Api Key");
+        }
+
+        var chefsApi = await endpointManagementAppService.GetChefsApiBaseUrlAsync();
+        var url = $"{chefsApi}/files/{chefsFileAttachmentId}";
+        var decryptedApiKey = stringEncryptionService.Decrypt(applicationForm.ApiKey);
+
+        using var response = await resilientRestClient.HttpAsync(
+            HttpMethod.Get,
+            url,
+            null,
+            null,
+            basicAuth: (applicationForm.ChefsApplicationFormGuid, decryptedApiKey ?? string.Empty),
+            completionOption: HttpCompletionOption.ResponseHeadersRead
+        );
+
+        if (((int)response.StatusCode) != 200)
+        {
+            var errorContent = response.Content != null ? await response.Content.ReadAsStringAsync() : string.Empty;
+            throw new ApiException((int)response.StatusCode, "Error calling GetChefsFileAttachment: " + errorContent, response.ReasonPhrase ?? $"{response.StatusCode}");
+        }
+
+        var contentType = response.Content?.Headers?.ContentType?.MediaType ?? "application/octet-stream";
+        var extension = !string.IsNullOrEmpty(name) ? Path.GetExtension(Uri.UnescapeDataString(name)) : string.Empty;
+        var tempPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}{extension}");
+
+        try
+        {
+            await using (var writeStream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan))
+            await using (var contentStream = await response.Content!.ReadAsStreamAsync())
+            {
+                await contentStream.CopyToAsync(writeStream);
+            }
+
+            var readStream = new FileStream(tempPath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan | FileOptions.DeleteOnClose);
+            return new ChefsFileAttachmentStream(readStream, contentType);
+        }
+        catch
+        {
+            TryDeleteTempFile(tempPath);
+            throw;
+        }
+    }
+
+    private async Task<ApplicationForm?> GetApplicationFormBySubmissionId(Guid formSubmissionId)
+    {
+        var submission = await applicationFormSubmissionRepository.FirstOrDefaultAsync(
+            x => x.ChefsSubmissionGuid == formSubmissionId.ToString());
+
+        return submission == null
+            ? null
+            : await applicationFormRepository.FirstOrDefaultAsync(x => x.Id == submission.ApplicationFormId);
+    }
+
+    private static void TryDeleteTempFile(string tempPath)
+    {
+        try
+        {
+            if (File.Exists(tempPath))
+            {
+                File.Delete(tempPath);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup; never throw from cleanup path.
+        }
+    }
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/SubmissionAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/SubmissionAppService.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -111,87 +110,6 @@ public class SubmissionAppService(
 
         return new BlobDto { Name = name, Content = contentBytes, ContentType = contentType };
     }
-
-    [AllowAnonymous]
-    public async Task<ChefsFileAttachmentStream> GetChefsFileAttachmentStream(Guid? formSubmissionId, Guid? chefsFileAttachmentId, string name)
-    {
-        if (formSubmissionId == null)
-        {
-            throw new ApiException(400, "Missing required parameter 'formId' when calling GetSubmission");
-        }
-
-        if (chefsFileAttachmentId == null)
-        {
-            throw new ApiException(400, "Missing required parameter 'chefsFileAttachmentId' when calling GetFileAttachment");
-        }
-
-        ApplicationForm? applicationForm = await GetApplicationFormBySubmissionId(formSubmissionId) ?? throw new ApiException(400, "Missing Form configuration");
-        if (applicationForm.ChefsApplicationFormGuid == null)
-        {
-            throw new ApiException(400, "Missing CHEFS form Id");
-        }
-
-        if (applicationForm.ApiKey == null)
-        {
-            throw new ApiException(400, "Missing CHEFS Api Key");
-        }
-
-        string chefsApi = await endpointManagementAppService.GetChefsApiBaseUrlAsync();
-        string url = $"{chefsApi}/files/{chefsFileAttachmentId}";
-        var decryptedApiKey = stringEncryptionService.Decrypt(applicationForm.ApiKey!);
-
-        using var response = await resilientRestClient.HttpAsync(
-            HttpMethod.Get,
-            url,
-            null,
-            null,
-            basicAuth: (applicationForm.ChefsApplicationFormGuid!, decryptedApiKey ?? string.Empty),
-            completionOption: HttpCompletionOption.ResponseHeadersRead
-        );
-
-        if (((int)response.StatusCode) != 200)
-        {
-            var errorContent = response.Content != null ? await response.Content.ReadAsStringAsync() : string.Empty;
-            throw new ApiException((int)response.StatusCode, "Error calling GetChefsFileAttachment: " + errorContent, response.ReasonPhrase ?? $"{response.StatusCode}");
-        }
-
-        var contentType = response.Content?.Headers?.ContentType?.MediaType ?? "application/octet-stream";
-        var extension = !string.IsNullOrEmpty(name) ? Path.GetExtension(Uri.UnescapeDataString(name)) : string.Empty;
-        var tempPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}{extension}");
-
-        try
-        {
-            await using (var writeStream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan))
-            await using (var contentStream = await response.Content!.ReadAsStreamAsync())
-            {
-                await contentStream.CopyToAsync(writeStream);
-            }
-
-            var readStream = new FileStream(tempPath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan | FileOptions.DeleteOnClose);
-            return new ChefsFileAttachmentStream(readStream, contentType);
-        }
-        catch
-        {
-            TryDeleteTempFile(tempPath);
-            throw;
-        }
-    }
-
-    private static void TryDeleteTempFile(string tempPath)
-    {
-        try
-        {
-            if (File.Exists(tempPath))
-            {
-                File.Delete(tempPath);
-            }
-        }
-        catch
-        {
-            // Best-effort cleanup; never throw from cleanup path.
-        }
-    }
-
 
     public async Task<ApplicationForm?> GetApplicationFormBySubmissionId(Guid? formSubmissionId)
     {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/SubmissionAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/SubmissionAppService.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -109,6 +110,86 @@ public class SubmissionAppService(
         }
 
         return new BlobDto { Name = name, Content = contentBytes, ContentType = contentType };
+    }
+
+    [AllowAnonymous]
+    public async Task<ChefsFileAttachmentStream> GetChefsFileAttachmentStream(Guid? formSubmissionId, Guid? chefsFileAttachmentId, string name)
+    {
+        if (formSubmissionId == null)
+        {
+            throw new ApiException(400, "Missing required parameter 'formId' when calling GetSubmission");
+        }
+
+        if (chefsFileAttachmentId == null)
+        {
+            throw new ApiException(400, "Missing required parameter 'chefsFileAttachmentId' when calling GetFileAttachment");
+        }
+
+        ApplicationForm? applicationForm = await GetApplicationFormBySubmissionId(formSubmissionId) ?? throw new ApiException(400, "Missing Form configuration");
+        if (applicationForm.ChefsApplicationFormGuid == null)
+        {
+            throw new ApiException(400, "Missing CHEFS form Id");
+        }
+
+        if (applicationForm.ApiKey == null)
+        {
+            throw new ApiException(400, "Missing CHEFS Api Key");
+        }
+
+        string chefsApi = await endpointManagementAppService.GetChefsApiBaseUrlAsync();
+        string url = $"{chefsApi}/files/{chefsFileAttachmentId}";
+        var decryptedApiKey = stringEncryptionService.Decrypt(applicationForm.ApiKey!);
+
+        using var response = await resilientRestClient.HttpAsync(
+            HttpMethod.Get,
+            url,
+            null,
+            null,
+            basicAuth: (applicationForm.ChefsApplicationFormGuid!, decryptedApiKey ?? string.Empty),
+            completionOption: HttpCompletionOption.ResponseHeadersRead
+        );
+
+        if (((int)response.StatusCode) != 200)
+        {
+            var errorContent = response.Content != null ? await response.Content.ReadAsStringAsync() : string.Empty;
+            throw new ApiException((int)response.StatusCode, "Error calling GetChefsFileAttachment: " + errorContent, response.ReasonPhrase ?? $"{response.StatusCode}");
+        }
+
+        var contentType = response.Content?.Headers?.ContentType?.MediaType ?? "application/octet-stream";
+        var extension = !string.IsNullOrEmpty(name) ? Path.GetExtension(Uri.UnescapeDataString(name)) : string.Empty;
+        var tempPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}{extension}");
+
+        try
+        {
+            await using (var writeStream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan))
+            await using (var contentStream = await response.Content!.ReadAsStreamAsync())
+            {
+                await contentStream.CopyToAsync(writeStream);
+            }
+
+            var readStream = new FileStream(tempPath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan | FileOptions.DeleteOnClose);
+            return new ChefsFileAttachmentStream(readStream, contentType);
+        }
+        catch
+        {
+            TryDeleteTempFile(tempPath);
+            throw;
+        }
+    }
+
+    private static void TryDeleteTempFile(string tempPath)
+    {
+        try
+        {
+            if (File.Exists(tempPath))
+            {
+                File.Delete(tempPath);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup; never throw from cleanup path.
+        }
     }
 
 

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/AttachmentSummaryServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/AttachmentSummaryServiceTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Unity.AI;
+using Unity.AI.Extraction;
+using Unity.AI.Operations;
+using Unity.AI.Requests;
+using Unity.AI.Responses;
+using Unity.GrantManager.Applications;
+using Unity.GrantManager.Intakes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Unity.GrantManager.AI.Operations;
+
+public class AttachmentSummaryServiceTests : GrantManagerApplicationTestBase
+{
+    public AttachmentSummaryServiceTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+    }
+
+    [Fact]
+    public async Task GenerateAndSaveAsync_Uses_Streamed_Attachment_Text()
+    {
+        var attachmentId = Guid.NewGuid();
+        var submissionId = Guid.NewGuid();
+        var fileId = Guid.NewGuid();
+        var stream = new MemoryStream([1, 2, 3]);
+        AttachmentSummaryRequest? capturedRequest = null;
+
+        var attachment = new ApplicationChefsFileAttachment
+        {
+            ApplicationId = Guid.NewGuid(),
+            FileName = "test.txt",
+            ChefsSubmissionId = submissionId.ToString(),
+            ChefsFileId = fileId.ToString()
+        };
+
+        var attachmentRepository = Substitute.For<IApplicationChefsFileAttachmentRepository>();
+        attachmentRepository.GetAsync(attachmentId).Returns(attachment);
+
+        var streamProvider = Substitute.For<IChefsFileAttachmentStreamProvider>();
+        streamProvider.OpenAsync(submissionId, fileId, "test.txt")
+            .Returns(new ChefsFileAttachmentStream(stream, "text/plain"));
+
+        var textExtractionService = Substitute.For<ITextExtractionService>();
+        textExtractionService.ExtractTextAsync("test.txt", stream, "text/plain")
+            .Returns("extracted text");
+
+        var aiService = Substitute.For<IAIService>();
+        aiService.GenerateAttachmentSummaryAsync(Arg.Do<AttachmentSummaryRequest>(request => capturedRequest = request))
+            .Returns(new AttachmentSummaryResponse { Summary = "summary text" });
+
+        var service = new AttachmentSummaryService(
+            attachmentRepository,
+            streamProvider,
+            textExtractionService,
+            aiService,
+            NullLogger<AttachmentSummaryService>.Instance);
+
+        var result = await service.GenerateAndSaveAsync(attachmentId, "v1");
+
+        result.ShouldBe("summary text");
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest.FileName.ShouldBe("test.txt");
+        capturedRequest.ContentType.ShouldBe("text/plain");
+        capturedRequest.ExtractedText.ShouldBe("extracted text");
+        capturedRequest.PromptVersion.ShouldBe("v1");
+        attachment.AISummary.ShouldBe("summary text");
+
+        await attachmentRepository.Received(1).UpdateAsync(attachment);
+        stream.CanRead.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Pull request overview

Implements AB#32302 by streaming attachment content end-to-end through the AI summary flow, instead of buffering each attachment as a `byte[]` in memory.

The CHEFS attachment fetch now uses `HttpCompletionOption.ResponseHeadersRead` and exposes the network stream via a small DTO (`ChefsFileAttachmentStream`). `AttachmentSummaryService` writes the stream to a per-call temp `FileStream` (random GUID path) and hands it directly to `ITextExtractionService`, which is now Stream-only. `OpenAIRuntimeService` consumes the already-extracted text via `request.ExtractedText`. Existing summary behavior, error handling, and logging are preserved.

Scope is attachment processing only. No prompt, UI, or AI behavior changes.

**Changes:**
- `IResilientHttpRequest` / `ResilientHttpRequest` accept an `HttpCompletionOption` so the caller can pick `ResponseHeadersRead`
- New `ChefsFileAttachmentStream` DTO; `ISubmissionAppService` exposes a streaming variant
- `AttachmentSummaryService` streams to a per-call temp file and passes the `Stream` to `ITextExtractionService`
- `TextExtractionService` becomes Stream-only (drops byte[] paths)
- `AttachmentSummaryRequest` carries `ExtractedText`; `OpenAIRuntimeService` consumes it directly
- Error handling and logging for attachment failures preserved