### PR TITLE
Feature/ab#32310 support ai execution modes for multi step ai flows

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AIExecutionMode.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AIExecutionMode.cs
@@ -1,0 +1,17 @@
+namespace Unity.AI.Operations;
+
+/// <summary>
+/// Execution strategy for multi-step AI flows that iterate over many work items
+/// (e.g. multiple attachments, multiple scoresheet sections).
+/// </summary>
+public enum AIExecutionMode
+{
+    /// <summary>One item at a time, in order. Default; preserves legacy behavior.</summary>
+    Sequential,
+
+    /// <summary>All items started concurrently and awaited together.</summary>
+    Parallel,
+
+    /// <summary>Items processed in fixed-size batches, each batch run in parallel.</summary>
+    Batch
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AIExecutionMode.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AIExecutionMode.cs
@@ -12,6 +12,6 @@ public enum AIExecutionMode
     /// <summary>All items started concurrently and awaited together.</summary>
     Parallel,
 
-    /// <summary>Items processed in fixed-size batches, each batch run in parallel.</summary>
+    /// <summary>All items sent through one batch operation.</summary>
     Batch
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AIExecutionModeResolver.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AIExecutionModeResolver.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.Configuration;
+using Volo.Abp.DependencyInjection;
+
+namespace Unity.AI.Operations;
+
+/// <summary>
+/// Resolves the configured <see cref="AIExecutionMode"/> and batch size for a given flow.
+/// Configuration keys (all optional, default = Sequential / batch size 5):
+///   Azure:AIExecutionModes:{flowKey}  - "Sequential" | "Parallel" | "Batch" (case-insensitive)
+///   Azure:AIExecutionModes:BatchSize  - positive int, used only by Batch mode
+/// </summary>
+public class AIExecutionModeResolver(IConfiguration configuration) : ITransientDependency
+{
+    public const string AttachmentSummariesFlow = "AttachmentSummaries";
+    public const string ScoresheetFlow = "Scoresheet";
+
+    private const string ModeKeyPrefix = "Azure:AIExecutionModes:";
+    private const string BatchSizeKey = "Azure:AIExecutionModes:BatchSize";
+    private const int DefaultBatchSize = 5;
+
+    public AIExecutionMode ResolveMode(string flowKey)
+    {
+        var configured = configuration[ModeKeyPrefix + flowKey];
+        return configured?.Trim().ToLowerInvariant() switch
+        {
+            "parallel" => AIExecutionMode.Parallel,
+            "batch" => AIExecutionMode.Batch,
+            _ => AIExecutionMode.Sequential
+        };
+    }
+
+    public int ResolveBatchSize()
+    {
+        return int.TryParse(configuration[BatchSizeKey], out var size) && size > 0
+            ? size
+            : DefaultBatchSize;
+    }
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AIExecutionModeResolver.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AIExecutionModeResolver.cs
@@ -1,38 +1,33 @@
 using Microsoft.Extensions.Configuration;
+using Unity.AI.Prompts;
 using Volo.Abp.DependencyInjection;
 
 namespace Unity.AI.Operations;
 
 /// <summary>
-/// Resolves the configured <see cref="AIExecutionMode"/> and batch size for a given flow.
-/// Configuration keys (all optional, default = Sequential / batch size 5):
-///   Azure:AIExecutionModes:{flowKey}  - "Sequential" | "Parallel" | "Batch" (case-insensitive)
-///   Azure:AIExecutionModes:BatchSize  - positive int, used only by Batch mode
+/// Resolves the configured <see cref="AIExecutionMode"/> for an AI operation.
+/// Configuration keys (all optional, default = Sequential):
+///   Azure:Operations:{operationName}:ExecutionMode - "Sequential" | "Parallel" | "Batch" (case-insensitive)
+///   Azure:Operations:Defaults:ExecutionMode        - default when operation override is absent
 /// </summary>
 public class AIExecutionModeResolver(IConfiguration configuration) : ITransientDependency
 {
-    public const string AttachmentSummariesFlow = "AttachmentSummaries";
-    public const string ScoresheetFlow = "Scoresheet";
+    public const string AttachmentSummaryOperation = AIPromptTypes.AttachmentSummary;
+    public const string ApplicationScoringOperation = AIPromptTypes.ApplicationScoring;
 
-    private const string ModeKeyPrefix = "Azure:AIExecutionModes:";
-    private const string BatchSizeKey = "Azure:AIExecutionModes:BatchSize";
-    private const int DefaultBatchSize = 5;
-
-    public AIExecutionMode ResolveMode(string flowKey)
+    public AIExecutionMode ResolveMode(string operationName)
     {
-        var configured = configuration[ModeKeyPrefix + flowKey];
+        var configured = configuration[$"Azure:Operations:{operationName}:ExecutionMode"];
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            configured = configuration["Azure:Operations:Defaults:ExecutionMode"];
+        }
+
         return configured?.Trim().ToLowerInvariant() switch
         {
             "parallel" => AIExecutionMode.Parallel,
             "batch" => AIExecutionMode.Batch,
             _ => AIExecutionMode.Sequential
         };
-    }
-
-    public int ResolveBatchSize()
-    {
-        return int.TryParse(configuration[BatchSizeKey], out var size) && size > 0
-            ? size
-            : DefaultBatchSize;
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AIExecutionStrategy.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AIExecutionStrategy.cs
@@ -7,18 +7,19 @@ namespace Unity.AI.Operations;
 
 /// <summary>
 /// Runs an async operation across a collection of items using a configurable execution mode.
-/// Stateless and intentionally tiny: callers resolve mode + batch size and delegate iteration here.
+/// Stateless and intentionally tiny: callers resolve mode and provide item/batch work.
 /// </summary>
 public static class AIExecutionStrategy
 {
     public static async Task<List<TResult>> RunAsync<T, TResult>(
         IReadOnlyCollection<T> items,
         AIExecutionMode mode,
-        int batchSize,
-        Func<T, Task<TResult>> operation)
+        Func<T, Task<TResult>> operation,
+        Func<IReadOnlyCollection<T>, Task<List<TResult>>> batchOperation)
     {
         ArgumentNullException.ThrowIfNull(items);
         ArgumentNullException.ThrowIfNull(operation);
+        ArgumentNullException.ThrowIfNull(batchOperation);
 
         if (items.Count == 0)
         {
@@ -31,12 +32,7 @@ public static class AIExecutionStrategy
                 return [.. await Task.WhenAll(items.Select(operation))];
 
             case AIExecutionMode.Batch:
-                var batched = new List<TResult>(items.Count);
-                foreach (var batch in items.Chunk(Math.Max(1, batchSize)))
-                {
-                    batched.AddRange(await Task.WhenAll(batch.Select(operation)));
-                }
-                return batched;
+                return await batchOperation(items);
 
             default:
                 var sequential = new List<TResult>(items.Count);

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AIExecutionStrategy.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AIExecutionStrategy.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Unity.AI.Operations;
+
+/// <summary>
+/// Runs an async operation across a collection of items using a configurable execution mode.
+/// Stateless and intentionally tiny: callers resolve mode + batch size and delegate iteration here.
+/// </summary>
+public static class AIExecutionStrategy
+{
+    public static async Task<List<TResult>> RunAsync<T, TResult>(
+        IReadOnlyCollection<T> items,
+        AIExecutionMode mode,
+        int batchSize,
+        Func<T, Task<TResult>> operation)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        ArgumentNullException.ThrowIfNull(operation);
+
+        if (items.Count == 0)
+        {
+            return [];
+        }
+
+        switch (mode)
+        {
+            case AIExecutionMode.Parallel:
+                return [.. await Task.WhenAll(items.Select(operation))];
+
+            case AIExecutionMode.Batch:
+                var batched = new List<TResult>(items.Count);
+                foreach (var batch in items.Chunk(Math.Max(1, batchSize)))
+                {
+                    batched.AddRange(await Task.WhenAll(batch.Select(operation)));
+                }
+                return batched;
+
+            default:
+                var sequential = new List<TResult>(items.Count);
+                foreach (var item in items)
+                {
+                    sequential.Add(await operation(item));
+                }
+                return sequential;
+        }
+    }
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
@@ -111,12 +111,7 @@ namespace Unity.AI.Operations
 
                 if (applicationScoringResponse.Answers.Count > 0)
                 {
-                    var sectionJson = JsonSerializer.Serialize(applicationScoringResponse.Answers, _jsonOptions);
-                    using var sectionDoc = JsonDocument.Parse(sectionJson);
-                    foreach (var property in sectionDoc.RootElement.EnumerateObject())
-                    {
-                        sectionResults[property.Name] = property.Value.Clone();
-                    }
+                    CopyAnswers(applicationScoringResponse.Answers, sectionResults);
                 }
             }
             catch (Exception ex)
@@ -153,12 +148,7 @@ namespace Unity.AI.Operations
 
                 if (applicationScoringResponse.Answers.Count > 0)
                 {
-                    var sectionJson = JsonSerializer.Serialize(applicationScoringResponse.Answers, _jsonOptions);
-                    using var sectionDoc = JsonDocument.Parse(sectionJson);
-                    foreach (var property in sectionDoc.RootElement.EnumerateObject())
-                    {
-                        sectionResults[property.Name] = property.Value.Clone();
-                    }
+                    CopyAnswers(applicationScoringResponse.Answers, sectionResults);
                 }
             }
             catch (Exception ex)
@@ -188,6 +178,16 @@ namespace Unity.AI.Operations
             }
 
             return sectionQuestionsData;
+        }
+
+        private void CopyAnswers(Dictionary<string, ApplicationScoringAnswer> answers, Dictionary<string, object> results)
+        {
+            var answersJson = JsonSerializer.Serialize(answers, _jsonOptions);
+            using var answersDoc = JsonDocument.Parse(answersJson);
+            foreach (var property in answersDoc.RootElement.EnumerateObject())
+            {
+                results[property.Name] = property.Value.Clone();
+            }
         }
 
         private async Task<string?> GetFormSchemaAsync(Guid? formVersionId)

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
@@ -21,6 +21,7 @@ namespace Unity.AI.Operations
         IApplicationChefsFileAttachmentRepository applicationChefsFileAttachmentRepository,
         IScoresheetRepository scoresheetRepository,
         IAIService aiService,
+        AIExecutionModeResolver executionModeResolver,
         ILogger<ApplicationScoringService> logger) : IApplicationScoringService, ITransientDependency
     {
         private readonly JsonSerializerOptions _jsonOptions = new()
@@ -63,49 +64,22 @@ namespace Unity.AI.Operations
             var formSchema = await GetFormSchemaAsync(formSubmission?.ApplicationFormVersionId);
             var promptData = PromptDataPayloadBuilder.BuildPromptDataPayload(application, formSubmission, formSchema, logger);
 
+            var sections = scoresheet.Sections.OrderBy(s => s.Order).ToList();
+            var mode = executionModeResolver.ResolveMode(AIExecutionModeResolver.ScoresheetFlow);
+            var batchSize = executionModeResolver.ResolveBatchSize();
+
+            var perSectionResults = await AIExecutionStrategy.RunAsync(
+                sections,
+                mode,
+                batchSize,
+                section => ProcessSectionAsync(applicationId, section, promptData, attachmentSummaries, promptVersion));
+
             var allSectionResults = new Dictionary<string, object>();
-            foreach (var section in scoresheet.Sections.OrderBy(s => s.Order))
+            foreach (var sectionResult in perSectionResults)
             {
-                try
+                foreach (var kvp in sectionResult)
                 {
-                    var sectionQuestionsData = new List<object>();
-                    foreach (var field in section.Fields.OrderBy(f => f.Order))
-                    {
-                        var options = ExtractSelectListOptions(field);
-                        sectionQuestionsData.Add(new
-                        {
-                            id = field.Id.ToString(),
-                            question = field.Label,
-                            description = field.Description,
-                            type = field.Type.ToString(),
-                            options,
-                            allowed_answers = ExtractSelectListOptionNumbers(options)
-                        });
-                    }
-
-                    var applicationScoringRequest = new ApplicationScoringRequest
-                    {
-                        Data = promptData,
-                        Attachments = attachmentSummaries,
-                        SectionName = section.Name,
-                        SectionSchema = JsonSerializer.SerializeToElement(sectionQuestionsData, _jsonOptions),
-                        PromptVersion = promptVersion,
-                    };
-                    var applicationScoringResponse = await aiService.GenerateApplicationScoringAsync(applicationScoringRequest);
-
-                    if (applicationScoringResponse.Answers.Count > 0)
-                    {
-                        var sectionJson = JsonSerializer.Serialize(applicationScoringResponse.Answers, _jsonOptions);
-                        using var sectionDoc = JsonDocument.Parse(sectionJson);
-                        foreach (var property in sectionDoc.RootElement.EnumerateObject())
-                        {
-                            allSectionResults[property.Name] = property.Value.Clone();
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Error processing AI application scoring section {SectionName} for application {ApplicationId}", section.Name, applicationId);
+                    allSectionResults[kvp.Key] = kvp.Value;
                 }
             }
 
@@ -114,6 +88,58 @@ namespace Unity.AI.Operations
             application.AIScoresheetAnswers = validatedJson;
             await applicationRepository.UpdateAsync(application);
             return validatedJson;
+        }
+
+        private async Task<Dictionary<string, object>> ProcessSectionAsync(
+            Guid applicationId,
+            ScoresheetSection section,
+            JsonElement promptData,
+            List<AIAttachmentItem> attachmentSummaries,
+            string? promptVersion)
+        {
+            var sectionResults = new Dictionary<string, object>();
+            try
+            {
+                var sectionQuestionsData = new List<object>();
+                foreach (var field in section.Fields.OrderBy(f => f.Order))
+                {
+                    var options = ExtractSelectListOptions(field);
+                    sectionQuestionsData.Add(new
+                    {
+                        id = field.Id.ToString(),
+                        question = field.Label,
+                        description = field.Description,
+                        type = field.Type.ToString(),
+                        options,
+                        allowed_answers = ExtractSelectListOptionNumbers(options)
+                    });
+                }
+
+                var applicationScoringRequest = new ApplicationScoringRequest
+                {
+                    Data = promptData,
+                    Attachments = attachmentSummaries,
+                    SectionName = section.Name,
+                    SectionSchema = JsonSerializer.SerializeToElement(sectionQuestionsData, _jsonOptions),
+                    PromptVersion = promptVersion,
+                };
+                var applicationScoringResponse = await aiService.GenerateApplicationScoringAsync(applicationScoringRequest);
+
+                if (applicationScoringResponse.Answers.Count > 0)
+                {
+                    var sectionJson = JsonSerializer.Serialize(applicationScoringResponse.Answers, _jsonOptions);
+                    using var sectionDoc = JsonDocument.Parse(sectionJson);
+                    foreach (var property in sectionDoc.RootElement.EnumerateObject())
+                    {
+                        sectionResults[property.Name] = property.Value.Clone();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error processing AI application scoring section {SectionName} for application {ApplicationId}", section.Name, applicationId);
+            }
+            return sectionResults;
         }
 
         private async Task<string?> GetFormSchemaAsync(Guid? formVersionId)

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
@@ -65,14 +65,13 @@ namespace Unity.AI.Operations
             var promptData = PromptDataPayloadBuilder.BuildPromptDataPayload(application, formSubmission, formSchema, logger);
 
             var sections = scoresheet.Sections.OrderBy(s => s.Order).ToList();
-            var mode = executionModeResolver.ResolveMode(AIExecutionModeResolver.ScoresheetFlow);
-            var batchSize = executionModeResolver.ResolveBatchSize();
+            var mode = executionModeResolver.ResolveMode(AIExecutionModeResolver.ApplicationScoringOperation);
 
             var perSectionResults = await AIExecutionStrategy.RunAsync(
                 sections,
                 mode,
-                batchSize,
-                section => ProcessSectionAsync(applicationId, section, promptData, attachmentSummaries, promptVersion));
+                section => ProcessSectionAsync(applicationId, section, promptData, attachmentSummaries, promptVersion),
+                batch => ProcessSectionsAsync(applicationId, batch, promptData, attachmentSummaries, promptVersion));
 
             var allSectionResults = new Dictionary<string, object>();
             foreach (var sectionResult in perSectionResults)
@@ -100,27 +99,12 @@ namespace Unity.AI.Operations
             var sectionResults = new Dictionary<string, object>();
             try
             {
-                var sectionQuestionsData = new List<object>();
-                foreach (var field in section.Fields.OrderBy(f => f.Order))
-                {
-                    var options = ExtractSelectListOptions(field);
-                    sectionQuestionsData.Add(new
-                    {
-                        id = field.Id.ToString(),
-                        question = field.Label,
-                        description = field.Description,
-                        type = field.Type.ToString(),
-                        options,
-                        allowed_answers = ExtractSelectListOptionNumbers(options)
-                    });
-                }
-
                 var applicationScoringRequest = new ApplicationScoringRequest
                 {
                     Data = promptData,
                     Attachments = attachmentSummaries,
                     SectionName = section.Name,
-                    SectionSchema = JsonSerializer.SerializeToElement(sectionQuestionsData, _jsonOptions),
+                    SectionSchema = JsonSerializer.SerializeToElement(BuildSectionQuestionsData(section), _jsonOptions),
                     PromptVersion = promptVersion,
                 };
                 var applicationScoringResponse = await aiService.GenerateApplicationScoringAsync(applicationScoringRequest);
@@ -140,6 +124,70 @@ namespace Unity.AI.Operations
                 logger.LogError(ex, "Error processing AI application scoring section {SectionName} for application {ApplicationId}", section.Name, applicationId);
             }
             return sectionResults;
+        }
+
+        private async Task<List<Dictionary<string, object>>> ProcessSectionsAsync(
+            Guid applicationId,
+            IReadOnlyCollection<ScoresheetSection> sections,
+            JsonElement promptData,
+            List<AIAttachmentItem> attachmentSummaries,
+            string? promptVersion)
+        {
+            var sectionResults = new Dictionary<string, object>();
+            try
+            {
+                var questions = sections
+                    .OrderBy(s => s.Order)
+                    .SelectMany(BuildSectionQuestionsData)
+                    .ToList();
+
+                var applicationScoringRequest = new ApplicationScoringRequest
+                {
+                    Data = promptData,
+                    Attachments = attachmentSummaries,
+                    SectionName = "All Sections",
+                    SectionSchema = JsonSerializer.SerializeToElement(questions, _jsonOptions),
+                    PromptVersion = promptVersion,
+                };
+                var applicationScoringResponse = await aiService.GenerateApplicationScoringAsync(applicationScoringRequest);
+
+                if (applicationScoringResponse.Answers.Count > 0)
+                {
+                    var sectionJson = JsonSerializer.Serialize(applicationScoringResponse.Answers, _jsonOptions);
+                    using var sectionDoc = JsonDocument.Parse(sectionJson);
+                    foreach (var property in sectionDoc.RootElement.EnumerateObject())
+                    {
+                        sectionResults[property.Name] = property.Value.Clone();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error processing AI application scoring batch for application {ApplicationId}", applicationId);
+            }
+
+            return [sectionResults];
+        }
+
+        private static List<object> BuildSectionQuestionsData(ScoresheetSection section)
+        {
+            var sectionQuestionsData = new List<object>();
+            foreach (var field in section.Fields.OrderBy(f => f.Order))
+            {
+                var options = ExtractSelectListOptions(field);
+                sectionQuestionsData.Add(new
+                {
+                    id = field.Id.ToString(),
+                    section = section.Name,
+                    question = field.Label,
+                    description = field.Description,
+                    type = field.Type.ToString(),
+                    options,
+                    allowed_answers = ExtractSelectListOptionNumbers(options)
+                });
+            }
+
+            return sectionQuestionsData;
         }
 
         private async Task<string?> GetFormSchemaAsync(Guid? formVersionId)

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AttachmentSummaryService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AttachmentSummaryService.cs
@@ -47,10 +47,11 @@ public class AttachmentSummaryService(
     {
         var ids = attachmentIds as IReadOnlyCollection<Guid> ?? attachmentIds.ToList();
         var mode = executionModeResolver.ResolveMode(AIExecutionModeResolver.AttachmentSummaryOperation);
-        if (mode == AIExecutionMode.Batch)
+        if (mode != AIExecutionMode.Sequential)
         {
             logger.LogWarning(
-                "AI attachment summary batch mode is not supported by the single-attachment AI contract. Falling back to sequential execution.");
+                "AI attachment summary {ExecutionMode} mode is not supported by the current repository-backed execution path. Falling back to sequential execution.",
+                mode);
             mode = AIExecutionMode.Sequential;
         }
 

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AttachmentSummaryService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AttachmentSummaryService.cs
@@ -16,6 +16,7 @@ public class AttachmentSummaryService(
     IChefsFileAttachmentStreamProvider chefsFileAttachmentStreamProvider,
     ITextExtractionService textExtractionService,
     IAIService aiService,
+    AIExecutionModeResolver executionModeResolver,
     ILogger<AttachmentSummaryService> logger) : IAttachmentSummaryService, ITransientDependency
 {
     private const string SummaryGenerationFailedMessage = "AI summary generation failed.";
@@ -44,22 +45,28 @@ public class AttachmentSummaryService(
 
     public async Task<List<string>> GenerateAndSaveAsync(IEnumerable<Guid> attachmentIds, string? promptVersion = null)
     {
-        var summaries = new List<string>();
+        var ids = attachmentIds as IReadOnlyCollection<Guid> ?? attachmentIds.ToList();
+        var mode = executionModeResolver.ResolveMode(AIExecutionModeResolver.AttachmentSummariesFlow);
+        var batchSize = executionModeResolver.ResolveBatchSize();
 
-        foreach (var attachmentId in attachmentIds)
+        return await AIExecutionStrategy.RunAsync(
+            ids,
+            mode,
+            batchSize,
+            id => GenerateOrFallbackAsync(id, promptVersion));
+    }
+
+    private async Task<string> GenerateOrFallbackAsync(Guid attachmentId, string? promptVersion)
+    {
+        try
         {
-            try
-            {
-                summaries.Add(await GenerateAndSaveAsync(attachmentId, promptVersion));
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error generating AI summary for attachment {AttachmentId}", attachmentId);
-                summaries.Add(SummaryGenerationFailedMessage);
-            }
+            return await GenerateAndSaveAsync(attachmentId, promptVersion);
         }
-
-        return summaries;
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error generating AI summary for attachment {AttachmentId}", attachmentId);
+            return SummaryGenerationFailedMessage;
+        }
     }
 
     public async Task<List<string>> GenerateForApplicationAsync(Guid applicationId, string? promptVersion = null)

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AttachmentSummaryService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AttachmentSummaryService.cs
@@ -46,14 +46,30 @@ public class AttachmentSummaryService(
     public async Task<List<string>> GenerateAndSaveAsync(IEnumerable<Guid> attachmentIds, string? promptVersion = null)
     {
         var ids = attachmentIds as IReadOnlyCollection<Guid> ?? attachmentIds.ToList();
-        var mode = executionModeResolver.ResolveMode(AIExecutionModeResolver.AttachmentSummariesFlow);
-        var batchSize = executionModeResolver.ResolveBatchSize();
+        var mode = executionModeResolver.ResolveMode(AIExecutionModeResolver.AttachmentSummaryOperation);
+        if (mode == AIExecutionMode.Batch)
+        {
+            logger.LogWarning(
+                "AI attachment summary batch mode is not supported by the single-attachment AI contract. Falling back to sequential execution.");
+            mode = AIExecutionMode.Sequential;
+        }
 
         return await AIExecutionStrategy.RunAsync(
             ids,
             mode,
-            batchSize,
-            id => GenerateOrFallbackAsync(id, promptVersion));
+            id => GenerateOrFallbackAsync(id, promptVersion),
+            batch => GenerateSequentiallyAsync(batch, promptVersion));
+    }
+
+    private async Task<List<string>> GenerateSequentiallyAsync(IReadOnlyCollection<Guid> attachmentIds, string? promptVersion)
+    {
+        var summaries = new List<string>(attachmentIds.Count);
+        foreach (var attachmentId in attachmentIds)
+        {
+            summaries.Add(await GenerateOrFallbackAsync(attachmentId, promptVersion));
+        }
+
+        return summaries;
     }
 
     private async Task<string> GenerateOrFallbackAsync(Guid attachmentId, string? promptVersion)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationScoringJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationScoringJob.cs
@@ -2,9 +2,11 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 using Unity.GrantManager.GrantApplications;
+using Unity.GrantManager.GrantApplications.Automation.Events;
 using Volo.Abp.BackgroundJobs;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Repositories;
+using Volo.Abp.EventBus.Local;
 using Volo.Abp.MultiTenancy;
 using Volo.Abp.Uow;
 
@@ -15,6 +17,7 @@ public class GenerateApplicationScoringJob(
     IRepository<AIGenerationRequest, Guid> generationRequestRepository,
     ICurrentTenant currentTenant,
     IUnitOfWorkManager unitOfWorkManager,
+    ILocalEventBus localEventBus,
     ILogger<GenerateApplicationScoringJob> logger) : AsyncBackgroundJob<GenerateApplicationScoringBackgroundJobArgs>, ITransientDependency
 {
     public override async Task ExecuteAsync(GenerateApplicationScoringBackgroundJobArgs args)
@@ -25,7 +28,14 @@ public class GenerateApplicationScoringJob(
             try
             {
                 logger.LogInformation("Executing AI application scoring job for application {ApplicationId}.", args.ApplicationId);
-                await applicationScoringAppService.GenerateApplicationScoringAsync(args.ApplicationId, args.PromptVersion);
+                var result = await applicationScoringAppService.GenerateApplicationScoringForPipelineAsync(args.ApplicationId, args.PromptVersion);
+                if (result.Completed)
+                {
+                    await localEventBus.PublishAsync(new ApplicationAIScoringGeneratedEvent
+                    {
+                        ApplicationId = args.ApplicationId
+                    });
+                }
                 logger.LogInformation("Completed AI application scoring job for application {ApplicationId}.", args.ApplicationId);
                 await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);
             }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.json
@@ -152,7 +152,8 @@
       "Defaults": {
         "Provider": "OpenAI",
         "Profile": "Gpt4oMini",
-        "PromptVersion": "v1"
+        "PromptVersion": "v1",
+        "ExecutionMode": "Sequential"
       },
       "AttachmentSummary": {
         "MaxCompletionTokens": 2000

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/AIExecutionModeResolverTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/AIExecutionModeResolverTests.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Configuration;
+using Shouldly;
+using System.Collections.Generic;
+using Unity.AI.Operations;
+using Unity.AI.Prompts;
+using Xunit;
+
+namespace Unity.GrantManager.AI.Operations;
+
+public class AIExecutionModeResolverTests
+{
+    [Fact]
+    public void ResolveMode_Uses_Operation_Override_Before_Default()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Azure:Operations:Defaults:ExecutionMode"] = "Parallel",
+                [$"Azure:Operations:{AIPromptTypes.ApplicationScoring}:ExecutionMode"] = "Batch"
+            })
+            .Build();
+
+        var resolver = new AIExecutionModeResolver(configuration);
+
+        resolver.ResolveMode(AIPromptTypes.ApplicationScoring).ShouldBe(AIExecutionMode.Batch);
+        resolver.ResolveMode(AIPromptTypes.AttachmentSummary).ShouldBe(AIExecutionMode.Parallel);
+    }
+}

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/AIExecutionStrategyTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/AIExecutionStrategyTests.cs
@@ -1,0 +1,39 @@
+using Shouldly;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Unity.AI.Operations;
+using Xunit;
+
+namespace Unity.GrantManager.AI.Operations;
+
+public class AIExecutionStrategyTests
+{
+    [Fact]
+    public async Task Batch_Uses_Single_Batch_Operation()
+    {
+        var itemCalls = 0;
+        var batchCalls = 0;
+        IReadOnlyCollection<int>? batchItems = null;
+
+        var results = await AIExecutionStrategy.RunAsync(
+            [1, 2, 3],
+            AIExecutionMode.Batch,
+            item =>
+            {
+                itemCalls++;
+                return Task.FromResult(item);
+            },
+            items =>
+            {
+                batchCalls++;
+                batchItems = items;
+                return Task.FromResult(new List<int> { 6 });
+            });
+
+        itemCalls.ShouldBe(0);
+        batchCalls.ShouldBe(1);
+        batchItems.ShouldNotBeNull();
+        batchItems.Count.ShouldBe(3);
+        results.ShouldBe([6]);
+    }
+}

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/AttachmentSummaryServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/AttachmentSummaryServiceTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Shouldly;
@@ -59,6 +60,7 @@ public class AttachmentSummaryServiceTests : GrantManagerApplicationTestBase
             streamProvider,
             textExtractionService,
             aiService,
+            new AIExecutionModeResolver(new ConfigurationBuilder().Build()),
             NullLogger<AttachmentSummaryService>.Instance);
 
         var result = await service.GenerateAndSaveAsync(attachmentId, "v1");


### PR DESCRIPTION
## Pull request overview

Implements AB#32310 by adding configurable execution modes for multi-step AI flows.

The branch introduces a small shared execution strategy for flows that process multiple AI work items. Execution mode is resolved per operation from `Azure:Operations:{OperationName}:ExecutionMode`, then from `Azure:Operations:Defaults:ExecutionMode`, and finally defaults to `Sequential` when unset or invalid. This matches the existing operation/default config pattern used for provider and profile settings.

Default behavior is unchanged: `Sequential` processes one item at a time.

**Changes:**
- Adds `AIExecutionMode`: `Sequential`, `Parallel`, `Batch`.
- Adds `AIExecutionModeResolver` for operation-specific/default mode lookup.
- Adds `AIExecutionStrategy.RunAsync(...)` to centralize sequential, parallel, and batch execution.
- Routes bulk attachment summary generation through the strategy.
- Keeps attachment-summary `Batch` safe by falling back to sequential because the current attachment AI contract is single-attachment.
- Routes scoresheet section generation through the strategy.
- Supports scoresheet `Batch` by sending all section questions in one scoring request.
- Keeps per-section scoring results isolated before merging, so `Parallel` does not mutate shared state.
- Updates appsettings with `Azure:Operations:Defaults:ExecutionMode`.
- Updates the scoring background job to call the pipeline-safe scoring method and publish completion when scoring completes.