### PR TITLE
Feature/ab#32290 throttle ai analysis requests

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/RateLimit/AIRateLimitStateDto.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/RateLimit/AIRateLimitStateDto.cs
@@ -1,0 +1,6 @@
+namespace Unity.AI.RateLimit;
+
+public class AIRateLimitStateDto
+{
+    public int RetryAfterSeconds { get; set; }
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/RateLimit/IAIRateLimitAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/RateLimit/IAIRateLimitAppService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+using Volo.Abp.Application.Services;
+
+namespace Unity.AI.RateLimit;
+
+public interface IAIRateLimitAppService : IApplicationService
+{
+    Task<AIRateLimitStateDto> GetStateAsync();
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/RateLimit/IAIRateLimiter.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/RateLimit/IAIRateLimiter.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using System;
 
 namespace Unity.AI.RateLimit;
 
@@ -6,9 +7,19 @@ public interface IAIRateLimiter
 {
     /// <summary>
     /// Throws <see cref="Volo.Abp.UserFriendlyException"/> if the current user is still
-    /// inside their AI generate cooldown window, otherwise stamps a fresh cooldown.
+    /// inside their AI generate cooldown window.
     /// </summary>
-    Task EnsureAndStampAsync();
+    Task EnsureAsync();
+
+    /// <summary>
+    /// Starts a fresh cooldown for the current user. No-op for callers without a user.
+    /// </summary>
+    Task StampAsync();
+
+    /// <summary>
+    /// Starts a fresh cooldown for the supplied user. No-op when userId is null.
+    /// </summary>
+    Task StampAsync(Guid? userId);
 
     /// <summary>
     /// Returns the remaining cooldown for the current user. RetryAfterSeconds is 0 when

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/RateLimit/IAIRateLimiter.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/RateLimit/IAIRateLimiter.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+
+namespace Unity.AI.RateLimit;
+
+public interface IAIRateLimiter
+{
+    /// <summary>
+    /// Throws <see cref="Volo.Abp.UserFriendlyException"/> if the current user is still
+    /// inside their AI generate cooldown window, otherwise stamps a fresh cooldown.
+    /// </summary>
+    Task EnsureAndStampAsync();
+
+    /// <summary>
+    /// Returns the remaining cooldown for the current user. RetryAfterSeconds is 0 when
+    /// the user can generate immediately.
+    /// </summary>
+    Task<AIRateLimitStateDto> GetStateAsync();
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/RateLimit/AIRateLimitAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/RateLimit/AIRateLimitAppService.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Unity.AI.RateLimit;
+
+[Authorize]
+public class AIRateLimitAppService(IAIRateLimiter rateLimiter)
+    : AIAppService, IAIRateLimitAppService
+{
+    public virtual Task<AIRateLimitStateDto> GetStateAsync() => rateLimiter.GetStateAsync();
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/RateLimit/AIRateLimiter.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/RateLimit/AIRateLimiter.cs
@@ -26,8 +26,14 @@ public class AIRateLimiter(
     private const string LockPrefix = "AI:CooldownLock:";
     private const int DefaultCooldownSeconds = 60;
 
-    private int CooldownSeconds =>
-        configuration.GetValue<int?>("AI:RateLimit:CooldownSeconds") ?? DefaultCooldownSeconds;
+    private int CooldownSeconds
+    {
+        get
+        {
+            var configured = configuration.GetValue<int?>("AI:RateLimit:CooldownSeconds");
+            return configured > 0 ? configured.Value : DefaultCooldownSeconds;
+        }
+    }
 
     public virtual async Task EnsureAsync()
     {
@@ -58,7 +64,11 @@ public class AIRateLimiter(
     {
         if (userId is Guid resolvedUserId)
         {
-            await StampAsync(resolvedUserId, CooldownSeconds);
+            var userLock = distributedLockProvider.CreateLock(LockPrefix + resolvedUserId);
+            using (await userLock.AcquireAsync())
+            {
+                await StampAsync(resolvedUserId, CooldownSeconds);
+            }
         }
     }
 
@@ -69,10 +79,14 @@ public class AIRateLimiter(
             return new AIRateLimitStateDto { RetryAfterSeconds = 0 };
         }
 
-        return new AIRateLimitStateDto
+        var userLock = distributedLockProvider.CreateLock(LockPrefix + userId);
+        using (await userLock.AcquireAsync())
         {
-            RetryAfterSeconds = await GetRemainingSecondsAsync(userId)
-        };
+            return new AIRateLimitStateDto
+            {
+                RetryAfterSeconds = await GetRemainingSecondsAsync(userId)
+            };
+        }
     }
 
     private async Task<int> GetRemainingSecondsAsync(Guid userId)

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/RateLimit/AIRateLimiter.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/RateLimit/AIRateLimiter.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Configuration;
+using Volo.Abp;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Users;
+
+namespace Unity.AI.RateLimit;
+
+/// <summary>
+/// Per-user cooldown for AI generate calls. KISS: a single cache entry per user
+/// holds the cooldown end ticks; the cache TTL matches the cooldown so a missing
+/// entry means the user can generate again. Anonymous/system callers are not
+/// rate-limited (background event handlers also flow through the AI queue).
+/// </summary>
+public class AIRateLimiter(
+    IDistributedCache cache,
+    ICurrentUser currentUser,
+    IConfiguration configuration) : IAIRateLimiter, ITransientDependency
+{
+    private const string KeyPrefix = "AI:Cooldown:";
+    private const int DefaultCooldownSeconds = 60;
+
+    private int CooldownSeconds =>
+        configuration.GetValue<int?>("AI:RateLimit:CooldownSeconds") ?? DefaultCooldownSeconds;
+
+    public virtual async Task EnsureAndStampAsync()
+    {
+        if (currentUser.Id is not Guid userId)
+        {
+            // No user (background/system flow). User-level rate limit does not apply.
+            return;
+        }
+
+        var remaining = await GetRemainingSecondsAsync(userId);
+        if (remaining > 0)
+        {
+            throw new UserFriendlyException(
+                $"AI generation is rate limited. Try again in {remaining} second{(remaining == 1 ? "" : "s")}.");
+        }
+
+        await StampAsync(userId, CooldownSeconds);
+    }
+
+    public virtual async Task<AIRateLimitStateDto> GetStateAsync()
+    {
+        if (currentUser.Id is not Guid userId)
+        {
+            return new AIRateLimitStateDto { RetryAfterSeconds = 0 };
+        }
+
+        return new AIRateLimitStateDto
+        {
+            RetryAfterSeconds = await GetRemainingSecondsAsync(userId)
+        };
+    }
+
+    private async Task<int> GetRemainingSecondsAsync(Guid userId)
+    {
+        var raw = await cache.GetStringAsync(KeyFor(userId));
+        if (string.IsNullOrEmpty(raw) ||
+            !long.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var untilTicks) ||
+            untilTicks < DateTime.MinValue.Ticks ||
+            untilTicks > DateTime.MaxValue.Ticks)
+        {
+            return 0;
+        }
+
+        var seconds = (int)Math.Ceiling((new DateTime(untilTicks, DateTimeKind.Utc) - DateTime.UtcNow).TotalSeconds);
+        return seconds > 0 ? seconds : 0;
+    }
+
+    private async Task StampAsync(Guid userId, int seconds)
+    {
+        var until = DateTime.UtcNow.AddSeconds(seconds);
+        await cache.SetStringAsync(
+            KeyFor(userId),
+            until.Ticks.ToString(CultureInfo.InvariantCulture),
+            new DistributedCacheEntryOptions { AbsoluteExpiration = until });
+    }
+
+    private static string KeyFor(Guid userId) => KeyPrefix + userId;
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/RateLimit/AIRateLimiter.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/RateLimit/AIRateLimiter.cs
@@ -29,7 +29,7 @@ public class AIRateLimiter(
     private int CooldownSeconds =>
         configuration.GetValue<int?>("AI:RateLimit:CooldownSeconds") ?? DefaultCooldownSeconds;
 
-    public virtual async Task EnsureAndStampAsync()
+    public virtual async Task EnsureAsync()
     {
         if (currentUser.Id is not Guid userId)
         {
@@ -46,8 +46,19 @@ public class AIRateLimiter(
                 throw new UserFriendlyException(
                     $"AI generation is rate limited. Try again in {remaining} second{(remaining == 1 ? "" : "s")}.");
             }
+        }
+    }
 
-            await StampAsync(userId, CooldownSeconds);
+    public virtual async Task StampAsync()
+    {
+        await StampAsync(currentUser.Id);
+    }
+
+    public virtual async Task StampAsync(Guid? userId)
+    {
+        if (userId is Guid resolvedUserId)
+        {
+            await StampAsync(resolvedUserId, CooldownSeconds);
         }
     }
 

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/RateLimit/AIRateLimiter.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/RateLimit/AIRateLimiter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Threading.Tasks;
+using Medallion.Threading;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 using Volo.Abp;
@@ -18,9 +19,11 @@ namespace Unity.AI.RateLimit;
 public class AIRateLimiter(
     IDistributedCache cache,
     ICurrentUser currentUser,
-    IConfiguration configuration) : IAIRateLimiter, ITransientDependency
+    IConfiguration configuration,
+    IDistributedLockProvider distributedLockProvider) : IAIRateLimiter, ITransientDependency
 {
     private const string KeyPrefix = "AI:Cooldown:";
+    private const string LockPrefix = "AI:CooldownLock:";
     private const int DefaultCooldownSeconds = 60;
 
     private int CooldownSeconds =>
@@ -34,14 +37,18 @@ public class AIRateLimiter(
             return;
         }
 
-        var remaining = await GetRemainingSecondsAsync(userId);
-        if (remaining > 0)
+        var userLock = distributedLockProvider.CreateLock(LockPrefix + userId);
+        using (await userLock.AcquireAsync())
         {
-            throw new UserFriendlyException(
-                $"AI generation is rate limited. Try again in {remaining} second{(remaining == 1 ? "" : "s")}.");
-        }
+            var remaining = await GetRemainingSecondsAsync(userId);
+            if (remaining > 0)
+            {
+                throw new UserFriendlyException(
+                    $"AI generation is rate limited. Try again in {remaining} second{(remaining == 1 ? "" : "s")}.");
+            }
 
-        await StampAsync(userId, CooldownSeconds);
+            await StampAsync(userId, CooldownSeconds);
+        }
     }
 
     public virtual async Task<AIRateLimitStateDto> GetStateAsync()

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Unity.AI.Application.csproj
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Unity.AI.Application.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Volo.Abp.Mapperly" Version="10.3.0" />
     <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
     <PackageReference Include="Volo.Abp.Ddd.Application" Version="10.3.0" />
+    <PackageReference Include="Volo.Abp.DistributedLocking" Version="10.3.0" />
     <PackageReference Include="Volo.Abp.EntityFrameworkCore" Version="10.3.0" />
     <PackageReference Include="Volo.Abp.Features" Version="10.3.0" />
     <PackageReference Include="Volo.Abp.TenantManagement.Domain" Version="10.3.0" />

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/Automation/BackgroundJobs/GenerateApplicationAnalysisBackgroundJobArgs.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/Automation/BackgroundJobs/GenerateApplicationAnalysisBackgroundJobArgs.cs
@@ -4,6 +4,7 @@ public class GenerateApplicationAnalysisBackgroundJobArgs
 {
     public Guid ApplicationId { get; set; }
     public Guid? TenantId { get; set; }
+    public Guid? RequestedByUserId { get; set; }
     public string? PromptVersion { get; set; }
     public string RequestKey { get; set; } = string.Empty;
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/Automation/BackgroundJobs/GenerateApplicationScoringBackgroundJobArgs.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/Automation/BackgroundJobs/GenerateApplicationScoringBackgroundJobArgs.cs
@@ -4,6 +4,7 @@ public class GenerateApplicationScoringBackgroundJobArgs
 {
     public Guid ApplicationId { get; set; }
     public Guid? TenantId { get; set; }
+    public Guid? RequestedByUserId { get; set; }
     public string? PromptVersion { get; set; }
     public string RequestKey { get; set; } = string.Empty;
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/Automation/BackgroundJobs/GenerateAttachmentSummaryBackgroundJobArgs.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/Automation/BackgroundJobs/GenerateAttachmentSummaryBackgroundJobArgs.cs
@@ -4,6 +4,7 @@ public class GenerateAttachmentSummaryBackgroundJobArgs
 {
     public Guid ApplicationId { get; set; }
     public Guid? TenantId { get; set; }
+    public Guid? RequestedByUserId { get; set; }
     public string? PromptVersion { get; set; }
     public string RequestKey { get; set; } = string.Empty;
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/Automation/BackgroundJobs/RunApplicationAIPipelineJobArgs.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/Automation/BackgroundJobs/RunApplicationAIPipelineJobArgs.cs
@@ -6,6 +6,7 @@ public class RunApplicationAIPipelineJobArgs
 {
     public Guid ApplicationId { get; set; }
     public Guid? TenantId { get; set; }
+    public Guid? RequestedByUserId { get; set; }
     public string? PromptVersion { get; set; }
     public string RequestKey { get; set; } = string.Empty;
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/ApplicationAIGenerationQueue.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/ApplicationAIGenerationQueue.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Unity.AI.Automation;
+using Unity.AI.RateLimit;
 using Unity.GrantManager.GrantApplications;
 using Unity.GrantManager.GrantApplications.Automation.BackgroundJobs;
 using Medallion.Threading;
@@ -16,6 +17,7 @@ public class ApplicationAIGenerationQueue(
     IBackgroundJobManager backgroundJobManager,
     IRepository<AIGenerationRequest, Guid> generationRequestRepository,
     IDistributedLockProvider distributedLockProvider,
+    IAIRateLimiter aiRateLimiter,
     ILogger<ApplicationAIGenerationQueue> logger)
     : IApplicationAIGenerationQueue, ITransientDependency
 {
@@ -106,6 +108,10 @@ public class ApplicationAIGenerationQueue(
         Guid? applicationId,
         Func<Task> enqueue)
     {
+        // Single chokepoint for all AI generate flows (manual + auto).
+        // The limiter is a no-op for system/background callers without an authenticated user.
+        await aiRateLimiter.EnsureAndStampAsync();
+
         var requestLock = distributedLockProvider.CreateLock($"ai-generation:{requestKey}");
 
         using (await requestLock.AcquireAsync())

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/ApplicationAIGenerationQueue.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/ApplicationAIGenerationQueue.cs
@@ -108,10 +108,6 @@ public class ApplicationAIGenerationQueue(
         Guid? applicationId,
         Func<Task> enqueue)
     {
-        // Single chokepoint for all AI generate flows (manual + auto).
-        // The limiter is a no-op for system/background callers without an authenticated user.
-        await aiRateLimiter.EnsureAndStampAsync();
-
         var requestLock = distributedLockProvider.CreateLock($"ai-generation:{requestKey}");
 
         using (await requestLock.AcquireAsync())
@@ -130,6 +126,10 @@ public class ApplicationAIGenerationQueue(
             {
                 return;
             }
+
+            // Single chokepoint for all AI generate flows (manual + auto).
+            // The limiter is a no-op for system/background callers without an authenticated user.
+            await aiRateLimiter.EnsureAndStampAsync();
 
             var request = new AIGenerationRequest(
                 Guid.NewGuid(),

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/ApplicationAIGenerationQueue.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/ApplicationAIGenerationQueue.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.BackgroundJobs;
 using Volo.Abp.DependencyInjection;
+using Volo.Abp.Users;
 
 namespace Unity.GrantManager.GrantApplications.Automation;
 
@@ -18,6 +19,7 @@ public class ApplicationAIGenerationQueue(
     IRepository<AIGenerationRequest, Guid> generationRequestRepository,
     IDistributedLockProvider distributedLockProvider,
     IAIRateLimiter aiRateLimiter,
+    ICurrentUser currentUser,
     ILogger<ApplicationAIGenerationQueue> logger)
     : IApplicationAIGenerationQueue, ITransientDependency
 {
@@ -35,6 +37,7 @@ public class ApplicationAIGenerationQueue(
                 {
                     ApplicationId = applicationId,
                     PromptVersion = promptVersion,
+                    RequestedByUserId = currentUser.Id,
                     TenantId = tenantId,
                     RequestKey = requestKey
                 });
@@ -55,6 +58,7 @@ public class ApplicationAIGenerationQueue(
                 {
                     ApplicationId = applicationId,
                     PromptVersion = promptVersion,
+                    RequestedByUserId = currentUser.Id,
                     TenantId = tenantId,
                     RequestKey = requestKey
                 });
@@ -75,6 +79,7 @@ public class ApplicationAIGenerationQueue(
                 {
                     ApplicationId = applicationId,
                     PromptVersion = promptVersion,
+                    RequestedByUserId = currentUser.Id,
                     TenantId = tenantId,
                     RequestKey = requestKey
                 });
@@ -95,6 +100,7 @@ public class ApplicationAIGenerationQueue(
                 {
                     ApplicationId = applicationId,
                     PromptVersion = promptVersion,
+                    RequestedByUserId = currentUser.Id,
                     TenantId = tenantId,
                     RequestKey = requestKey
                 });

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/ApplicationAIGenerationQueue.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/ApplicationAIGenerationQueue.cs
@@ -129,7 +129,7 @@ public class ApplicationAIGenerationQueue(
 
             // Single chokepoint for all AI generate flows (manual + auto).
             // The limiter is a no-op for system/background callers without an authenticated user.
-            await aiRateLimiter.EnsureAndStampAsync();
+            await aiRateLimiter.EnsureAsync();
 
             var request = new AIGenerationRequest(
                 Guid.NewGuid(),

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/AIGenerationRequestJobHelper.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/AIGenerationRequestJobHelper.cs
@@ -61,7 +61,7 @@ public static class AIGenerationRequestJobHelper
         await uow.CompleteAsync();
     }
 
-    public static async Task MarkCompletedInNewUowAsync(
+    public static async Task<Guid?> MarkCompletedInNewUowAsync(
         IUnitOfWorkManager unitOfWorkManager,
         IRepository<AIGenerationRequest, Guid> generationRequestRepository,
         string requestKey)
@@ -70,6 +70,7 @@ public static class AIGenerationRequestJobHelper
         var request = await GetLatestRequestAsync(generationRequestRepository, x => x.RequestKey == requestKey);
         await MarkCompletedAsync(generationRequestRepository, request);
         await uow.CompleteAsync();
+        return request?.CreatorId;
     }
 
     public static async Task MarkFailedInNewUowAsync(

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/AIGenerationRequestJobHelper.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/AIGenerationRequestJobHelper.cs
@@ -61,7 +61,7 @@ public static class AIGenerationRequestJobHelper
         await uow.CompleteAsync();
     }
 
-    public static async Task<Guid?> MarkCompletedInNewUowAsync(
+    public static async Task<Guid?> MarkCompletedInNewUowAndGetCreatorIdAsync(
         IUnitOfWorkManager unitOfWorkManager,
         IRepository<AIGenerationRequest, Guid> generationRequestRepository,
         string requestKey)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/AIGenerationRequestJobHelper.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/AIGenerationRequestJobHelper.cs
@@ -2,6 +2,8 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Unity.AI.RateLimit;
 using Unity.GrantManager.GrantApplications;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Uow;
@@ -82,6 +84,27 @@ public static class AIGenerationRequestJobHelper
         var request = await GetLatestRequestAsync(generationRequestRepository, x => x.RequestKey == requestKey);
         await MarkFailedAsync(generationRequestRepository, request, failureReason);
         await uow.CompleteAsync();
+    }
+
+    public static async Task StampRateLimitBestEffortAsync(
+        IAIRateLimiter aiRateLimiter,
+        ILogger logger,
+        Guid? requestedByUserId,
+        Guid applicationId,
+        string requestKey)
+    {
+        try
+        {
+            await aiRateLimiter.StampAsync(requestedByUserId);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "AI rate-limit cooldown stamp failed after completed AI generation request for application {ApplicationId} and request {RequestKey}.",
+                applicationId,
+                requestKey);
+        }
     }
 
     public static async Task<AIGenerationRequest?> GetLatestRequestAsync(

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/AIGenerationRequestJobHelper.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/AIGenerationRequestJobHelper.cs
@@ -61,7 +61,7 @@ public static class AIGenerationRequestJobHelper
         await uow.CompleteAsync();
     }
 
-    public static async Task<Guid?> MarkCompletedInNewUowAndGetCreatorIdAsync(
+    public static async Task MarkCompletedInNewUowAsync(
         IUnitOfWorkManager unitOfWorkManager,
         IRepository<AIGenerationRequest, Guid> generationRequestRepository,
         string requestKey)
@@ -70,7 +70,6 @@ public static class AIGenerationRequestJobHelper
         var request = await GetLatestRequestAsync(generationRequestRepository, x => x.RequestKey == requestKey);
         await MarkCompletedAsync(generationRequestRepository, request);
         await uow.CompleteAsync();
-        return request?.CreatorId;
     }
 
     public static async Task MarkFailedInNewUowAsync(

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationAnalysisJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationAnalysisJob.cs
@@ -31,8 +31,8 @@ public class GenerateApplicationAnalysisJob(
                 await applicationAnalysisService.RegenerateAndSaveAsync(args.ApplicationId, args.PromptVersion);
                 logger.LogInformation("Completed AI application analysis job for application {ApplicationId}.", args.ApplicationId);
 
-                var creatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAndGetCreatorIdAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
-                await aiRateLimiter.StampAsync(creatorId);
+                await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+                await aiRateLimiter.StampAsync(args.RequestedByUserId);
             }
             catch (Exception ex)
             {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationAnalysisJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationAnalysisJob.cs
@@ -32,7 +32,7 @@ public class GenerateApplicationAnalysisJob(
                 logger.LogInformation("Completed AI application analysis job for application {ApplicationId}.", args.ApplicationId);
 
                 await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
-                await aiRateLimiter.StampAsync(args.RequestedByUserId);
+                await AIGenerationRequestJobHelper.StampRateLimitBestEffortAsync(aiRateLimiter, logger, args.RequestedByUserId, args.ApplicationId, args.RequestKey);
             }
             catch (Exception ex)
             {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationAnalysisJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationAnalysisJob.cs
@@ -31,7 +31,7 @@ public class GenerateApplicationAnalysisJob(
                 await applicationAnalysisService.RegenerateAndSaveAsync(args.ApplicationId, args.PromptVersion);
                 logger.LogInformation("Completed AI application analysis job for application {ApplicationId}.", args.ApplicationId);
 
-                var creatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+                var creatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAndGetCreatorIdAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
                 await aiRateLimiter.StampAsync(creatorId);
             }
             catch (Exception ex)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationAnalysisJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationAnalysisJob.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 using Unity.AI.Operations;
+using Unity.AI.RateLimit;
 using Unity.GrantManager.GrantApplications;
 using Volo.Abp.BackgroundJobs;
 using Volo.Abp.DependencyInjection;
@@ -16,6 +17,7 @@ public class GenerateApplicationAnalysisJob(
     IRepository<AIGenerationRequest, Guid> generationRequestRepository,
     ICurrentTenant currentTenant,
     IUnitOfWorkManager unitOfWorkManager,
+    IAIRateLimiter aiRateLimiter,
     ILogger<GenerateApplicationAnalysisJob> logger) : AsyncBackgroundJob<GenerateApplicationAnalysisBackgroundJobArgs>, ITransientDependency
 {
     public override async Task ExecuteAsync(GenerateApplicationAnalysisBackgroundJobArgs args)
@@ -29,7 +31,8 @@ public class GenerateApplicationAnalysisJob(
                 await applicationAnalysisService.RegenerateAndSaveAsync(args.ApplicationId, args.PromptVersion);
                 logger.LogInformation("Completed AI application analysis job for application {ApplicationId}.", args.ApplicationId);
 
-                await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+                var creatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+                await aiRateLimiter.StampAsync(creatorId);
             }
             catch (Exception ex)
             {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationScoringJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationScoringJob.cs
@@ -40,7 +40,7 @@ public class GenerateApplicationScoringJob(
                 }
                 logger.LogInformation("Completed AI application scoring job for application {ApplicationId}.", args.ApplicationId);
 
-                var creatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+                var creatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAndGetCreatorIdAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
                 await aiRateLimiter.StampAsync(creatorId);
             }
             catch (Exception ex)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationScoringJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationScoringJob.cs
@@ -41,7 +41,7 @@ public class GenerateApplicationScoringJob(
                 logger.LogInformation("Completed AI application scoring job for application {ApplicationId}.", args.ApplicationId);
 
                 await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
-                await aiRateLimiter.StampAsync(args.RequestedByUserId);
+                await AIGenerationRequestJobHelper.StampRateLimitBestEffortAsync(aiRateLimiter, logger, args.RequestedByUserId, args.ApplicationId, args.RequestKey);
             }
             catch (Exception ex)
             {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationScoringJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationScoringJob.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
+using Unity.AI.RateLimit;
 using Unity.GrantManager.GrantApplications;
 using Unity.GrantManager.GrantApplications.Automation.Events;
 using Volo.Abp.BackgroundJobs;
@@ -18,6 +19,7 @@ public class GenerateApplicationScoringJob(
     ICurrentTenant currentTenant,
     IUnitOfWorkManager unitOfWorkManager,
     ILocalEventBus localEventBus,
+    IAIRateLimiter aiRateLimiter,
     ILogger<GenerateApplicationScoringJob> logger) : AsyncBackgroundJob<GenerateApplicationScoringBackgroundJobArgs>, ITransientDependency
 {
     public override async Task ExecuteAsync(GenerateApplicationScoringBackgroundJobArgs args)
@@ -37,7 +39,9 @@ public class GenerateApplicationScoringJob(
                     });
                 }
                 logger.LogInformation("Completed AI application scoring job for application {ApplicationId}.", args.ApplicationId);
-                await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+
+                var creatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+                await aiRateLimiter.StampAsync(creatorId);
             }
             catch (Exception ex)
             {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationScoringJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationScoringJob.cs
@@ -40,8 +40,8 @@ public class GenerateApplicationScoringJob(
                 }
                 logger.LogInformation("Completed AI application scoring job for application {ApplicationId}.", args.ApplicationId);
 
-                var creatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAndGetCreatorIdAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
-                await aiRateLimiter.StampAsync(creatorId);
+                await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+                await aiRateLimiter.StampAsync(args.RequestedByUserId);
             }
             catch (Exception ex)
             {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateAttachmentSummaryJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateAttachmentSummaryJob.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 using Unity.AI.Operations;
+using Unity.AI.RateLimit;
 using Unity.GrantManager.GrantApplications;
 using Volo.Abp.BackgroundJobs;
 using Volo.Abp.DependencyInjection;
@@ -16,6 +17,7 @@ public class GenerateAttachmentSummaryJob(
     IRepository<AIGenerationRequest, Guid> generationRequestRepository,
     ICurrentTenant currentTenant,
     IUnitOfWorkManager unitOfWorkManager,
+    IAIRateLimiter aiRateLimiter,
     ILogger<GenerateAttachmentSummaryJob> logger) : AsyncBackgroundJob<GenerateAttachmentSummaryBackgroundJobArgs>, ITransientDependency
 {
     public override async Task ExecuteAsync(GenerateAttachmentSummaryBackgroundJobArgs args)
@@ -29,7 +31,9 @@ public class GenerateAttachmentSummaryJob(
                     "Executing AI attachment summary job for application {ApplicationId}.",
                     args.ApplicationId);
                 await attachmentSummaryService.GenerateForApplicationAsync(args.ApplicationId, args.PromptVersion);
-                await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+
+                var creatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+                await aiRateLimiter.StampAsync(creatorId);
             }
             catch (Exception ex)
             {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateAttachmentSummaryJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateAttachmentSummaryJob.cs
@@ -32,8 +32,8 @@ public class GenerateAttachmentSummaryJob(
                     args.ApplicationId);
                 await attachmentSummaryService.GenerateForApplicationAsync(args.ApplicationId, args.PromptVersion);
 
-                var creatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAndGetCreatorIdAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
-                await aiRateLimiter.StampAsync(creatorId);
+                await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+                await aiRateLimiter.StampAsync(args.RequestedByUserId);
             }
             catch (Exception ex)
             {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateAttachmentSummaryJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateAttachmentSummaryJob.cs
@@ -32,7 +32,7 @@ public class GenerateAttachmentSummaryJob(
                     args.ApplicationId);
                 await attachmentSummaryService.GenerateForApplicationAsync(args.ApplicationId, args.PromptVersion);
 
-                var creatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+                var creatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAndGetCreatorIdAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
                 await aiRateLimiter.StampAsync(creatorId);
             }
             catch (Exception ex)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateAttachmentSummaryJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateAttachmentSummaryJob.cs
@@ -33,7 +33,7 @@ public class GenerateAttachmentSummaryJob(
                 await attachmentSummaryService.GenerateForApplicationAsync(args.ApplicationId, args.PromptVersion);
 
                 await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
-                await aiRateLimiter.StampAsync(args.RequestedByUserId);
+                await AIGenerationRequestJobHelper.StampRateLimitBestEffortAsync(aiRateLimiter, logger, args.RequestedByUserId, args.ApplicationId, args.RequestKey);
             }
             catch (Exception ex)
             {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/RunApplicationAIPipelineJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/RunApplicationAIPipelineJob.cs
@@ -51,7 +51,7 @@ public class RunApplicationAIPipelineJob(
                 if (!attachmentSummariesEnabled && !applicationAnalysisEnabled && !scoringEnabled)
                 {
                     logger.LogDebug("All AI features are disabled, skipping queued AI generation for application {ApplicationId}.", args.ApplicationId);
-                    var creatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+                    var creatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAndGetCreatorIdAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
                     await aiRateLimiter.StampAsync(creatorId);
                     return;
                 }
@@ -115,7 +115,7 @@ public class RunApplicationAIPipelineJob(
                     throw analysisException;
                 }
 
-                var completedCreatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+                var completedCreatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAndGetCreatorIdAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
                 await aiRateLimiter.StampAsync(completedCreatorId);
             }
             catch (Exception ex)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/RunApplicationAIPipelineJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/RunApplicationAIPipelineJob.cs
@@ -52,7 +52,7 @@ public class RunApplicationAIPipelineJob(
                 {
                     logger.LogDebug("All AI features are disabled, skipping queued AI generation for application {ApplicationId}.", args.ApplicationId);
                     await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
-                    await aiRateLimiter.StampAsync(args.RequestedByUserId);
+                    await AIGenerationRequestJobHelper.StampRateLimitBestEffortAsync(aiRateLimiter, logger, args.RequestedByUserId, args.ApplicationId, args.RequestKey);
                     return;
                 }
 
@@ -116,7 +116,7 @@ public class RunApplicationAIPipelineJob(
                 }
 
                 await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
-                await aiRateLimiter.StampAsync(args.RequestedByUserId);
+                await AIGenerationRequestJobHelper.StampRateLimitBestEffortAsync(aiRateLimiter, logger, args.RequestedByUserId, args.ApplicationId, args.RequestKey);
             }
             catch (Exception ex)
             {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/RunApplicationAIPipelineJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/RunApplicationAIPipelineJob.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Unity.AI.RateLimit;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Attachments;
 using Unity.GrantManager.GrantApplications;
@@ -27,6 +28,7 @@ public class RunApplicationAIPipelineJob(
     IRepository<AIGenerationRequest, Guid> generationRequestRepository,
     ICurrentTenant currentTenant,
     IUnitOfWorkManager unitOfWorkManager,
+    IAIRateLimiter aiRateLimiter,
     ILogger<RunApplicationAIPipelineJob> logger) : AsyncBackgroundJob<RunApplicationAIPipelineJobArgs>, ITransientDependency
 {
     public override async Task ExecuteAsync(RunApplicationAIPipelineJobArgs args)
@@ -49,7 +51,8 @@ public class RunApplicationAIPipelineJob(
                 if (!attachmentSummariesEnabled && !applicationAnalysisEnabled && !scoringEnabled)
                 {
                     logger.LogDebug("All AI features are disabled, skipping queued AI generation for application {ApplicationId}.", args.ApplicationId);
-                    await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+                    var creatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+                    await aiRateLimiter.StampAsync(creatorId);
                     return;
                 }
 
@@ -112,7 +115,8 @@ public class RunApplicationAIPipelineJob(
                     throw analysisException;
                 }
 
-                await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+                var completedCreatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+                await aiRateLimiter.StampAsync(completedCreatorId);
             }
             catch (Exception ex)
             {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/RunApplicationAIPipelineJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/RunApplicationAIPipelineJob.cs
@@ -51,8 +51,8 @@ public class RunApplicationAIPipelineJob(
                 if (!attachmentSummariesEnabled && !applicationAnalysisEnabled && !scoringEnabled)
                 {
                     logger.LogDebug("All AI features are disabled, skipping queued AI generation for application {ApplicationId}.", args.ApplicationId);
-                    var creatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAndGetCreatorIdAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
-                    await aiRateLimiter.StampAsync(creatorId);
+                    await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+                    await aiRateLimiter.StampAsync(args.RequestedByUserId);
                     return;
                 }
 
@@ -115,8 +115,8 @@ public class RunApplicationAIPipelineJob(
                     throw analysisException;
                 }
 
-                var completedCreatorId = await AIGenerationRequestJobHelper.MarkCompletedInNewUowAndGetCreatorIdAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
-                await aiRateLimiter.StampAsync(completedCreatorId);
+                await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
+                await aiRateLimiter.StampAsync(args.RequestedByUserId);
             }
             catch (Exception ex)
             {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.cshtml
@@ -58,6 +58,7 @@
 @section scripts
 {
     <abp-script src="/Pages/GrantApplications/ai-generation-button-state.js" />
+    <abp-script src="/Pages/GrantApplications/ai-rate-limit.js" />
     <abp-script src="/Pages/GrantApplications/Details.js" />
     <abp-script src="/libs/formiojs/formio.form.min.js" />
     <abp-script src="/Pages/GrantApplications/ai-analysis.js" />

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-analysis.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-analysis.js
@@ -10,6 +10,10 @@ const dismissedSectionVisibility = {
     recommendation: false
 };
 
+const aiAnalysisPollIntervalMs = 15000;
+const aiAnalysisMaxPollFailures = 3;
+let aiAnalysisMonitor = null;
+
 function getAnalysisLabels() {
     const labels = document.getElementById('aiAnalysisLabels')?.dataset ?? {};
 
@@ -415,82 +419,56 @@ globalThis.queueApplicationAnalysis = function(triggerButton = null) {
     const applicationId = $('#DetailsViewApplicationId').val();
     const $button = triggerButton ? $(triggerButton) : $('#regenerateApplicationAnalysis');
     const existingHtml = $button.html();
-    const aiAnalysisPollIntervalMs = 15000;
-    const aiAnalysisMaxPollFailures = 3;
 
     if (!applicationId || $button.prop('disabled')) {
         return;
     }
 
-    $button
-        .html('<span class="ai-button-content"><span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span><span>Generating...</span></span>')
-        .prop('disabled', true);
     globalThis.AIGenerationButtonState?.setGenerating($button);
-
-    let aiAnalysisPollTimeoutId = null;
-    let aiAnalysisPollFailures = 0;
-    const stopAIAnalysisPolling = function() {
-        if (aiAnalysisPollTimeoutId) {
-            clearTimeout(aiAnalysisPollTimeoutId);
-            aiAnalysisPollTimeoutId = null;
-        }
-    };
-
-    const poll = function() {
-        unity.grantManager.grantApplications.grantApplication
-                .getAIGenerationStatus(applicationId, 'application-analysis')
-            .done(function(request) {
-                    aiAnalysisPollFailures = 0;
-                    const statusText = globalThis.AIGenerationButtonState?.resolveStatus(request?.status) ?? '';
-
-                    if (statusText === 'Failed') {
-                        stopAIAnalysisPolling();
-                        loadAIAnalysis();
-                        globalThis.AIGenerationButtonState?.restore($button);
-                        $button.html(existingHtml).prop('disabled', false);
-                        abp.message.error(request?.failureReason || 'AI analysis failed.');
-                        return;
-                    }
-
-                    if (!request || request.isActive === false || statusText === 'Completed') {
-                        stopAIAnalysisPolling();
-                        loadAIAnalysis();
-                        globalThis.AIGenerationButtonState?.setCompleted($button);
-                        $button.html('<span class="ai-button-content"><span>Completed</span></span>').prop('disabled', true);
-                        return;
-                    }
-
-                    aiAnalysisPollTimeoutId = setTimeout(poll, aiAnalysisPollIntervalMs);
-            })
-        .fail(function(error) {
-            console.warn('Failed to poll AI analysis status.', error);
-            aiAnalysisPollFailures += 1;
-
-                if (aiAnalysisPollFailures > aiAnalysisMaxPollFailures) {
-                    stopAIAnalysisPolling();
-                    $button.html(existingHtml).prop('disabled', false);
-                    abp.message.error('Unable to load AI analysis status. Please try again.');
-                return;
-            }
-
-                aiAnalysisPollTimeoutId = setTimeout(poll, aiAnalysisPollIntervalMs);
-            });
-    };
 
     unity.grantManager.grantApplications.grantApplication
         .queueApplicationAnalysis(applicationId)
         .done(function(request) {
-            aiAnalysisPollFailures = 0;
-            stopAIAnalysisPolling();
-            aiAnalysisPollTimeoutId = setTimeout(poll, 500);
+            const status = globalThis.AIGenerationButtonState?.resolveStatus(request?.status) ?? '';
+
+            if (status === 'Completed') {
+                globalThis.AIGenerationButtonState?.restore($button);
+                $button.html(existingHtml).prop('disabled', false);
+                loadAIAnalysis();
+                globalThis.refreshAIRateLimitState?.();
+                return;
+            }
+
+            monitorAIAnalysisGeneration(applicationId, $button, existingHtml);
         })
         .fail(function(error) {
             console.error('Failed to queue AI analysis.', error);
-            stopAIAnalysisPolling();
+            aiAnalysisMonitor?.stop();
             globalThis.AIGenerationButtonState?.restore($button);
             $button.html(existingHtml).prop('disabled', false);
             abp.message.error('Failed to queue AI analysis. Please try again.');
         });
+}
+
+function monitorAIAnalysisGeneration(applicationId, $button, existingHtml) {
+    aiAnalysisMonitor?.stop();
+    aiAnalysisMonitor = globalThis.AIGenerationButtonState.monitor({
+        $button,
+        originalHtml: existingHtml,
+        intervalMs: aiAnalysisPollIntervalMs,
+        maxFailures: aiAnalysisMaxPollFailures,
+        getStatus: () => unity.grantManager.grantApplications.grantApplication
+            .getAIGenerationStatus(applicationId, 'application-analysis'),
+        onComplete: loadAIAnalysis,
+        onFailed: (request) => {
+            loadAIAnalysis();
+            abp.message.error(request?.failureReason || 'AI analysis failed.');
+        },
+        onPollFailed: (error) => {
+            console.warn('Failed to poll AI analysis status.', error);
+            abp.message.error('Unable to load AI analysis status. Please try again.');
+        }
+    });
 }
 
 function loadAIAnalysis() {
@@ -531,5 +509,22 @@ $(function() {
         $regenerateButton.on('click', function() {
             queueApplicationAnalysis();
         });
+
+        const applicationId = $('#DetailsViewApplicationId').val();
+        if (!applicationId) {
+            return;
+        }
+
+        unity.grantManager.grantApplications.grantApplication
+            .getAIGenerationStatus(applicationId, 'application-analysis')
+            .done(function(request) {
+                if (request?.isActive !== true) {
+                    return;
+                }
+
+                const existingHtml = $regenerateButton.html();
+                globalThis.AIGenerationButtonState?.setGenerating($regenerateButton);
+                monitorAIAnalysisGeneration(applicationId, $regenerateButton, existingHtml);
+            });
     }
 });

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-generation-button-state.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-generation-button-state.js
@@ -6,14 +6,13 @@
         opacity: '1',
     };
 
-    const completedStyles = {
-        'border-color': '#2e7d32',
-        color: '#2e7d32',
-        opacity: '1',
-    };
-
     function applyStyles($button, styles) {
         $button.css(styles);
+    }
+
+    function restoreButton($button, html) {
+        global.AIGenerationButtonState.restore($button);
+        $button.html(html).prop('disabled', false);
     }
 
     global.AIGenerationButtonState = {
@@ -32,18 +31,74 @@
             }
         },
         setGenerating($button) {
+            $button.removeAttr('data-ai-cooldown-active');
+            $button.attr('data-ai-generating', '1');
+            $button
+                .html('<span class="ai-button-content"><span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span><span>Generating...</span></span>')
+                .prop('disabled', true);
             applyStyles($button, generatingStyles);
         },
-        setCompleted($button) {
-            applyStyles($button, completedStyles);
-        },
         restore($button) {
+            $button.removeAttr('data-ai-generating');
             $button.css({
                 'background-color': '',
                 'border-color': '',
                 color: '',
                 opacity: '',
             }).removeClass('disabled');
+        },
+        monitor(options) {
+            const intervalMs = options.intervalMs || 15000;
+            const maxFailures = options.maxFailures || 3;
+            let timeoutId = null;
+            let failures = 0;
+
+            const stop = () => {
+                if (timeoutId) {
+                    clearTimeout(timeoutId);
+                    timeoutId = null;
+                }
+            };
+
+            const poll = () => {
+                options.getStatus()
+                    .done((request) => {
+                        failures = 0;
+                        const status = this.resolveStatus(request?.status);
+
+                        if (status === 'Failed') {
+                            stop();
+                            restoreButton(options.$button, options.originalHtml);
+                            options.onFailed?.(request);
+                            return;
+                        }
+
+                        if (!request || request.isActive === false || status === 'Completed') {
+                            stop();
+                            restoreButton(options.$button, options.originalHtml);
+                            options.onComplete?.(request);
+                            global.refreshAIRateLimitState?.();
+                            return;
+                        }
+
+                        timeoutId = setTimeout(poll, intervalMs);
+                    })
+                    .fail((error) => {
+                        failures += 1;
+                        if (failures > maxFailures) {
+                            stop();
+                            restoreButton(options.$button, options.originalHtml);
+                            options.onPollFailed?.(error);
+                            return;
+                        }
+
+                        timeoutId = setTimeout(poll, intervalMs);
+                    });
+            };
+
+            stop();
+            timeoutId = setTimeout(poll, options.initialDelayMs ?? 500);
+            return { stop };
         },
     };
 })(globalThis);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-rate-limit.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-rate-limit.js
@@ -1,0 +1,109 @@
+/* AB#32300 — per-user 60s cooldown for AI Generate buttons.
+ * Server stamps the cooldown; this module only mirrors that state in the UI.
+ * Strategy: on load, fetch the user's remaining seconds and disable every
+ * .ai-generate-btn with a countdown. After any generate click resolves we
+ * re-fetch (a successful click sets a new cooldown; a failed/blocked click
+ * may report the existing one). KISS — no per-button logic, no mutex.
+ */
+(function () {
+    const BUTTON_SELECTOR = '.ai-generate-btn';
+    const ATTR_LABEL = 'data-original-label';
+    const ATTR_COOLDOWN = 'data-ai-cooldown-active';
+
+    let countdownTimer = null;
+    let lastFetchAt = 0;
+
+    function buttons() {
+        return document.querySelectorAll(BUTTON_SELECTOR);
+    }
+
+    function rememberLabel(btn) {
+        if (!btn.getAttribute(ATTR_LABEL)) {
+            const label = btn.querySelector('.ai-button-content span:last-child') || btn;
+            btn.setAttribute(ATTR_LABEL, label.textContent.trim());
+        }
+    }
+
+    function setLabel(btn, text) {
+        const label = btn.querySelector('.ai-button-content span:last-child');
+        if (label) {
+            label.textContent = text;
+        } else {
+            btn.textContent = text;
+        }
+    }
+
+    function disable(btn, seconds) {
+        rememberLabel(btn);
+        btn.setAttribute(ATTR_COOLDOWN, '1');
+        btn.setAttribute('disabled', 'disabled');
+        btn.classList.add('disabled');
+        setLabel(btn, `Wait ${seconds}s`);
+    }
+
+    function restore(btn) {
+        if (btn.getAttribute(ATTR_COOLDOWN) !== '1') return;
+        btn.removeAttribute(ATTR_COOLDOWN);
+        btn.removeAttribute('disabled');
+        btn.classList.remove('disabled');
+        const original = btn.getAttribute(ATTR_LABEL);
+        if (original) setLabel(btn, original);
+    }
+
+    function clearTimer() {
+        if (countdownTimer) {
+            clearInterval(countdownTimer);
+            countdownTimer = null;
+        }
+    }
+
+    function applyCooldown(seconds) {
+        clearTimer();
+        if (!seconds || seconds <= 0) {
+            buttons().forEach(restore);
+            return;
+        }
+        let remaining = seconds;
+        buttons().forEach(b => disable(b, remaining));
+        countdownTimer = setInterval(() => {
+            remaining -= 1;
+            if (remaining <= 0) {
+                clearTimer();
+                buttons().forEach(restore);
+                return;
+            }
+            buttons().forEach(b => {
+                if (b.getAttribute(ATTR_COOLDOWN) === '1') setLabel(b, `Wait ${remaining}s`);
+            });
+        }, 1000);
+    }
+
+    async function fetchState() {
+        // Throttle to once per second to avoid hammering on chained clicks.
+        const now = Date.now();
+        if (now - lastFetchAt < 1000) return;
+        lastFetchAt = now;
+        try {
+            const res = await fetch('/api/app/ai-rate-limit/state', {
+                credentials: 'same-origin',
+                headers: { Accept: 'application/json' },
+            });
+            if (!res.ok) return;
+            const data = await res.json();
+            applyCooldown(Number(data.retryAfterSeconds) || 0);
+        } catch (_) {
+            // Best-effort; the server is the source of truth.
+        }
+    }
+
+    document.addEventListener('click', (e) => {
+        const btn = e.target.closest(BUTTON_SELECTOR);
+        if (!btn) return;
+        // Re-check shortly after the click so a successful generate immediately
+        // shows the fresh 60s cooldown.
+        setTimeout(fetchState, 250);
+    });
+
+    document.addEventListener('DOMContentLoaded', fetchState);
+    if (document.readyState !== 'loading') fetchState();
+})();

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-rate-limit.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-rate-limit.js
@@ -110,6 +110,6 @@
         setTimeout(fetchState, 250);
     });
 
-    document.addEventListener('DOMContentLoaded', fetchState);
+    document.addEventListener('DOMContentLoaded', () => fetchState());
     if (document.readyState !== 'loading') fetchState();
 })();

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-rate-limit.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-rate-limit.js
@@ -1,4 +1,4 @@
-/* AB#32300 — per-user 60s cooldown for AI Generate buttons.
+/* AB#32290 — per-user 60s cooldown for AI Generate buttons.
  * Server stamps the cooldown; this module only mirrors that state in the UI.
  * Strategy: on load, fetch the user's remaining seconds and disable every
  * .ai-generate-btn with a countdown. After any generate click resolves we
@@ -34,6 +34,10 @@
     }
 
     function disable(btn, seconds) {
+        if (btn.getAttribute('data-ai-generating') === '1') {
+            return;
+        }
+
         rememberLabel(btn);
         btn.setAttribute(ATTR_COOLDOWN, '1');
         btn.setAttribute('disabled', 'disabled');
@@ -95,6 +99,8 @@
             // Best-effort; the server is the source of truth.
         }
     }
+
+    globalThis.refreshAIRateLimitState = fetchState;
 
     document.addEventListener('click', (e) => {
         const btn = e.target.closest(BUTTON_SELECTOR);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-rate-limit.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-rate-limit.js
@@ -82,10 +82,10 @@
         }, 1000);
     }
 
-    async function fetchState() {
+    async function fetchState(force = false) {
         // Throttle to once per second to avoid hammering on chained clicks.
         const now = Date.now();
-        if (now - lastFetchAt < 1000) return;
+        if (!force && now - lastFetchAt < 1000) return;
         lastFetchAt = now;
         try {
             const res = await fetch('/api/app/ai-rate-limit/state', {
@@ -100,7 +100,7 @@
         }
     }
 
-    globalThis.refreshAIRateLimitState = fetchState;
+    globalThis.refreshAIRateLimitState = () => fetchState(true);
 
     document.addEventListener('click', (e) => {
         const btn = e.target.closest(BUTTON_SELECTOR);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentScoresWidget/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentScoresWidget/Default.js
@@ -584,55 +584,21 @@ function queueApplicationScoring(triggerButton = null) {
     const applicationId = $('#DetailsViewApplicationId').val();
     const $button = triggerButton ? $(triggerButton) : $('#regenerateAiScoresheetBtn');
     const existingHtml = $button.html();
-    const aiGenerationPollIntervalMs = 15000;
-    let aiGenerationPollTimeoutId = null;
 
     if (!applicationId || $button.prop('disabled')) {
         return;
     }
 
-    $button
-        .html(
-            '<span class="ai-button-content"><span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span><span>Generating...</span></span>'
-        )
-        .prop('disabled', true);
     globalThis.AIGenerationButtonState?.setGenerating($button);
 
-    const stopPolling = function () {
-        if (aiGenerationPollTimeoutId) {
-            clearTimeout(aiGenerationPollTimeoutId);
-            aiGenerationPollTimeoutId = null;
-        }
-    };
-
-    const poll = function () {
-        unity.grantManager.grantApplications.grantApplication
-            .getAIGenerationStatus(applicationId, 'application-scoring')
-            .done(function (request) {
-                const status = globalThis.AIGenerationButtonState?.resolveStatus(request?.status) ?? '';
-
-                if (status === 'Failed') {
-                    stopPolling();
-                    abp.message.error(request?.failureReason || 'AI scoring failed.');
-                    globalThis.AIGenerationButtonState?.restore($button);
-                    $button.html(existingHtml).prop('disabled', false);
-                    return;
-                }
-
-                if (!request || request.isActive === false || status === 'Completed') {
-                    stopPolling();
-                    globalThis.AIGenerationButtonState?.setCompleted($button);
-                    $button.html('<span class="ai-button-content"><span>Completed</span></span>').prop('disabled', true);
-                    PubSub.publish('refresh_assessment_scores', null);
-                    return;
-                }
-
-                aiGenerationPollTimeoutId = setTimeout(poll, aiGenerationPollIntervalMs);
-            })
-            .fail(function () {
-                aiGenerationPollTimeoutId = setTimeout(poll, aiGenerationPollIntervalMs);
-            });
-    };
+    const monitorScoring = () => globalThis.AIGenerationButtonState.monitor({
+        $button,
+        originalHtml: existingHtml,
+        getStatus: () => unity.grantManager.grantApplications.grantApplication
+            .getAIGenerationStatus(applicationId, 'application-scoring'),
+        onComplete: () => PubSub.publish('refresh_assessment_scores', null),
+        onFailed: (request) => abp.message.error(request?.failureReason || 'AI scoring failed.')
+    });
 
     unity.grantManager.grantApplications.grantApplication
         .queueApplicationScoring(applicationId)
@@ -640,15 +606,16 @@ function queueApplicationScoring(triggerButton = null) {
             const status = globalThis.AIGenerationButtonState?.resolveStatus(request?.status) ?? '';
 
             if (status === 'Completed') {
-                $button.html('<span class="ai-button-content"><span>Completed</span></span>').prop('disabled', true);
+                globalThis.AIGenerationButtonState?.restore($button);
+                $button.html(existingHtml).prop('disabled', false);
                 PubSub.publish('refresh_assessment_scores', null);
+                globalThis.refreshAIRateLimitState?.();
                 return;
             }
 
-            aiGenerationPollTimeoutId = setTimeout(poll, 500);
+            monitorScoring();
         })
         .fail(function () {
-            stopPolling();
             abp.message.error(
                 'Failed to queue AI scoring. Please try again.'
             );

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ReviewList/ReviewList.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ReviewList/ReviewList.js
@@ -237,6 +237,7 @@ $(function () {
         let generateButtons = new $.fn.dataTable.Buttons(reviewListTable, assessmentGenerateButtonGroup);
         generateButtons.container().appendTo("#AdjudicationTeamLeadActionBar");
         reviewListTable.buttons('Generate:name').enable();
+        resumeActiveReviewListAiButton(reviewListTable);
     }
 
     async function CreateAssessmentButton() {
@@ -457,84 +458,68 @@ function unityWorkflowButtonAction(e, dt, button, config) {
 
 function generateAiButtonAction(e, dt, button, config) {
     const $button = button?.node ? $(button.node) : null;
-    const aiGenerationPollIntervalMs = 15000;
-    let aiGenerationPollTimeoutId = null;
 
     if ($button?.length) {
-        $button.prop('disabled', true);
-        $button.html('<span class="ai-button-content"><i class="unt-icon-sm fa-solid fa-wand-sparkles"></i><span>Generating...</span></span>');
         globalThis.AIGenerationButtonState?.setGenerating($button);
     }
-
-    const stopPolling = function () {
-        if (aiGenerationPollTimeoutId) {
-            clearTimeout(aiGenerationPollTimeoutId);
-            aiGenerationPollTimeoutId = null;
-        }
-    };
-
-    const poll = function () {
-        unity.grantManager.grantApplications.grantApplication
-            .getAIGenerationStatus(pageApplicationId, 'application-scoring')
-            .done(function (request) {
-                const status = globalThis.AIGenerationButtonState?.resolveStatus(request?.status) ?? '';
-
-                if (status === 'Failed') {
-                    stopPolling();
-                    abp.message.error(request?.failureReason || 'AI scoring failed.');
-                    if ($button?.length) {
-                        globalThis.AIGenerationButtonState?.restore($button);
-                        $button.prop('disabled', false);
-                        $button.html(generateAiButtonText(null, null, null));
-                    }
-                    return;
-                }
-
-                if (!request || request.isActive === false || status === 'Completed') {
-                    stopPolling();
-                    setReviewListAiButtonCompleted($button);
-                    refreshReviewListAfterAiScoring();
-                    return;
-                }
-
-                aiGenerationPollTimeoutId = setTimeout(poll, aiGenerationPollIntervalMs);
-            })
-            .fail(function () {
-                aiGenerationPollTimeoutId = setTimeout(poll, aiGenerationPollIntervalMs);
-            });
-    };
 
     unity.grantManager.grantApplications.grantApplication.queueApplicationScoring(pageApplicationId)
         .done(function (request) {
             const status = globalThis.AIGenerationButtonState?.resolveStatus(request?.status) ?? '';
 
             if (status === 'Completed') {
-                setReviewListAiButtonCompleted($button);
+                restoreReviewListAiButton($button);
                 refreshReviewListAfterAiScoring();
+                globalThis.refreshAIRateLimitState?.();
                 return;
             }
 
-            aiGenerationPollTimeoutId = setTimeout(poll, 500);
+            pollReviewListAiButton($button);
         })
         .fail(function () {
-            stopPolling();
             abp.message.error('Failed to queue AI scoring. Please try again.');
-            if ($button?.length) {
-                globalThis.AIGenerationButtonState?.restore($button);
-                $button.prop('disabled', false);
-                $button.html(generateAiButtonText(null, null, null));
-            }
+            restoreReviewListAiButton($button);
         })
         ;
 }
 
-function setReviewListAiButtonCompleted($button) {
+function restoreReviewListAiButton($button) {
     if (!$button?.length) {
         return;
     }
 
-    globalThis.AIGenerationButtonState?.setCompleted($button);
-    $button.html('<span class="ai-button-content"><i class="unt-icon-sm fa-solid fa-wand-sparkles"></i><span>Completed</span></span>').prop('disabled', true);
+    globalThis.AIGenerationButtonState?.restore($button);
+    $button.html(generateAiButtonText(null, null, null)).prop('disabled', false);
+}
+
+function resumeActiveReviewListAiButton(reviewListTable) {
+    const button = reviewListTable.button('Generate:name');
+    if (!button?.any()) {
+        return;
+    }
+
+    const $button = $(button.node());
+    unity.grantManager.grantApplications.grantApplication
+        .getAIGenerationStatus(pageApplicationId, 'application-scoring')
+        .done(function(request) {
+            if (request?.isActive !== true) {
+                return;
+            }
+
+            globalThis.AIGenerationButtonState?.setGenerating($button);
+            pollReviewListAiButton($button);
+        });
+}
+
+function pollReviewListAiButton($button) {
+    globalThis.AIGenerationButtonState.monitor({
+        $button,
+        originalHtml: generateAiButtonText(null, null, null),
+        getStatus: () => unity.grantManager.grantApplications.grantApplication
+            .getAIGenerationStatus(pageApplicationId, 'application-scoring'),
+        onComplete: refreshReviewListAfterAiScoring,
+        onFailed: (request) => abp.message.error(request?.failureReason || 'AI scoring failed.')
+    });
 }
 
 function refreshReviewListAfterAiScoring() {

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/RateLimit/AIRateLimiterTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/RateLimit/AIRateLimiterTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Unity.AI.RateLimit;
+using Volo.Abp;
+using Volo.Abp.Users;
+using Xunit;
+
+namespace Unity.GrantManager.AI.RateLimit;
+
+public class AIRateLimiterTests
+{
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly IDistributedCache _cache = new MemoryDistributedCache(
+        Options.Create(new MemoryDistributedCacheOptions()));
+    private readonly ICurrentUser _currentUser = Substitute.For<ICurrentUser>();
+    private readonly IConfiguration _configuration;
+
+    public AIRateLimiterTests()
+    {
+        _currentUser.Id.Returns(_userId);
+        _configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AI:RateLimit:CooldownSeconds"] = "60"
+            }).Build();
+    }
+
+    private AIRateLimiter NewLimiter() => new(_cache, _currentUser, _configuration);
+
+    [Fact]
+    public async Task GetStateAsync_Returns_Zero_When_NoCooldown()
+    {
+        var state = await NewLimiter().GetStateAsync();
+        state.RetryAfterSeconds.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task EnsureAndStampAsync_FirstCall_Stamps_AndAllowsThrough()
+    {
+        await NewLimiter().EnsureAndStampAsync();
+        var state = await NewLimiter().GetStateAsync();
+        state.RetryAfterSeconds.ShouldBeInRange(1, 60);
+    }
+
+    [Fact]
+    public async Task EnsureAndStampAsync_SecondCall_Throws_WithRemainingSecondsMessage()
+    {
+        var limiter = NewLimiter();
+        await limiter.EnsureAndStampAsync();
+
+        var ex = await Should.ThrowAsync<UserFriendlyException>(() => limiter.EnsureAndStampAsync());
+        ex.Message.ShouldContain("rate limited");
+        ex.Message.ShouldMatch(@"\d+ second");
+    }
+
+    [Fact]
+    public async Task GetStateAsync_Returns_Zero_For_AnonymousUser()
+    {
+        _currentUser.Id.Returns((Guid?)null);
+        var state = await NewLimiter().GetStateAsync();
+        state.RetryAfterSeconds.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task EnsureAndStampAsync_IsNoOp_For_AnonymousUser()
+    {
+        _currentUser.Id.Returns((Guid?)null);
+        await NewLimiter().EnsureAndStampAsync(); // Should not throw.
+        var state = await NewLimiter().GetStateAsync();
+        state.RetryAfterSeconds.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task DifferentUsers_Have_IndependentCooldowns()
+    {
+        await NewLimiter().EnsureAndStampAsync();
+
+        _currentUser.Id.Returns(Guid.NewGuid());
+        await NewLimiter().EnsureAndStampAsync(); // Should not throw.
+    }
+
+    [Fact]
+    public async Task ExpiredCooldown_AllowsNewStamp()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AI:RateLimit:CooldownSeconds"] = "1"
+            }).Build();
+        var limiter = new AIRateLimiter(_cache, _currentUser, config);
+
+        await limiter.EnsureAndStampAsync();
+        await Task.Delay(TimeSpan.FromSeconds(1.2), CancellationToken.None);
+        await limiter.EnsureAndStampAsync(); // Should not throw.
+    }
+}

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/RateLimit/AIRateLimiterTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/RateLimit/AIRateLimiterTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Medallion.Threading;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
@@ -33,7 +35,7 @@ public class AIRateLimiterTests
             }).Build();
     }
 
-    private AIRateLimiter NewLimiter() => new(_cache, _currentUser, _configuration);
+    private AIRateLimiter NewLimiter() => new(_cache, _currentUser, _configuration, new TestDistributedLockProvider());
 
     [Fact]
     public async Task GetStateAsync_Returns_Zero_When_NoCooldown()
@@ -88,6 +90,18 @@ public class AIRateLimiterTests
     }
 
     [Fact]
+    public async Task ConcurrentCalls_ForSameUser_OnlyAllowOneThrough()
+    {
+        var limiter = NewLimiter();
+
+        var results = await Task.WhenAll(
+            TryEnsureAndStampAsync(limiter),
+            TryEnsureAndStampAsync(limiter));
+
+        results.Count(x => x).ShouldBe(1);
+    }
+
+    [Fact]
     public async Task ExpiredCooldown_AllowsNewStamp()
     {
         var config = new ConfigurationBuilder()
@@ -95,10 +109,68 @@ public class AIRateLimiterTests
             {
                 ["AI:RateLimit:CooldownSeconds"] = "1"
             }).Build();
-        var limiter = new AIRateLimiter(_cache, _currentUser, config);
+        var limiter = new AIRateLimiter(_cache, _currentUser, config, new TestDistributedLockProvider());
 
         await limiter.EnsureAndStampAsync();
         await Task.Delay(TimeSpan.FromSeconds(1.2), CancellationToken.None);
         await limiter.EnsureAndStampAsync(); // Should not throw.
+    }
+
+    private static async Task<bool> TryEnsureAndStampAsync(AIRateLimiter limiter)
+    {
+        try
+        {
+            await limiter.EnsureAndStampAsync();
+            return true;
+        }
+        catch (UserFriendlyException)
+        {
+            return false;
+        }
+    }
+
+    private sealed class TestDistributedLockProvider : IDistributedLockProvider
+    {
+        public IDistributedLock CreateLock(string name) => new TestDistributedLock(name);
+    }
+
+    private sealed class TestDistributedLock(string name) : IDistributedLock
+    {
+        private static readonly SemaphoreSlim Gate = new(1, 1);
+
+        public string Name => name;
+
+        public IDistributedSynchronizationHandle Acquire(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            Gate.Wait(cancellationToken);
+            return new TestDistributedSynchronizationHandle(Gate);
+        }
+
+        public async ValueTask<IDistributedSynchronizationHandle> AcquireAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            await Gate.WaitAsync(cancellationToken);
+            return new TestDistributedSynchronizationHandle(Gate);
+        }
+
+        public IDistributedSynchronizationHandle? TryAcquire(TimeSpan timeout = default, CancellationToken cancellationToken = default) =>
+            Gate.Wait(timeout, cancellationToken) ? new TestDistributedSynchronizationHandle(Gate) : null;
+
+        public async ValueTask<IDistributedSynchronizationHandle?> TryAcquireAsync(TimeSpan timeout = default, CancellationToken cancellationToken = default) =>
+            await Gate.WaitAsync(timeout, cancellationToken)
+                ? new TestDistributedSynchronizationHandle(Gate)
+                : null;
+    }
+
+    private sealed class TestDistributedSynchronizationHandle(SemaphoreSlim gate) : IDistributedSynchronizationHandle
+    {
+        public CancellationToken HandleLostToken => CancellationToken.None;
+
+        public void Dispose() => gate.Release();
+
+        public ValueTask DisposeAsync()
+        {
+            Dispose();
+            return ValueTask.CompletedTask;
+        }
     }
 }

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/RateLimit/AIRateLimiterTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/RateLimit/AIRateLimiterTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Medallion.Threading;
@@ -45,20 +44,29 @@ public class AIRateLimiterTests
     }
 
     [Fact]
-    public async Task EnsureAndStampAsync_FirstCall_Stamps_AndAllowsThrough()
+    public async Task EnsureAsync_AllowsThrough_When_NoCooldown()
     {
-        await NewLimiter().EnsureAndStampAsync();
+        await NewLimiter().EnsureAsync();
         var state = await NewLimiter().GetStateAsync();
+        state.RetryAfterSeconds.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task StampAsync_Starts_Cooldown()
+    {
+        var limiter = NewLimiter();
+        await limiter.StampAsync();
+        var state = await limiter.GetStateAsync();
         state.RetryAfterSeconds.ShouldBeInRange(1, 60);
     }
 
     [Fact]
-    public async Task EnsureAndStampAsync_SecondCall_Throws_WithRemainingSecondsMessage()
+    public async Task EnsureAsync_Throws_When_Cooldown_Exists()
     {
         var limiter = NewLimiter();
-        await limiter.EnsureAndStampAsync();
+        await limiter.StampAsync();
 
-        var ex = await Should.ThrowAsync<UserFriendlyException>(() => limiter.EnsureAndStampAsync());
+        var ex = await Should.ThrowAsync<UserFriendlyException>(() => limiter.EnsureAsync());
         ex.Message.ShouldContain("rate limited");
         ex.Message.ShouldMatch(@"\d+ second");
     }
@@ -72,10 +80,10 @@ public class AIRateLimiterTests
     }
 
     [Fact]
-    public async Task EnsureAndStampAsync_IsNoOp_For_AnonymousUser()
+    public async Task EnsureAsync_IsNoOp_For_AnonymousUser()
     {
         _currentUser.Id.Returns((Guid?)null);
-        await NewLimiter().EnsureAndStampAsync(); // Should not throw.
+        await NewLimiter().EnsureAsync(); // Should not throw.
         var state = await NewLimiter().GetStateAsync();
         state.RetryAfterSeconds.ShouldBe(0);
     }
@@ -83,22 +91,24 @@ public class AIRateLimiterTests
     [Fact]
     public async Task DifferentUsers_Have_IndependentCooldowns()
     {
-        await NewLimiter().EnsureAndStampAsync();
+        await NewLimiter().StampAsync();
 
         _currentUser.Id.Returns(Guid.NewGuid());
-        await NewLimiter().EnsureAndStampAsync(); // Should not throw.
+        await NewLimiter().EnsureAsync(); // Should not throw.
     }
 
     [Fact]
-    public async Task ConcurrentCalls_ForSameUser_OnlyAllowOneThrough()
+    public async Task StampAsync_ForSuppliedUser_Starts_Cooldown_ForThatUser()
     {
-        var limiter = NewLimiter();
+        var otherUserId = Guid.NewGuid();
 
-        var results = await Task.WhenAll(
-            TryEnsureAndStampAsync(limiter),
-            TryEnsureAndStampAsync(limiter));
+        await NewLimiter().StampAsync(otherUserId);
 
-        results.Count(x => x).ShouldBe(1);
+        await NewLimiter().EnsureAsync(); // Current user should not be blocked.
+
+        _currentUser.Id.Returns(otherUserId);
+        var ex = await Should.ThrowAsync<UserFriendlyException>(() => NewLimiter().EnsureAsync());
+        ex.Message.ShouldContain("rate limited");
     }
 
     [Fact]
@@ -111,22 +121,9 @@ public class AIRateLimiterTests
             }).Build();
         var limiter = new AIRateLimiter(_cache, _currentUser, config, new TestDistributedLockProvider());
 
-        await limiter.EnsureAndStampAsync();
+        await limiter.StampAsync();
         await Task.Delay(TimeSpan.FromSeconds(1.2), CancellationToken.None);
-        await limiter.EnsureAndStampAsync(); // Should not throw.
-    }
-
-    private static async Task<bool> TryEnsureAndStampAsync(AIRateLimiter limiter)
-    {
-        try
-        {
-            await limiter.EnsureAndStampAsync();
-            return true;
-        }
-        catch (UserFriendlyException)
-        {
-            return false;
-        }
+        await limiter.EnsureAsync(); // Should not throw.
     }
 
     private sealed class TestDistributedLockProvider : IDistributedLockProvider

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/AIGenerationQueueTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/AIGenerationQueueTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Unity.AI.RateLimit;
 using Unity.GrantManager.GrantApplications;
 using Unity.GrantManager.GrantApplications.Automation;
 using Unity.GrantManager.GrantApplications.Automation.BackgroundJobs;
@@ -130,6 +131,48 @@ public class AIGenerationQueueTests(ITestOutputHelper outputHelper) : GrantManag
             r.OperationType == AIGenerationRequestKeyHelper.ApplicationAnalysisOperationType &&
             r.RequestKey == capturedArgs.RequestKey &&
             r.Status == AIGenerationRequestStatus.Queued), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueueApplicationAnalysisAsync_Should_Check_Rate_Limit_Before_Enqueueing_New_Request()
+    {
+        var applicationId = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        var repository = Substitute.For<IRepository<AIGenerationRequest, Guid>>();
+        repository.GetQueryableAsync().Returns(Task.FromResult<IQueryable<AIGenerationRequest>>(Array.Empty<AIGenerationRequest>().AsQueryable()));
+        repository.InsertAsync(Arg.Any<AIGenerationRequest>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => Task.FromResult(callInfo.Arg<AIGenerationRequest>()));
+
+        var backgroundJobManager = Substitute.For<IBackgroundJobManager>();
+        var rateLimiter = Substitute.For<IAIRateLimiter>();
+        rateLimiter.EnsureAsync().Returns(Task.CompletedTask);
+        var queue = CreateQueue(backgroundJobManager, repository, rateLimiter);
+
+        await queue.QueueApplicationAnalysisAsync(applicationId, tenantId);
+
+        await rateLimiter.Received(1).EnsureAsync();
+        await repository.Received(1).InsertAsync(Arg.Any<AIGenerationRequest>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await backgroundJobManager.Received(1).EnqueueAsync(Arg.Any<GenerateApplicationAnalysisBackgroundJobArgs>(), Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
+    }
+
+    [Fact]
+    public async Task QueueApplicationAnalysisAsync_Should_Not_Insert_Or_Enqueue_When_Rate_Limited()
+    {
+        var applicationId = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        var repository = Substitute.For<IRepository<AIGenerationRequest, Guid>>();
+        repository.GetQueryableAsync().Returns(Task.FromResult<IQueryable<AIGenerationRequest>>(Array.Empty<AIGenerationRequest>().AsQueryable()));
+
+        var backgroundJobManager = Substitute.For<IBackgroundJobManager>();
+        var rateLimiter = Substitute.For<IAIRateLimiter>();
+        rateLimiter.EnsureAsync().Returns<Task>(_ => throw new InvalidOperationException("rate limited"));
+        var queue = CreateQueue(backgroundJobManager, repository, rateLimiter);
+
+        await Should.ThrowAsync<InvalidOperationException>(() => queue.QueueApplicationAnalysisAsync(applicationId, tenantId));
+
+        await rateLimiter.Received(1).EnsureAsync();
+        await repository.DidNotReceive().InsertAsync(Arg.Any<AIGenerationRequest>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await backgroundJobManager.DidNotReceive().EnqueueAsync(Arg.Any<GenerateApplicationAnalysisBackgroundJobArgs>(), Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
     }
 
     [Fact]
@@ -308,8 +351,12 @@ public class AIGenerationQueueTests(ITestOutputHelper outputHelper) : GrantManag
         IRepository<AIGenerationRequest, Guid> repository,
         Unity.AI.RateLimit.IAIRateLimiter? rateLimiter = null)
     {
-        rateLimiter ??= Substitute.For<Unity.AI.RateLimit.IAIRateLimiter>();
-        rateLimiter.EnsureAsync().Returns(Task.CompletedTask);
+        if (rateLimiter == null)
+        {
+            rateLimiter = Substitute.For<Unity.AI.RateLimit.IAIRateLimiter>();
+            rateLimiter.EnsureAsync().Returns(Task.CompletedTask);
+        }
+
         return new ApplicationAIGenerationQueue(
             backgroundJobManager,
             repository,

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/AIGenerationQueueTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/AIGenerationQueueTests.cs
@@ -78,12 +78,15 @@ public class AIGenerationQueueTests(ITestOutputHelper outputHelper) : GrantManag
         repository.GetQueryableAsync().Returns(Task.FromResult<IQueryable<AIGenerationRequest>>(new[] { request }.AsQueryable()));
 
         var backgroundJobManager = Substitute.For<IBackgroundJobManager>();
-        var queue = CreateQueue(backgroundJobManager, repository);
+        var rateLimiter = Substitute.For<Unity.AI.RateLimit.IAIRateLimiter>();
+        rateLimiter.EnsureAndStampAsync().Returns(Task.CompletedTask);
+        var queue = CreateQueue(backgroundJobManager, repository, rateLimiter);
 
         await queue.QueueApplicationAnalysisAsync(applicationId, tenantId, promptVersion);
 
         await backgroundJobManager.DidNotReceive().EnqueueAsync(Arg.Any<GenerateApplicationAnalysisBackgroundJobArgs>());
         await repository.DidNotReceive().InsertAsync(Arg.Any<AIGenerationRequest>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await rateLimiter.DidNotReceive().EnsureAndStampAsync();
     }
 
     [Fact]
@@ -297,9 +300,10 @@ public class AIGenerationQueueTests(ITestOutputHelper outputHelper) : GrantManag
 
     private static ApplicationAIGenerationQueue CreateQueue(
         IBackgroundJobManager backgroundJobManager,
-        IRepository<AIGenerationRequest, Guid> repository)
+        IRepository<AIGenerationRequest, Guid> repository,
+        Unity.AI.RateLimit.IAIRateLimiter? rateLimiter = null)
     {
-        var rateLimiter = Substitute.For<Unity.AI.RateLimit.IAIRateLimiter>();
+        rateLimiter ??= Substitute.For<Unity.AI.RateLimit.IAIRateLimiter>();
         rateLimiter.EnsureAndStampAsync().Returns(Task.CompletedTask);
         return new ApplicationAIGenerationQueue(
             backgroundJobManager,

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/AIGenerationQueueTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/AIGenerationQueueTests.cs
@@ -79,14 +79,14 @@ public class AIGenerationQueueTests(ITestOutputHelper outputHelper) : GrantManag
 
         var backgroundJobManager = Substitute.For<IBackgroundJobManager>();
         var rateLimiter = Substitute.For<Unity.AI.RateLimit.IAIRateLimiter>();
-        rateLimiter.EnsureAndStampAsync().Returns(Task.CompletedTask);
+        rateLimiter.EnsureAsync().Returns(Task.CompletedTask);
         var queue = CreateQueue(backgroundJobManager, repository, rateLimiter);
 
         await queue.QueueApplicationAnalysisAsync(applicationId, tenantId, promptVersion);
 
         await backgroundJobManager.DidNotReceive().EnqueueAsync(Arg.Any<GenerateApplicationAnalysisBackgroundJobArgs>());
         await repository.DidNotReceive().InsertAsync(Arg.Any<AIGenerationRequest>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
-        await rateLimiter.DidNotReceive().EnsureAndStampAsync();
+        await rateLimiter.DidNotReceive().EnsureAsync();
     }
 
     [Fact]
@@ -304,7 +304,7 @@ public class AIGenerationQueueTests(ITestOutputHelper outputHelper) : GrantManag
         Unity.AI.RateLimit.IAIRateLimiter? rateLimiter = null)
     {
         rateLimiter ??= Substitute.For<Unity.AI.RateLimit.IAIRateLimiter>();
-        rateLimiter.EnsureAndStampAsync().Returns(Task.CompletedTask);
+        rateLimiter.EnsureAsync().Returns(Task.CompletedTask);
         return new ApplicationAIGenerationQueue(
             backgroundJobManager,
             repository,

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/AIGenerationQueueTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/AIGenerationQueueTests.cs
@@ -13,6 +13,7 @@ using Unity.GrantManager.GrantApplications.Automation.BackgroundJobs;
 using Volo.Abp.BackgroundJobs;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.DistributedLocking;
+using Volo.Abp.Users;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -50,6 +51,7 @@ public class AIGenerationQueueTests(ITestOutputHelper outputHelper) : GrantManag
         capturedArgs!.ApplicationId.ShouldBe(applicationId);
         capturedArgs.TenantId.ShouldBe(tenantId);
         capturedArgs.PromptVersion.ShouldBe("v1");
+        capturedArgs.RequestedByUserId.ShouldBe(CreateQueueCurrentUserId);
         capturedArgs.RequestKey.ShouldBe(AIGenerationRequestKeyHelper.BuildRequestKey(tenantId, applicationId, AIGenerationRequestKeyHelper.PipelineOperationType));
         await backgroundJobManager.Received(1).EnqueueAsync(Arg.Any<RunApplicationAIPipelineJobArgs>(), Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
         await repository.Received(1).InsertAsync(Arg.Is<AIGenerationRequest>(r =>
@@ -120,6 +122,7 @@ public class AIGenerationQueueTests(ITestOutputHelper outputHelper) : GrantManag
         capturedArgs!.ApplicationId.ShouldBe(applicationId);
         capturedArgs.TenantId.ShouldBe(tenantId);
         capturedArgs.PromptVersion.ShouldBe(promptVersion);
+        capturedArgs.RequestedByUserId.ShouldBe(CreateQueueCurrentUserId);
         capturedArgs.RequestKey.ShouldBe(AIGenerationRequestKeyHelper.BuildRequestKey(tenantId, applicationId, AIGenerationRequestKeyHelper.ApplicationAnalysisOperationType));
         await repository.Received(1).InsertAsync(Arg.Is<AIGenerationRequest>(r =>
             r.ApplicationId == applicationId &&
@@ -186,6 +189,7 @@ public class AIGenerationQueueTests(ITestOutputHelper outputHelper) : GrantManag
         capturedArgs!.ApplicationId.ShouldBe(applicationId);
         capturedArgs.TenantId.ShouldBe(tenantId);
         capturedArgs.PromptVersion.ShouldBe(promptVersion);
+        capturedArgs.RequestedByUserId.ShouldBe(CreateQueueCurrentUserId);
         capturedArgs.RequestKey.ShouldBe(AIGenerationRequestKeyHelper.BuildRequestKey(tenantId, applicationId, AIGenerationRequestKeyHelper.AttachmentSummaryOperationType));
         await repository.Received(1).InsertAsync(Arg.Is<AIGenerationRequest>(r =>
             r.ApplicationId == applicationId &&
@@ -252,6 +256,7 @@ public class AIGenerationQueueTests(ITestOutputHelper outputHelper) : GrantManag
         capturedArgs!.ApplicationId.ShouldBe(applicationId);
         capturedArgs.TenantId.ShouldBe(tenantId);
         capturedArgs.PromptVersion.ShouldBe(promptVersion);
+        capturedArgs.RequestedByUserId.ShouldBe(CreateQueueCurrentUserId);
         capturedArgs.RequestKey.ShouldBe(AIGenerationRequestKeyHelper.BuildRequestKey(tenantId, applicationId, AIGenerationRequestKeyHelper.ApplicationScoringOperationType));
         await repository.Received(1).InsertAsync(Arg.Is<AIGenerationRequest>(r =>
             r.ApplicationId == applicationId &&
@@ -310,6 +315,16 @@ public class AIGenerationQueueTests(ITestOutputHelper outputHelper) : GrantManag
             repository,
             new TestDistributedLockProvider(),
             rateLimiter,
+            CreateCurrentUser(),
             Substitute.For<ILogger<ApplicationAIGenerationQueue>>());
+    }
+
+    private static readonly Guid CreateQueueCurrentUserId = Guid.NewGuid();
+
+    private static ICurrentUser CreateCurrentUser()
+    {
+        var currentUser = Substitute.For<ICurrentUser>();
+        currentUser.Id.Returns(CreateQueueCurrentUserId);
+        return currentUser;
     }
 }

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/AIGenerationQueueTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/AIGenerationQueueTests.cs
@@ -299,10 +299,13 @@ public class AIGenerationQueueTests(ITestOutputHelper outputHelper) : GrantManag
         IBackgroundJobManager backgroundJobManager,
         IRepository<AIGenerationRequest, Guid> repository)
     {
+        var rateLimiter = Substitute.For<Unity.AI.RateLimit.IAIRateLimiter>();
+        rateLimiter.EnsureAndStampAsync().Returns(Task.CompletedTask);
         return new ApplicationAIGenerationQueue(
             backgroundJobManager,
             repository,
             new TestDistributedLockProvider(),
+            rateLimiter,
             Substitute.For<ILogger<ApplicationAIGenerationQueue>>());
     }
 }

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/RunApplicationAIPipelineJobTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/RunApplicationAIPipelineJobTests.cs
@@ -33,11 +33,13 @@ public class RunApplicationAIPipelineJobTests(ITestOutputHelper outputHelper) : 
         requests.Add(request);
 
         var job = BuildJob(featureChecker, repository);
+        var requestedByUserId = Guid.NewGuid();
 
         await job.ExecuteAsync(new RunApplicationAIPipelineJobArgs
         {
             ApplicationId = request.ApplicationId!.Value,
             RequestKey = request.RequestKey,
+            RequestedByUserId = requestedByUserId,
             TenantId = request.TenantId
         });
 
@@ -61,21 +63,26 @@ public class RunApplicationAIPipelineJobTests(ITestOutputHelper outputHelper) : 
             .Returns(new ApplicationScoringResultDto { Completed = true });
 
         var localEventBus = Substitute.For<ILocalEventBus>();
+        var rateLimiter = Substitute.For<IAIRateLimiter>();
+        var requestedByUserId = Guid.NewGuid();
 
         var job = BuildJob(
             featureChecker,
             repository,
             localEventBus: localEventBus,
+            rateLimiter: rateLimiter,
             applicationScoringAppService: scoringAppService);
 
         await job.ExecuteAsync(new RunApplicationAIPipelineJobArgs
         {
             ApplicationId = request.ApplicationId!.Value,
             RequestKey = request.RequestKey,
+            RequestedByUserId = requestedByUserId,
             TenantId = request.TenantId
         });
 
         request.Status.ShouldBe(AIGenerationRequestStatus.Completed);
+        await rateLimiter.Received(1).StampAsync(requestedByUserId);
         await localEventBus.Received(1).PublishAsync(
             Arg.Is<Automation.Events.ApplicationAIScoringGeneratedEvent>(x => x.ApplicationId == request.ApplicationId));
     }
@@ -86,7 +93,8 @@ public class RunApplicationAIPipelineJobTests(ITestOutputHelper outputHelper) : 
         ILocalEventBus? localEventBus = null,
         IAttachmentSummaryAppService? attachmentSummaryAppService = null,
         IApplicationAnalysisAppService? applicationAnalysisAppService = null,
-        IApplicationScoringAppService? applicationScoringAppService = null)
+        IApplicationScoringAppService? applicationScoringAppService = null,
+        IAIRateLimiter? rateLimiter = null)
     {
         return new RunApplicationAIPipelineJob(
             Substitute.For<IApplicationChefsFileAttachmentRepository>(),
@@ -98,7 +106,7 @@ public class RunApplicationAIPipelineJobTests(ITestOutputHelper outputHelper) : 
             generationRequestRepository,
             Substitute.For<ICurrentTenant>(),
             GetRequiredService<IUnitOfWorkManager>(),
-            Substitute.For<IAIRateLimiter>(),
+            rateLimiter ?? Substitute.For<IAIRateLimiter>(),
             NullLogger<RunApplicationAIPipelineJob>.Instance);
     }
 

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/RunApplicationAIPipelineJobTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/RunApplicationAIPipelineJobTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Attachments;
 using Unity.GrantManager.GrantApplications.Automation.BackgroundJobs;
+using Unity.AI.RateLimit;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.EventBus.Local;
 using Volo.Abp.Features;
@@ -97,6 +98,7 @@ public class RunApplicationAIPipelineJobTests(ITestOutputHelper outputHelper) : 
             generationRequestRepository,
             Substitute.For<ICurrentTenant>(),
             GetRequiredService<IUnitOfWorkManager>(),
+            Substitute.For<IAIRateLimiter>(),
             NullLogger<RunApplicationAIPipelineJob>.Instance);
     }
 


### PR DESCRIPTION
## Pull request overview

Implements AB#32290 by enforcing a per-user cooldown across AI Generate actions so repeated clicks or refreshes cannot trigger excessive token consumption.

A single distributed-cache key per user (`AI:Cooldown:{userId}`, default 60s TTL) gates AI generation through `ApplicationAIGenerationQueue`. The queue calls `IAIRateLimiter.EnsureAsync()` before enqueueing; background jobs call `StampAsync()` only after successful completion so the UI flow is `Generate -> Generating -> Wait`.

A small read endpoint (`GET /api/app/ai-rate-limit/state`) exposes the remaining cooldown so the page can disable every `.ai-generate-btn` with a countdown that survives refresh.

**Changes:**
- New `IAIRateLimiter` chokepoint and `AIRateLimiter` (distributed cache, configurable TTL via `AI:RateLimit:CooldownSeconds`)
- New `IAIRateLimitAppService` + `AIRateLimitAppService` with `GET /api/app/ai-rate-limit/state` returning `{ retryAfterSeconds }`
- `ApplicationAIGenerationQueue` rejects requests while the current user is cooling down
- AI background jobs stamp the cooldown after successful completion without committing failed generation work
- Web page wires `ai-rate-limit.js` into `Details.cshtml`; the script disables `.ai-generate-btn` and counts down on page load and after generation completion
- Shared AI button monitor resumes `Generating...` state after refresh while queued work is still active
- Tests for rate limiter cooldown semantics, queue integration, and pipeline job wiring