### PR TITLE
AB#32892 centralize AI feature-disabled checks

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Attachments/AttachmentSummaryAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Attachments/AttachmentSummaryAppService.cs
@@ -2,11 +2,13 @@ using Microsoft.AspNetCore.Authorization;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Unity.AI;
+using Unity.AI.Features;
+using Unity.AI.Localization;
 using Unity.AI.Operations;
 using Unity.AI.Permissions;
+using Unity.AI.Settings;
 using Volo.Abp;
 using Volo.Abp.DependencyInjection;
-using Volo.Abp.Features;
 
 namespace Unity.GrantManager.Attachments;
 
@@ -14,25 +16,23 @@ namespace Unity.GrantManager.Attachments;
 [ExposeServices(typeof(AttachmentSummaryAppService), typeof(IAttachmentSummaryAppService))]
 public class AttachmentSummaryAppService(
     IAttachmentSummaryService attachmentSummaryService,
-    IFeatureChecker featureChecker) : AIAppService, IAttachmentSummaryAppService
+    AIFeatureGuard featureGuard) : AIAppService, IAttachmentSummaryAppService
 {
-    public async Task<AttachmentSummaryResultDto> GenerateAttachmentSummaryAsync(System.Guid attachmentId, string? promptVersion = null)
+    public virtual async Task<AttachmentSummaryResultDto> GenerateAttachmentSummaryAsync(System.Guid attachmentId, string? promptVersion = null)
     {
-        if (!await featureChecker.IsEnabledAsync("Unity.AI.AttachmentSummaries"))
-        {
-            throw new UserFriendlyException("AI attachment summaries are not enabled.");
-        }
+        await featureGuard.EnsureEnabledAsync(
+            AIFeatures.AttachmentSummaries,
+            AILocalizationKeys.AttachmentSummariesDisabled);
 
         await attachmentSummaryService.GenerateAndSaveAsync(attachmentId, promptVersion);
         return new AttachmentSummaryResultDto { Completed = true };
     }
 
-    public async Task<List<AttachmentSummaryResultDto>> GenerateAttachmentSummariesAsync(List<System.Guid> attachmentIds, string? promptVersion = null)
+    public virtual async Task<List<AttachmentSummaryResultDto>> GenerateAttachmentSummariesAsync(List<System.Guid> attachmentIds, string? promptVersion = null)
     {
-        if (!await featureChecker.IsEnabledAsync("Unity.AI.AttachmentSummaries"))
-        {
-            throw new UserFriendlyException("AI attachment summaries are not enabled.");
-        }
+        await featureGuard.EnsureEnabledAsync(
+            AIFeatures.AttachmentSummaries,
+            AILocalizationKeys.AttachmentSummariesDisabled);
 
         if (attachmentIds.Count == 0)
         {
@@ -54,7 +54,10 @@ public class AttachmentSummaryAppService(
     [RemoteService(IsEnabled = false)]
     public virtual async Task<List<AttachmentSummaryResultDto>> GenerateAttachmentSummariesForPipelineAsync(List<System.Guid> attachmentIds, string? promptVersion = null)
     {
-        if (attachmentIds.Count == 0) return [];
+        if (attachmentIds.Count == 0)
+        {
+            return [];
+        }
 
         var results = new List<AttachmentSummaryResultDto>();
         foreach (var attachmentId in attachmentIds)
@@ -62,6 +65,7 @@ public class AttachmentSummaryAppService(
             await attachmentSummaryService.GenerateAndSaveAsync(attachmentId, promptVersion);
             results.Add(new AttachmentSummaryResultDto { Completed = true });
         }
+
         return results;
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationAnalysisAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationAnalysisAppService.cs
@@ -3,9 +3,11 @@ using System;
 using System.Threading.Tasks;
 using Unity.AI;
 using Unity.AI.Automation;
+using Unity.AI.Features;
+using Unity.AI.Localization;
 using Unity.AI.Permissions;
+using Unity.AI.Settings;
 using Volo.Abp;
-using Volo.Abp.Features;
 using Volo.Abp.MultiTenancy;
 
 namespace Unity.GrantManager.GrantApplications;
@@ -14,16 +16,15 @@ namespace Unity.GrantManager.GrantApplications;
 public class ApplicationAnalysisAppService(
     Unity.AI.Operations.IApplicationAnalysisService applicationAnalysisService,
     IApplicationAIGenerationQueue aiGenerationQueue,
-    IFeatureChecker featureChecker,
+    AIFeatureGuard featureGuard,
     ICurrentTenant currentTenant)
     : AIAppService, IApplicationAnalysisAppService
 {
     public virtual async Task<ApplicationAnalysisResultDto> GenerateApplicationAnalysisAsync(Guid applicationId, string? promptVersion = null)
     {
-        if (!await featureChecker.IsEnabledAsync("Unity.AI.ApplicationAnalysis"))
-        {
-            throw new UserFriendlyException("AI application analysis is not enabled.");
-        }
+        await featureGuard.EnsureEnabledAsync(
+            AIFeatures.ApplicationAnalysis,
+            AILocalizationKeys.ApplicationAnalysisDisabled);
 
         await aiGenerationQueue.QueueApplicationAnalysisAsync(applicationId, currentTenant.Id, promptVersion);
         return new ApplicationAnalysisResultDto { Completed = false };

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationContentAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationContentAppService.cs
@@ -3,9 +3,10 @@ using System;
 using System.Threading.Tasks;
 using Unity.AI;
 using Unity.AI.Automation;
+using Unity.AI.Features;
+using Unity.AI.Localization;
 using Unity.AI.Permissions;
-using Volo.Abp;
-using Volo.Abp.Features;
+using Unity.AI.Settings;
 using Volo.Abp.MultiTenancy;
 
 namespace Unity.GrantManager.GrantApplications;
@@ -15,20 +16,15 @@ namespace Unity.GrantManager.GrantApplications;
 [Authorize(AIPermissions.Analysis.ViewScoringResult)]
 public class ApplicationContentAppService(
     IApplicationAIGenerationQueue aiGenerationQueue,
-    IFeatureChecker featureChecker,
+    AIFeatureGuard featureGuard,
     ICurrentTenant currentTenant)
     : AIAppService, IApplicationContentAppService
 {
-    public async Task<ApplicationContentResultDto> GenerateContentAsync(Guid applicationId, string? promptVersion = null)
+    public virtual async Task<ApplicationContentResultDto> GenerateContentAsync(Guid applicationId, string? promptVersion = null)
     {
-        var attachmentSummariesEnabled = await featureChecker.IsEnabledAsync("Unity.AI.AttachmentSummaries");
-        var applicationAnalysisEnabled = await featureChecker.IsEnabledAsync("Unity.AI.ApplicationAnalysis");
-        var scoringEnabled = await featureChecker.IsEnabledAsync("Unity.AI.Scoring");
-
-        if (!attachmentSummariesEnabled || !applicationAnalysisEnabled || !scoringEnabled)
-        {
-            throw new UserFriendlyException("AI generate all is not enabled.");
-        }
+        await featureGuard.EnsureEnabledAsync(AIFeatures.AttachmentSummaries, AILocalizationKeys.GenerateAllDisabled);
+        await featureGuard.EnsureEnabledAsync(AIFeatures.ApplicationAnalysis, AILocalizationKeys.GenerateAllDisabled);
+        await featureGuard.EnsureEnabledAsync(AIFeatures.Scoring, AILocalizationKeys.GenerateAllDisabled);
 
         await aiGenerationQueue.QueueAllAIStagesAsync(applicationId, currentTenant.Id, promptVersion);
 

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationScoringAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationScoringAppService.cs
@@ -2,28 +2,29 @@ using Microsoft.AspNetCore.Authorization;
 using System;
 using System.Threading.Tasks;
 using Unity.AI;
+using Unity.AI.Features;
+using Unity.AI.Localization;
 using Unity.AI.Operations;
 using Unity.AI.Permissions;
+using Unity.AI.Settings;
 using Unity.GrantManager.GrantApplications.Automation.Events;
 using Volo.Abp;
 using Volo.Abp.EventBus.Local;
-using Volo.Abp.Features;
 
 namespace Unity.GrantManager.GrantApplications;
 
 [Authorize(AIPermissions.Analysis.GenerateScoring)]
 public class ApplicationScoringAppService(
     IApplicationScoringService applicationScoringService,
-    IFeatureChecker featureChecker,
+    AIFeatureGuard featureGuard,
     ILocalEventBus localEventBus)
     : AIAppService, IApplicationScoringAppService
 {
     public virtual async Task<ApplicationScoringResultDto> GenerateApplicationScoringAsync(Guid applicationId, string? promptVersion = null)
     {
-        if (!await featureChecker.IsEnabledAsync("Unity.AI.Scoring"))
-        {
-            throw new UserFriendlyException("AI scoring is not enabled.");
-        }
+        await featureGuard.EnsureEnabledAsync(
+            AIFeatures.Scoring,
+            AILocalizationKeys.ScoringDisabled);
 
         await applicationScoringService.RegenerateAndSaveAsync(applicationId, promptVersion);
 

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Settings/AIFeatureGuard.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Settings/AIFeatureGuard.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Localization;
+using System.Threading.Tasks;
+using Unity.AI.Localization;
+using Volo.Abp;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Features;
+
+namespace Unity.AI.Settings;
+
+public class AIFeatureGuard(
+    IFeatureChecker featureChecker,
+    IStringLocalizer<AIResource> localizer) : ITransientDependency
+{
+    public async Task EnsureEnabledAsync(string featureName, string disabledMessageKey)
+    {
+        if (!await featureChecker.IsEnabledAsync(featureName))
+        {
+            throw new UserFriendlyException(localizer[disabledMessageKey]);
+        }
+    }
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Domain.Shared/Features/AIFeatures.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Domain.Shared/Features/AIFeatures.cs
@@ -1,0 +1,9 @@
+namespace Unity.AI.Features;
+
+public static class AIFeatures
+{
+    public const string Reporting = "Unity.AIReporting";
+    public const string AttachmentSummaries = "Unity.AI.AttachmentSummaries";
+    public const string ApplicationAnalysis = "Unity.AI.ApplicationAnalysis";
+    public const string Scoring = "Unity.AI.Scoring";
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Domain.Shared/Localization/AI/en.json
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Domain.Shared/Localization/AI/en.json
@@ -18,6 +18,11 @@
     "Setting:AI.AutomaticGenerationEnabled": "Automatically Generate AI Analysis",
     "Setting:AI.ManualGenerationEnabled": "Manually Initiate AI Analysis",
 
+    "AI:AttachmentSummariesDisabled": "AI attachment summaries are not enabled.",
+    "AI:ApplicationAnalysisDisabled": "AI application analysis is not enabled.",
+    "AI:ScoringDisabled": "AI scoring is not enabled.",
+    "AI:GenerateAllDisabled": "AI generation is not enabled.",
+
     "AIPrompts": "AI Prompts",
     "AIPrompt": "AI Prompt",
     "AIPromptVersion": "Prompt Version",

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Domain.Shared/Localization/AILocalizationKeys.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Domain.Shared/Localization/AILocalizationKeys.cs
@@ -1,0 +1,9 @@
+namespace Unity.AI.Localization;
+
+public static class AILocalizationKeys
+{
+    public const string AttachmentSummariesDisabled = "AI:AttachmentSummariesDisabled";
+    public const string ApplicationAnalysisDisabled = "AI:ApplicationAnalysisDisabled";
+    public const string ScoringDisabled = "AI:ScoringDisabled";
+    public const string GenerateAllDisabled = "AI:GenerateAllDisabled";
+}

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/ApplicationContentAppServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/ApplicationContentAppServiceTests.cs
@@ -1,7 +1,10 @@
+using Microsoft.Extensions.Localization;
 using NSubstitute;
 using Shouldly;
 using System;
 using System.Threading.Tasks;
+using Unity.AI.Localization;
+using Unity.AI.Settings;
 using Unity.GrantManager.GrantApplications;
 using Unity.GrantManager.GrantApplications.Automation.BackgroundJobs;
 using Unity.AI.Automation;
@@ -20,6 +23,8 @@ public class ApplicationContentAppServiceTests(ITestOutputHelper outputHelper) :
         featureChecker.IsEnabledAsync("Unity.AI.AttachmentSummaries").Returns(true);
         featureChecker.IsEnabledAsync("Unity.AI.ApplicationAnalysis").Returns(true);
         featureChecker.IsEnabledAsync("Unity.AI.Scoring").Returns(true);
+        var localizer = Substitute.For<IStringLocalizer<AIResource>>();
+        var featureGuard = new AIFeatureGuard(featureChecker, localizer);
 
         var queue = Substitute.For<IApplicationAIGenerationQueue>();
         queue.QueueAllAIStagesAsync(Arg.Any<Guid>(), Arg.Any<Guid?>(), Arg.Any<string?>())
@@ -27,7 +32,7 @@ public class ApplicationContentAppServiceTests(ITestOutputHelper outputHelper) :
         var currentTenant = Substitute.For<Volo.Abp.MultiTenancy.ICurrentTenant>();
         currentTenant.Id.Returns(Guid.NewGuid());
 
-        var service = new ApplicationContentAppService(queue, featureChecker, currentTenant);
+        var service = new ApplicationContentAppService(queue, featureGuard, currentTenant);
 
         var result = await service.GenerateContentAsync(Guid.NewGuid());
 
@@ -36,3 +41,4 @@ public class ApplicationContentAppServiceTests(ITestOutputHelper outputHelper) :
         await queue.Received(1).QueueAllAIStagesAsync(Arg.Any<Guid>(), Arg.Any<Guid?>(), Arg.Any<string?>());
     }
 }
+


### PR DESCRIPTION
## Pull request overview

Centralizes repeated AI feature-disabled checks in a small `AIFeatureGuard`. The affected app services now use typed feature constants and localized disabled messages instead of hardcoded feature-name strings and English text.

**Changes:**
- New `Settings/AIFeatureGuard` wrapping `IFeatureChecker` + `IStringLocalizer<AIResource>`
- New `AIFeatures` constants for AI feature names
- New `AILocalizationKeys` constants for guard messages
- Add `AI:*Disabled` localization entries (en.json)
- Update 4 AppServices: `AttachmentSummary`, `ApplicationAnalysis`, `ApplicationContent`, `ApplicationScoring`
- Update affected tests for the new guard dependency