### PR TITLE
feature/AB#32688 - AppList Performance Only Necessary Columns Net10 Update

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/GrantApplicationListInputDto.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/GrantApplicationListInputDto.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Volo.Abp.Application.Dtos;
 
 namespace Unity.GrantManager.GrantApplications
@@ -7,5 +8,11 @@ namespace Unity.GrantManager.GrantApplications
     {
         public DateTime? SubmittedFromDate { get; set; }
         public DateTime? SubmittedToDate { get; set; }
+        /// <summary>
+        /// Column names that are currently visible in the UI. When provided, only 
+        /// the database JOINs required to populate those columns are executed. 
+        /// Pass null or an empty list to load everything (backward-compatible).
+        /// </summary>
+        public List<string>? RequestedFields { get; set; }
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/GrantApplicationAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/GrantApplicationAppService.cs
@@ -117,7 +117,7 @@ public class GrantApplicationAppService(
                 TotalProjectBudget = rec.TotalProjectBudget,
                 EconomicRegion = rec.EconomicRegion ?? string.Empty,
                 City = rec.City ?? string.Empty,
-                ProposalDate = rec.ProposalDate ?? default,
+                ProposalDate = rec.ProposalDate,
                 SubmissionDate = rec.SubmissionDate,
                 FinalDecisionDate = rec.FinalDecisionDate,
                 DueDate = rec.DueDate,
@@ -133,7 +133,7 @@ public class GrantApplicationAppService(
                 DeclineRational = MapDeclineRationalDisplayValue(rec.DeclineRational ?? string.Empty),
                 Notes = rec.Notes ?? string.Empty,
                 AssessmentResultStatus = rec.AssessmentResultStatus ?? string.Empty,
-                AssessmentResultDate = rec.AssessmentResultDate ?? default,
+                AssessmentResultDate = rec.AssessmentResultDate,
                 ProjectStartDate = rec.ProjectStartDate,
                 ProjectEndDate = rec.ProjectEndDate,
                 PercentageTotalProjectBudget = rec.PercentageTotalProjectBudget,
@@ -165,7 +165,7 @@ public class GrantApplicationAppService(
                 // From ApplicationForm
                 Category = rec.Category,
 
-                // From Applicant — both the nested DTO and the flattened top-level properties
+                // From Applicant - both the nested DTO and the flattened top-level properties
                 Applicant = new GrantApplicationApplicantDto
                 {
                     Id = rec.ApplicantId,
@@ -255,7 +255,7 @@ public class GrantApplicationAppService(
         //Code is temporarily commented out as this will be the way to get the accurate count
         //once the core GrantApplications data table is moved server side from client side.
         //Until then, since it is client side and always requests all records at once to be
-        //loaded, an extra round-trip to the database for a query is uncessary. 
+        //loaded, an extra round-trip to the database for a query is unnecessary. 
 
         //var totalCount = await applicationRepository.GetCountAsync(input.SubmittedFromDate,input.SubmittedToDate);
 #pragma warning restore S125

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/GrantApplicationAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/GrantApplicationAppService.cs
@@ -22,6 +22,7 @@ using Unity.GrantManager.Applications;
 using Unity.GrantManager.Events;
 using Unity.GrantManager.Flex;
 using Unity.GrantManager.Identity;
+using Unity.GrantManager.GlobalTag;
 using Unity.GrantManager.Payments;
 using Unity.Modules.Shared;
 using Unity.Modules.Shared.Correlation;
@@ -72,56 +73,177 @@ public class GrantApplicationAppService(
 
     public async Task<PagedResultDto<GrantApplicationDto>> GetListAsync(GrantApplicationListInputDto input)
     {
-        // 1. Fetch applications with filters + paging in DB
-        var applications = await applicationRepository.WithFullDetailsAsync(
+        var listRecords = await applicationRepository.GetApplicationListRecordsAsync(
             input.SkipCount,
             input.MaxResultCount,
             input.Sorting,
             input.SubmittedFromDate,
-            input.SubmittedToDate
+            input.SubmittedToDate,
+            requestedFields: input.RequestedFields
         );
 
-        var applicationIds = applications.Select(a => a.Id).ToList();
+        var applicationIds = listRecords.Select(r => r.Id).ToList();
 
-        // 2. Fetch payment rollup batch if feature enabled
-        bool paymentsFeatureEnabled = await FeatureChecker.IsEnabledAsync(PaymentConsts.UnityPaymentsFeature);
+
+        // Fetch payment rollup batch only when the feature is enabled AND at least one
+        // payment column is visible. The two payment column sNames are "totalPaidAmount"
+        // and "paymentInfo"; null RequestedFields means all columns are requested.
+        bool paymentColumnsRequested = input.RequestedFields == null || input.RequestedFields.Any(f =>
+                f.Equals("totalPaidAmount", StringComparison.OrdinalIgnoreCase)
+             || f.Equals("paymentInfo", StringComparison.OrdinalIgnoreCase));
+
+
+        bool paymentsFeatureEnabled = false;
+        if (paymentColumnsRequested) // Only even check if a column is requested.
+        {
+            paymentsFeatureEnabled = await FeatureChecker.IsEnabledAsync(PaymentConsts.UnityPaymentsFeature);
+        }
 
         Dictionary<Guid, ApplicationPaymentRollupDto> paymentRollupBatch = [];
 
-        if (paymentsFeatureEnabled && applicationIds.Count > 0)
+        if (paymentColumnsRequested && paymentsFeatureEnabled && applicationIds.Count > 0)
         {
             paymentRollupBatch = await paymentRequestService.GetApplicationPaymentRollupBatchAsync(applicationIds);
         }
 
-        // 3. Map applications to DTOs
-        var appDtos = applications.Select(app =>
+        var appDtos = listRecords.Select(rec =>
         {
-            var appDto = ObjectMapper.Map<Application, GrantApplicationDto>(app);
+            var appDto = new GrantApplicationDto
+            {
+                Id = rec.Id,
+                ProjectName = rec.ProjectName,
+                ReferenceNo = rec.ReferenceNo,
+                RequestedAmount = rec.RequestedAmount,
+                TotalProjectBudget = rec.TotalProjectBudget,
+                EconomicRegion = rec.EconomicRegion ?? string.Empty,
+                City = rec.City ?? string.Empty,
+                ProposalDate = rec.ProposalDate ?? default,
+                SubmissionDate = rec.SubmissionDate,
+                FinalDecisionDate = rec.FinalDecisionDate,
+                DueDate = rec.DueDate,
+                NotificationDate = rec.NotificationDate,
+                ProjectSummary = rec.ProjectSummary ?? string.Empty,
+                TotalScore = rec.TotalScore ?? 0,
+                RecommendedAmount = rec.RecommendedAmount,
+                ApprovedAmount = rec.ApprovedAmount,
+                LikelihoodOfFunding = rec.LikelihoodOfFunding ?? string.Empty,
+                DueDiligenceStatus = rec.DueDiligenceStatus ?? string.Empty,
+                SubStatus = rec.SubStatus ?? string.Empty,
+                SubStatusDisplayValue = MapSubstatusDisplayValue(rec.SubStatus ?? string.Empty),
+                DeclineRational = MapDeclineRationalDisplayValue(rec.DeclineRational ?? string.Empty),
+                Notes = rec.Notes ?? string.Empty,
+                AssessmentResultStatus = rec.AssessmentResultStatus ?? string.Empty,
+                AssessmentResultDate = rec.AssessmentResultDate ?? default,
+                ProjectStartDate = rec.ProjectStartDate,
+                ProjectEndDate = rec.ProjectEndDate,
+                PercentageTotalProjectBudget = rec.PercentageTotalProjectBudget,
+                ProjectFundingTotal = rec.ProjectFundingTotal,
+                Community = rec.Community,
+                CommunityPopulation = rec.CommunityPopulation,
+                Acquisition = rec.Acquisition,
+                Forestry = rec.Forestry,
+                ForestryFocus = rec.ForestryFocus,
+                ElectoralDistrict = rec.ElectoralDistrict,
+                ApplicantElectoralDistrict = rec.ApplicantElectoralDistrict,
+                Place = rec.Place,
+                RegionalDistrict = rec.RegionalDistrict,
+                OwnerId = rec.OwnerId,
+                DefaultSiteId = rec.DefaultSiteId,
+                SigningAuthorityFullName = rec.SigningAuthorityFullName,
+                SigningAuthorityTitle = rec.SigningAuthorityTitle,
+                SigningAuthorityEmail = rec.SigningAuthorityEmail,
+                SigningAuthorityBusinessPhone = rec.SigningAuthorityBusinessPhone,
+                SigningAuthorityCellPhone = rec.SigningAuthorityCellPhone,
+                ContractNumber = rec.ContractNumber,
+                ContractExecutionDate = rec.ContractExecutionDate,
+                RiskRanking = rec.RiskRanking,
+                UnityApplicationId = rec.UnityApplicationId,
 
-            appDto.Status = app.ApplicationStatus.InternalStatus;
-            appDto.Applicant = ObjectMapper.Map<Applicant, GrantApplicationApplicantDto>(app.Applicant);
-            appDto.Category = app.ApplicationForm.Category ?? string.Empty;
-            appDto.Owner = BuildApplicationOwner(app.Owner);
-            appDto.OrganizationName = app.Applicant?.OrgName ?? string.Empty;
-            appDto.ApplicationTag = ObjectMapper.Map<List<ApplicationTags>, List<ApplicationTagsDto>>(app.ApplicationTags?.ToList() ?? []);
-            appDto.NonRegOrgName = app.Applicant?.NonRegOrgName ?? string.Empty;
-            appDto.OrganizationType = app.Applicant?.OrganizationType ?? string.Empty;
-            appDto.Assignees = BuildApplicationAssignees(app.ApplicationAssignments);
-            appDto.SubStatusDisplayValue = MapSubstatusDisplayValue(appDto.SubStatus ?? string.Empty);
-            appDto.DeclineRational = MapDeclineRationalDisplayValue(appDto.DeclineRational ?? string.Empty);
-            appDto.ContactFullName = app.ApplicantAgent?.Name;
-            appDto.ContactEmail = app.ApplicantAgent?.Email;
-            appDto.ContactTitle = app.ApplicantAgent?.Title;
-            appDto.ContactBusinessPhone = app.ApplicantAgent?.Phone;
-            appDto.ContactCellPhone = app.ApplicantAgent?.Phone2;
-            appDto.ApplicationLinks = ObjectMapper.Map<List<ApplicationLink>, List<ApplicationLinksDto>>(app.ApplicationLinks?.ToList() ?? []);
+                // From ApplicationStatus
+                Status = rec.Status,
+
+                // From ApplicationForm
+                Category = rec.Category,
+
+                // From Applicant — both the nested DTO and the flattened top-level properties
+                Applicant = new GrantApplicationApplicantDto
+                {
+                    Id = rec.ApplicantId,
+                    ApplicantName = rec.ApplicantName ?? string.Empty,
+                    SupplierId = rec.ApplicantSupplierId ?? Guid.Empty,
+                    Sector = rec.ApplicantSector ?? string.Empty,
+                    SubSector = rec.ApplicantSubSector ?? string.Empty,
+                    OrgNumber = rec.ApplicantOrgNumber ?? string.Empty,
+                    OrgName = rec.ApplicantOrgName ?? string.Empty,
+                    OrgStatus = rec.ApplicantOrgStatus ?? string.Empty,
+                    BusinessNumber = rec.ApplicantBusinessNumber ?? string.Empty,
+                    OrganizationType = rec.ApplicantOrganizationType ?? string.Empty,
+                    OrganizationSize = rec.ApplicantOrganizationSize ?? string.Empty,
+                    SectorSubSectorIndustryDesc = rec.ApplicantSectorSubSectorIndustryDesc ?? string.Empty,
+                    RedStop = rec.ApplicantRedStop ?? false,
+                    IndigenousOrgInd = rec.ApplicantIndigenousOrgInd ?? string.Empty,
+                    UnityApplicantId = rec.ApplicantUnityApplicantId ?? string.Empty,
+                    FiscalDay = rec.ApplicantFiscalDay?.ToString() ?? string.Empty,
+                    FiscalMonth = rec.ApplicantFiscalMonth ?? string.Empty
+                },
+                OrganizationName = rec.ApplicantOrgName ?? string.Empty,
+                NonRegOrgName = rec.ApplicantNonRegOrgName ?? string.Empty,
+                OrganizationType = rec.ApplicantOrganizationType ?? string.Empty,
+                OrgStatus = rec.ApplicantOrgStatus,
+                BusinessNumber = rec.ApplicantBusinessNumber,
+                OrgNumber = rec.ApplicantOrgNumber,
+                OrganizationSize = rec.ApplicantOrganizationSize,
+                SectorSubSectorIndustryDesc = rec.ApplicantSectorSubSectorIndustryDesc,
+                Sector = rec.ApplicantSector,
+                SubSector = rec.ApplicantSubSector,
+
+                // From ApplicantAgent
+                ContactFullName = rec.ContactFullName,
+                ContactTitle = rec.ContactTitle,
+                ContactEmail = rec.ContactEmail,
+                ContactBusinessPhone = rec.ContactBusinessPhone,
+                ContactCellPhone = rec.ContactCellPhone,
+
+                // From Owner
+                Owner = rec.OwnerPersonId.HasValue
+                    ? new GrantApplicationAssigneeDto { Id = rec.OwnerPersonId.Value, FullName = rec.OwnerFullName ?? string.Empty }
+                    : new GrantApplicationAssigneeDto(),
+
+                // Collections
+                ApplicationTag = rec.Tags
+                    .Select(t => new ApplicationTagsDto
+                    {
+                        Id = t.Id,
+                        ApplicationId = t.ApplicationId,
+                        Tag = t.TagName != null ? new TagDto { Name = t.TagName } : null
+                    }).ToList(),
+
+                Assignees = rec.Assignments
+                    .Select(a => new GrantApplicationAssigneeDto
+                    {
+                        Id = a.Id,
+                        ApplicationId = a.ApplicationId,
+                        AssigneeId = a.AssigneeId,
+                        FullName = a.AssigneeName,
+                        Duty = a.Duty
+                    }).ToList(),
+
+                ApplicationLinks = rec.Links
+                    .Select(l => new ApplicationLinksDto
+                    {
+                        Id = l.Id,
+                        ApplicationId = l.ApplicationId,
+                        LinkedApplicationId = l.LinkedApplicationId,
+                        LinkType = l.LinkType
+                    }).ToList()
+            };
 
             if (paymentsFeatureEnabled && paymentRollupBatch.Count > 0)
             {
-                paymentRollupBatch.TryGetValue(app.Id, out var rollup);
+                paymentRollupBatch.TryGetValue(rec.Id, out var rollup);
                 appDto.PaymentInfo = new PaymentInfoDto
                 {
-                    ApprovedAmount = app.ApprovedAmount,
+                    ApprovedAmount = rec.ApprovedAmount,
                     TotalPaid = rollup?.TotalPaid ?? 0
                 };
             }
@@ -129,11 +251,15 @@ public class GrantApplicationAppService(
 
         }).ToList();
 
-        // 4. Get total count using same filters
-        var totalCount = await applicationRepository.GetCountAsync(
-            input.SubmittedFromDate,
-            input.SubmittedToDate
-        );
+#pragma warning disable S125
+        //Code is temporarily commented out as this will be the way to get the accurate count
+        //once the core GrantApplications data table is moved server side from client side.
+        //Until then, since it is client side and always requests all records at once to be
+        //loaded, an extra round-trip to the database for a query is uncessary. 
+
+        //var totalCount = await applicationRepository.GetCountAsync(input.SubmittedFromDate,input.SubmittedToDate);
+#pragma warning restore S125
+        var totalCount = appDtos.Count;
 
         return new PagedResultDto<GrantApplicationDto>(totalCount, appDtos);
     }
@@ -961,7 +1087,7 @@ public class GrantApplicationAppService(
         return form.AccountCodingId;
     }
 
-    
+
 
     public async Task<bool> IsApplicantRedStopAsync(Guid applicationId)
     {
@@ -988,7 +1114,7 @@ public class GrantApplicationAppService(
 
         // NOTE: Authorization is applied on the AppService layer and is false by default
         // AUTHORIZATION HANDLING
-         bool isRedStop = application.Applicant != null && application.Applicant.RedStop == true;
+        bool isRedStop = application.Applicant != null && application.Applicant.RedStop == true;
         foreach (var item in actionDtos)
         {
             item.IsPermitted = !isRedStop && item.IsPermitted && (await AuthorizationService.IsGrantedAsync(application, GetActionAuthorizationRequirement(item.ApplicationAction)));

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/ApplicationListRecord.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/ApplicationListRecord.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Unity.GrantManager.Applications;
+
+/// <summary>
+/// Flattened projection returned by
+/// <see cref="IApplicationRepository.GetApplicationListRecordsAsync"/>.
+/// Only the columns required for the application list view are selected
+/// </summary>
+public class ApplicationListRecord
+{
+    public Guid Id { get; init; }
+    public string ProjectName { get; init; } = string.Empty;
+    public string ReferenceNo { get; init; } = string.Empty;
+    public decimal RequestedAmount { get; init; }
+    public decimal TotalProjectBudget { get; init; }
+    public string? EconomicRegion { get; init; }
+    public string? City { get; init; }
+    public DateTime? ProposalDate { get; init; }
+    public DateTime SubmissionDate { get; init; }
+    public DateTime? FinalDecisionDate { get; init; }
+    public DateTime? DueDate { get; init; }
+    public DateTime? NotificationDate { get; init; }
+    public string? ProjectSummary { get; init; }
+    public int? TotalScore { get; init; }
+    public decimal RecommendedAmount { get; init; }
+    public decimal ApprovedAmount { get; init; }
+    public string? LikelihoodOfFunding { get; init; }
+    public string? DueDiligenceStatus { get; init; }
+    public string? SubStatus { get; init; }
+    public string? DeclineRational { get; init; }
+    public string? Notes { get; init; }
+    public string? AssessmentResultStatus { get; init; }
+    public DateTime? AssessmentResultDate { get; init; }
+    public DateTime? ProjectStartDate { get; init; }
+    public DateTime? ProjectEndDate { get; init; }
+    public double? PercentageTotalProjectBudget { get; init; }
+    public decimal? ProjectFundingTotal { get; init; }
+    public string? Community { get; init; }
+    public int? CommunityPopulation { get; init; }
+    public string? Acquisition { get; init; }
+    public string? Forestry { get; init; }
+    public string? ForestryFocus { get; init; }
+    public string? ElectoralDistrict { get; init; }
+    public string? ApplicantElectoralDistrict { get; init; }
+    public string? Place { get; init; }
+    public string? RegionalDistrict { get; init; }
+    public Guid? OwnerId { get; init; }
+    public Guid? DefaultSiteId { get; init; }
+    public string? SigningAuthorityFullName { get; init; }
+    public string? SigningAuthorityTitle { get; init; }
+    public string? SigningAuthorityEmail { get; init; }
+    public string? SigningAuthorityBusinessPhone { get; init; }
+    public string? SigningAuthorityCellPhone { get; init; }
+    public string? ContractNumber { get; init; }
+    public DateTime? ContractExecutionDate { get; init; }
+    public string? RiskRanking { get; init; }
+    public string? UnityApplicationId { get; init; }
+
+    // ApplicationStatus (always joined)
+    public string Status { get; init; } = string.Empty;
+
+    // ApplicationForm (always joined)
+    public string Category { get; init; } = string.Empty;
+
+    // Applicant (always joined)
+    public Guid ApplicantId { get; init; }
+    public string? ApplicantName { get; init; }
+    public Guid? ApplicantSupplierId { get; init; }
+    public string? ApplicantSector { get; init; }
+    public string? ApplicantSubSector { get; init; }
+    public string? ApplicantOrgName { get; init; }
+    public string? ApplicantNonRegOrgName { get; init; }
+    public string? ApplicantOrganizationType { get; init; }
+    public string? ApplicantOrgNumber { get; init; }
+    public string? ApplicantOrgStatus { get; init; }
+    public string? ApplicantBusinessNumber { get; init; }
+    public string? ApplicantOrganizationSize { get; init; }
+    public string? ApplicantSectorSubSectorIndustryDesc { get; init; }
+    public bool? ApplicantRedStop { get; init; }
+    public string? ApplicantIndigenousOrgInd { get; init; }
+    public int? ApplicantFiscalDay { get; init; }
+    public string? ApplicantFiscalMonth { get; init; }
+    public string? ApplicantUnityApplicantId { get; init; }
+
+    // ApplicantAgent (left-joined when present)
+    public string? ContactFullName { get; init; }
+    public string? ContactTitle { get; init; }
+    public string? ContactEmail { get; init; }
+    public string? ContactBusinessPhone { get; init; }
+    public string? ContactCellPhone { get; init; }
+
+    //  Owner / Person (left-joined when present) 
+    public Guid? OwnerPersonId { get; init; }
+    public string? OwnerFullName { get; init; }
+
+    // Collections (correlated subqueries)
+    public List<ApplicationTagListItem> Tags { get; init; } = [];
+    public List<ApplicationAssignmentListItem> Assignments { get; init; } = [];
+    public List<ApplicationLinkListItem> Links { get; init; } = [];
+}
+
+public class ApplicationTagListItem
+{
+    public Guid Id { get; init; }
+    public Guid ApplicationId { get; init; }
+    public string? TagName { get; init; }
+}
+
+public class ApplicationAssignmentListItem
+{
+    public Guid Id { get; init; }
+    public Guid ApplicationId { get; init; }
+    public Guid AssigneeId { get; init; }
+    public string AssigneeName { get; init; } = string.Empty;
+    public string? Duty { get; init; }
+}
+
+public class ApplicationLinkListItem
+{
+    public Guid Id { get; init; }
+    public Guid ApplicationId { get; init; }
+    public Guid LinkedApplicationId { get; init; }
+    public ApplicationLinkType LinkType { get; init; }
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/IApplicationRepository.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/IApplicationRepository.cs
@@ -27,6 +27,17 @@ namespace Unity.GrantManager.Applications
             string? searchTerm = null // optional search filter
         );
 
+        // Optimized projected list for the application list table.
+        Task<List<ApplicationListRecord>> GetApplicationListRecordsAsync(
+            int skipCount,
+            int maxResultCount,
+            string? sorting = null,
+            DateTime? submittedFromDate = null,
+            DateTime? submittedToDate = null,
+            string? searchTerm = null,
+            IReadOnlyList<string>? requestedFields = null
+        );
+
         // Get applications by applicant ID
         Task<List<Application>> GetByApplicantIdAsync(Guid applicantId);
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/ApplicationRepository.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/ApplicationRepository.cs
@@ -64,13 +64,38 @@ public class ApplicationRepository
         return (fromUtc, toUtc);
     }
 
-    /// <summary>
-    /// Base query with all required includes
-    /// </summary>
+    private static readonly HashSet<string> ApplicantAgentFields = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "contactFullName", "contactTitle", "contactEmail",
+        "contactBusinessPhone", "contactCellPhone"
+    };
+
+    private static readonly HashSet<string> TagFields = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "applicationTag"
+    };
+
+    private static readonly HashSet<string> OwnerFields = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Owner"
+    };
+
+    private static readonly HashSet<string> ApplicationLinkFields = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "applicationLinks"
+    };
+
+    private static readonly HashSet<string> AssignmentFields = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "assignees"
+    };
+
+
     private async Task<IQueryable<Application>> BuildBaseQueryAsync()
     {
         return (await GetQueryableAsync())
             .AsNoTracking()
+            .AsSplitQuery()
             .Include(a => a.ApplicationForm)
             .Include(a => a.ApplicationStatus)
             .Include(a => a.Applicant)
@@ -141,7 +166,8 @@ public class ApplicationRepository
         DateTime? submittedFromDate,
         DateTime? submittedToDate)
     {
-        var query = await BuildBaseQueryAsync();
+        // Dont use full query, run basic to just get count.
+        var query = (await GetQueryableAsync()).AsNoTracking();
         var (fromUtc, toUtc) = ConvertToUtcRange(
             submittedFromDate,
             submittedToDate);
@@ -195,6 +221,317 @@ public class ApplicationRepository
             .Where(a => a.ApplicantId == applicantId)
             .OrderByDescending(a => a.SubmissionDate)
             .ToListAsync();
+    }
+
+    public async Task<List<ApplicationListRecord>> GetApplicationListRecordsAsync(
+        int skipCount,
+        int maxResultCount,
+        string? sorting = null,
+        DateTime? submittedFromDate = null,
+        DateTime? submittedToDate = null,
+        string? searchTerm = null,
+        IReadOnlyList<string>? requestedFields = null)
+    {
+        var fields = requestedFields != null
+            ? new HashSet<string>(requestedFields, StringComparer.OrdinalIgnoreCase)
+            : null; // null = all fields included
+
+        bool includeTags = fields == null || fields.Overlaps(TagFields);
+        bool includeAssignees = fields == null || fields.Overlaps(AssignmentFields);
+        bool includeLinks = fields == null || fields.Overlaps(ApplicationLinkFields);
+        bool includeApplicantAgent = fields == null || fields.Overlaps(ApplicantAgentFields);
+        bool includeOwner = fields == null || fields.Overlaps(OwnerFields);
+
+        // Sorting is omitted: the DataTable operates in client-side mode and re-sorts locally.
+        // skipCount/maxResultCount are not applied while the DataTable is in client-side mode.
+        var query = (await GetQueryableAsync()).AsNoTracking();
+
+        var (fromUtc, toUtc) = ConvertToUtcRange(submittedFromDate, submittedToDate);
+        if (fromUtc.HasValue)
+        {
+            query = query.Where(a => a.SubmissionDate >= fromUtc.Value);
+        }
+
+        if (toUtc.HasValue)
+        {
+            query = query.Where(a => a.SubmissionDate <= toUtc.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(searchTerm))
+        {
+            query = query.Where(a =>
+                a.ProjectName.Contains(searchTerm) ||
+                a.ReferenceNo.Contains(searchTerm));
+        }
+
+        // Base query — always-required navigations only (ApplicationStatus, ApplicationForm, Applicant).
+        var baseData = await query
+            .Select(a => new
+            {
+                a.Id,
+                a.ProjectName,
+                a.ReferenceNo,
+                a.RequestedAmount,
+                a.TotalProjectBudget,
+                a.EconomicRegion,
+                a.City,
+                a.ProposalDate,
+                a.SubmissionDate,
+                a.FinalDecisionDate,
+                a.DueDate,
+                a.NotificationDate,
+                a.ProjectSummary,
+                a.TotalScore,
+                a.RecommendedAmount,
+                a.ApprovedAmount,
+                a.LikelihoodOfFunding,
+                a.DueDiligenceStatus,
+                a.SubStatus,
+                a.DeclineRational,
+                a.Notes,
+                a.AssessmentResultStatus,
+                a.AssessmentResultDate,
+                a.ProjectStartDate,
+                a.ProjectEndDate,
+                a.PercentageTotalProjectBudget,
+                a.ProjectFundingTotal,
+                a.Community,
+                a.CommunityPopulation,
+                a.Acquisition,
+                a.Forestry,
+                a.ForestryFocus,
+                a.ElectoralDistrict,
+                a.ApplicantElectoralDistrict,
+                a.Place,
+                a.RegionalDistrict,
+                a.OwnerId,
+                a.DefaultSiteId,
+                a.SigningAuthorityFullName,
+                a.SigningAuthorityTitle,
+                a.SigningAuthorityEmail,
+                a.SigningAuthorityBusinessPhone,
+                a.SigningAuthorityCellPhone,
+                a.ContractNumber,
+                a.ContractExecutionDate,
+                a.RiskRanking,
+                a.UnityApplicationId,
+                Status = a.ApplicationStatus.InternalStatus, // ApplicationStatus (always joined)
+                Category = a.ApplicationForm.Category ?? string.Empty, // ApplicationForm (always joined)          
+                a.ApplicantId,
+                ApplicantName = a.Applicant.ApplicantName, // Applicant (always joined)
+                ApplicantSupplierId = a.Applicant.SupplierId,
+                ApplicantSector = a.Applicant.Sector,
+                ApplicantSubSector = a.Applicant.SubSector,
+                ApplicantOrgName = a.Applicant.OrgName,
+                ApplicantNonRegOrgName = a.Applicant.NonRegOrgName,
+                ApplicantOrganizationType = a.Applicant.OrganizationType,
+                ApplicantOrgNumber = a.Applicant.OrgNumber,
+                ApplicantOrgStatus = a.Applicant.OrgStatus,
+                ApplicantBusinessNumber = a.Applicant.BusinessNumber,
+                ApplicantOrganizationSize = a.Applicant.OrganizationSize,
+                ApplicantSectorSubSectorIndustryDesc = a.Applicant.SectorSubSectorIndustryDesc,
+                ApplicantRedStop = a.Applicant.RedStop,
+                ApplicantIndigenousOrgInd = a.Applicant.IndigenousOrgInd,
+                ApplicantFiscalDay = a.Applicant.FiscalDay,
+                ApplicantFiscalMonth = a.Applicant.FiscalMonth,
+                ApplicantUnityApplicantId = a.Applicant.UnityApplicantId,
+            })
+            .ToListAsync();
+
+        if (baseData.Count == 0)
+        {
+            return [];
+        }
+
+        // Conditionally join ApplicantAgent
+        var agentMap = new Dictionary<Guid, (string? Name, string? Title, string? Email, string? Phone, string? Phone2)>();
+        if (includeApplicantAgent)
+        {
+            var agentData = await query
+                .Where(a => a.ApplicantAgent != null)
+                .Select(a => new
+                {
+                    a.Id,
+                    a.ApplicantAgent!.Name,
+                    a.ApplicantAgent.Title,
+                    a.ApplicantAgent.Email,
+                    Phone = a.ApplicantAgent.Phone,
+                    Phone2 = a.ApplicantAgent.Phone2,
+                })
+                .ToListAsync();
+
+            agentMap = agentData.ToDictionary(
+                x => x.Id,
+                x => ((string?)x.Name, x.Title, x.Email, x.Phone, x.Phone2));
+        }
+
+        // Conditionally join Owner
+        var ownerMap = new Dictionary<Guid, (Guid PersonId, string? FullName)>();
+        if (includeOwner)
+        {
+            var ownerData = await query
+                .Where(a => a.Owner != null)
+                .Select(a => new { a.Id, OwnerId = a.Owner!.Id, OwnerFullName = a.Owner.FullName })
+                .ToListAsync();
+
+            ownerMap = ownerData.ToDictionary(
+                x => x.Id,
+                x => (x.OwnerId, (string?)x.OwnerFullName));
+        }
+
+        var dbContext = await GetDbContextAsync();
+
+        // matchingIds is kept as IQueryable<Guid> so EF Core translates it as a SQL subquery
+        // (WHERE ApplicationId IN (SELECT Id FROM Applications WHERE ...)) rather than
+        // binding thousands of individual GUID parameters.
+        var matchingIds = query.Select(a => a.Id);
+
+        // Conditionally join Tags
+        var tagsLookup = Enumerable.Empty<ApplicationTagListItem>().ToLookup(t => Guid.Empty);
+        if (includeTags)
+        {
+            var tags = await dbContext.Set<ApplicationTags>()
+                .AsNoTracking()
+                .Where(t => matchingIds.Contains(t.ApplicationId))
+                .Select(t => new ApplicationTagListItem
+                {
+                    Id = t.Id,
+                    ApplicationId = t.ApplicationId,
+                    TagName = t.Tag != null ? t.Tag.Name : null,
+                })
+                .ToListAsync();
+
+            tagsLookup = tags.ToLookup(t => t.ApplicationId);
+        }
+
+        // Conditionally join Assignments
+        var assignmentsLookup = Enumerable.Empty<ApplicationAssignmentListItem>().ToLookup(aa => Guid.Empty);
+        if (includeAssignees)
+        {
+            var assignments = await dbContext.Set<ApplicationAssignment>()
+                .AsNoTracking()
+                .Where(aa => matchingIds.Contains(aa.ApplicationId))
+                .Select(aa => new ApplicationAssignmentListItem
+                {
+                    Id = aa.Id,
+                    ApplicationId = aa.ApplicationId,
+                    AssigneeId = aa.AssigneeId,
+                    AssigneeName = aa.Assignee != null ? aa.Assignee.FullName : string.Empty,
+                    Duty = aa.Duty,
+                })
+                .ToListAsync();
+
+            assignmentsLookup = assignments.ToLookup(aa => aa.ApplicationId);
+        }
+
+        // Conditionally join Links
+        var linksLookup = Enumerable.Empty<ApplicationLinkListItem>().ToLookup(l => Guid.Empty);
+        if (includeLinks)
+        {
+            var links = await dbContext.Set<ApplicationLink>()
+                .AsNoTracking()
+                .Where(l => matchingIds.Contains(l.ApplicationId))
+                .Select(l => new ApplicationLinkListItem
+                {
+                    Id = l.Id,
+                    ApplicationId = l.ApplicationId,
+                    LinkedApplicationId = l.LinkedApplicationId,
+                    LinkType = l.LinkType,
+                })
+                .ToListAsync();
+
+            linksLookup = links.ToLookup(l => l.ApplicationId);
+        }
+
+        return baseData
+            .Select(a =>
+            {
+                agentMap.TryGetValue(a.Id, out var agent);
+                ownerMap.TryGetValue(a.Id, out var owner);
+                var hasOwner = includeOwner && ownerMap.ContainsKey(a.Id);
+
+                return new ApplicationListRecord
+                {
+                    Id = a.Id,
+                    ProjectName = a.ProjectName,
+                    ReferenceNo = a.ReferenceNo,
+                    RequestedAmount = a.RequestedAmount,
+                    TotalProjectBudget = a.TotalProjectBudget,
+                    EconomicRegion = a.EconomicRegion,
+                    City = a.City,
+                    ProposalDate = a.ProposalDate,
+                    SubmissionDate = a.SubmissionDate,
+                    FinalDecisionDate = a.FinalDecisionDate,
+                    DueDate = a.DueDate,
+                    NotificationDate = a.NotificationDate,
+                    ProjectSummary = a.ProjectSummary,
+                    TotalScore = a.TotalScore,
+                    RecommendedAmount = a.RecommendedAmount,
+                    ApprovedAmount = a.ApprovedAmount,
+                    LikelihoodOfFunding = a.LikelihoodOfFunding,
+                    DueDiligenceStatus = a.DueDiligenceStatus,
+                    SubStatus = a.SubStatus,
+                    DeclineRational = a.DeclineRational,
+                    Notes = a.Notes,
+                    AssessmentResultStatus = a.AssessmentResultStatus,
+                    AssessmentResultDate = a.AssessmentResultDate,
+                    ProjectStartDate = a.ProjectStartDate,
+                    ProjectEndDate = a.ProjectEndDate,
+                    PercentageTotalProjectBudget = a.PercentageTotalProjectBudget,
+                    ProjectFundingTotal = a.ProjectFundingTotal,
+                    Community = a.Community,
+                    CommunityPopulation = a.CommunityPopulation,
+                    Acquisition = a.Acquisition,
+                    Forestry = a.Forestry,
+                    ForestryFocus = a.ForestryFocus,
+                    ElectoralDistrict = a.ElectoralDistrict,
+                    ApplicantElectoralDistrict = a.ApplicantElectoralDistrict,
+                    Place = a.Place,
+                    RegionalDistrict = a.RegionalDistrict,
+                    OwnerId = a.OwnerId,
+                    DefaultSiteId = a.DefaultSiteId,
+                    SigningAuthorityFullName = a.SigningAuthorityFullName,
+                    SigningAuthorityTitle = a.SigningAuthorityTitle,
+                    SigningAuthorityEmail = a.SigningAuthorityEmail,
+                    SigningAuthorityBusinessPhone = a.SigningAuthorityBusinessPhone,
+                    SigningAuthorityCellPhone = a.SigningAuthorityCellPhone,
+                    ContractNumber = a.ContractNumber,
+                    ContractExecutionDate = a.ContractExecutionDate,
+                    RiskRanking = a.RiskRanking,
+                    UnityApplicationId = a.UnityApplicationId,
+                    Status = a.Status,
+                    Category = a.Category,
+                    ApplicantId = a.ApplicantId,
+                    ApplicantName = a.ApplicantName,
+                    ApplicantSupplierId = a.ApplicantSupplierId,
+                    ApplicantSector = a.ApplicantSector,
+                    ApplicantSubSector = a.ApplicantSubSector,
+                    ApplicantOrgName = a.ApplicantOrgName,
+                    ApplicantNonRegOrgName = a.ApplicantNonRegOrgName,
+                    ApplicantOrganizationType = a.ApplicantOrganizationType,
+                    ApplicantOrgNumber = a.ApplicantOrgNumber,
+                    ApplicantOrgStatus = a.ApplicantOrgStatus,
+                    ApplicantBusinessNumber = a.ApplicantBusinessNumber,
+                    ApplicantOrganizationSize = a.ApplicantOrganizationSize,
+                    ApplicantSectorSubSectorIndustryDesc = a.ApplicantSectorSubSectorIndustryDesc,
+                    ApplicantRedStop = a.ApplicantRedStop,
+                    ApplicantIndigenousOrgInd = a.ApplicantIndigenousOrgInd,
+                    ApplicantFiscalDay = a.ApplicantFiscalDay,
+                    ApplicantFiscalMonth = a.ApplicantFiscalMonth,
+                    ApplicantUnityApplicantId = a.ApplicantUnityApplicantId,
+                    ContactFullName = includeApplicantAgent ? agent.Name : null,
+                    ContactTitle = includeApplicantAgent ? agent.Title : null,
+                    ContactEmail = includeApplicantAgent ? agent.Email : null,
+                    ContactBusinessPhone = includeApplicantAgent ? agent.Phone : null,
+                    ContactCellPhone = includeApplicantAgent ? agent.Phone2 : null,
+                    OwnerPersonId = hasOwner ? owner.PersonId : (Guid?)null,
+                    OwnerFullName = hasOwner ? owner.FullName : null,
+                    Tags = includeTags ? tagsLookup[a.Id].ToList() : [],
+                    Assignments = includeAssignees ? assignmentsLookup[a.Id].ToList() : [],
+                    Links = includeLinks ? linksLookup[a.Id].ToList() : [],
+                };
+            })
+            .ToList();
     }
 
     public async Task<List<Application>> GetApplicationsBySiteIdAsync(Guid siteId)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.js
@@ -381,6 +381,8 @@ $(function () {
 
     function initializeDataTableAndEvents() {
         let initialLoad = true;
+        let isRestoringState = false;
+        let refreshDataTimeout = null;
         dataTable = initializeDataTable({
             dt,
             defaultVisibleColumns,
@@ -392,9 +394,32 @@ $(function () {
             },
             dataEndpoint: unity.grantManager.grantApplications.grantApplication.getList,
             data: function () {
+                let requestedFields;
+                if (dataTable) {
+                    try {
+                        const cols = dataTable.settings()[0].aoColumns;
+                        requestedFields = cols
+                            .filter(function (col, idx) { return dataTable.column(idx).visible(); })
+                            .map(function (col) { return col.sName; })
+                            .filter(function (name) { return !!name; });
+                        if (requestedFields.length > 0) {
+                            localStorage.setItem('GrantApplications_RequestedFields', JSON.stringify(requestedFields));
+                        }
+                    } catch { /* DataTable not yet fully initialised */ }
+                }
+                if (!requestedFields || requestedFields.length === 0) {
+                    try {
+                        const saved = localStorage.getItem('GrantApplications_RequestedFields');
+                        if (saved) requestedFields = JSON.parse(saved);
+                    } catch { }
+                }
+                if (!requestedFields || requestedFields.length === 0) {
+                    requestedFields = defaultVisibleColumns;
+                }
                 return {
                     submittedFromDate: grantTableFilters.submittedFromDate,
-                    submittedToDate: grantTableFilters.submittedToDate
+                    submittedToDate: grantTableFilters.submittedToDate,
+                    requestedFields: requestedFields
                 };
             },
             responseCallback,
@@ -415,20 +440,22 @@ $(function () {
                 };
             },
             onStateLoadParams: function (settings, data) {
-                if (!initialLoad && data?.customFilters) {
-                    // If there is any date change, this will refresh post load 
-                    // to ensure the correct data is shown based on the saved filters.
-                    data.refreshTableWithDates =
-                        data.customFilters.quickDateRange !== UIElements.quickDateRange.val()
-                        || data.customFilters.submittedFromDate !== UIElements.submittedFromInput.val()
-                        || data.customFilters.submittedToDate !== UIElements.submittedToInput.val();
-                    restoreCustomFilters(data.customFilters);
+                if (!initialLoad) {
+                    // Mark that a state restore is in progress so column-visibility.dt
+                    // events during restore don't trigger premature intermediate reloads.
+                    isRestoringState = true;
+                    if (data?.customFilters) {
+                        restoreCustomFilters(data.customFilters);
+                    }
                 }
             },
             onStateLoaded: function (dtApi, data) {
                 // This needs to only reload when clicking on the load state not on initial page load
                 // Otherwise it duplicates the data
-                if (!initialLoad && data?.refreshTableWithDates) {
+                if (!initialLoad) {
+                    // All column-visibility changes are applied by this point.
+                    // Clear the flag and fire a single reload with the correct column set.
+                    isRestoringState = false;
                     dtApi.ajax.reload(null, false);
                 }
                 initialLoad = false; // Reset flag after use
@@ -459,6 +486,27 @@ $(function () {
                     }
                 });
             }
+        });
+
+        dataTable.on('column-visibility.dt', function (e, settings, columnIdx) {
+            try {
+                const cols = dataTable.settings()[0].aoColumns;
+                const visibleFields = cols
+                    .filter(function (col, idx) { return dataTable.column(idx).visible(); })
+                    .map(function (col) { return col.sName; })
+                    .filter(function (name) { return !!name; });
+                if (visibleFields.length > 0) {
+                    localStorage.setItem('GrantApplications_RequestedFields', JSON.stringify(visibleFields));
+                }
+                // Only debounce on manual. During a saved-view restore, isRestoringState
+                // is true and onStateLoaded fires a single authoritative reload  after all columns are applied
+                if (!isRestoringState && cols[columnIdx]?.refreshData) {
+                    clearTimeout(refreshDataTimeout);
+                    refreshDataTimeout = setTimeout(function () {
+                        dataTable.ajax.reload(null, false);
+                    }, 300);
+                }
+            } catch { }
         });
     }
 
@@ -702,6 +750,7 @@ $(function () {
             data: 'assignees',
             name: 'assignees',
             className: 'dt-editable',
+            refreshData: true,
             render: function (data, type, row) {
                 let displayText = ' ';
 
@@ -1056,6 +1105,7 @@ $(function () {
             name: 'applicationTag',
             data: 'applicationTag',
             className: '',
+            refreshData: true,
             render: function (data) {
 
                 let tagNames = data
@@ -1132,6 +1182,7 @@ $(function () {
             name: 'Owner',
             data: 'owner',
             className: 'data-table-header',
+            refreshData: true,
             render: function (data) {
                 return data != null ? data.fullName : '';
             },
@@ -1238,6 +1289,7 @@ $(function () {
             name: 'applicationLinks',
             data: 'applicationLinks',
             className: 'data-table-header',
+            refreshData: true,
             render: function (data) {
                 const linkNames = Array.from(new Set((data || [])
                     .filter(x => x?.linkType)
@@ -1286,6 +1338,7 @@ $(function () {
             name: 'contactFullName',
             data: 'contactFullName',
             className: 'data-table-header',
+            refreshData: true,
             render: function (data) {
                 return data ?? '';
             },
@@ -1298,6 +1351,7 @@ $(function () {
             name: 'contactTitle',
             data: 'contactTitle',
             className: 'data-table-header',
+            refreshData: true,
             render: function (data) {
                 return data ?? '';
             },
@@ -1310,6 +1364,7 @@ $(function () {
             name: 'contactEmail',
             data: 'contactEmail',
             className: 'data-table-header',
+            refreshData: true,
             render: function (data) {
                 return data ?? '';
             },
@@ -1322,6 +1377,7 @@ $(function () {
             name: 'contactBusinessPhone',
             data: 'contactBusinessPhone',
             className: 'data-table-header',
+            refreshData: true,
             render: function (data) {
                 return data ?? '';
             },
@@ -1334,6 +1390,7 @@ $(function () {
             name: 'contactCellPhone',
             data: 'contactCellPhone',
             className: 'data-table-header',
+            refreshData: true,
             render: function (data) {
                 return data ?? '';
             },

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/ApplicationListRecordAlignmentTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/ApplicationListRecordAlignmentTests.cs
@@ -1,0 +1,421 @@
+﻿using Shouldly;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Unity.GrantManager.Applications;
+
+using Volo.Abp.Uow;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Unity.GrantManager.GrantApplications;
+
+/// <summary>
+/// Verifies that <see cref="IApplicationRepository.GetApplicationListRecordsAsync"/> returns
+/// field values consistent with the full-entity data returned by
+/// <see cref="IApplicationRepository.WithFullDetailsAsync"/> for the same filter inputs.
+/// </summary>
+public class ApplicationListRecordAlignmentTests : GrantManagerApplicationTestBase
+{
+    private readonly IApplicationRepository _applicationRepository;
+    private readonly IUnitOfWorkManager _unitOfWorkManager;
+
+    public ApplicationListRecordAlignmentTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+        _applicationRepository = GetRequiredService<IApplicationRepository>();
+        _unitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_WithNullRequestedFields_ReturnsSameCount_As_WithFullDetailsAsync()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var fullDetails = await _applicationRepository.WithFullDetailsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue);
+
+        var listRecords = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: null);
+
+        listRecords.Count.ShouldBe(fullDetails.Count);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_ScalarFields_Match_WithFullDetailsAsync()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var fullDetails = await _applicationRepository.WithFullDetailsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue);
+
+        var listRecords = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: null);
+
+        fullDetails.ShouldNotBeEmpty();
+
+        foreach (var app in fullDetails)
+        {
+            var rec = listRecords.FirstOrDefault(r => r.Id == app.Id);
+            rec.ShouldNotBeNull($"No ApplicationListRecord found for Application Id={app.Id}");
+
+            rec.ProjectName.ShouldBe(app.ProjectName, $"ProjectName mismatch for Id={app.Id}");
+            rec.ReferenceNo.ShouldBe(app.ReferenceNo, $"ReferenceNo mismatch for Id={app.Id}");
+            rec.RequestedAmount.ShouldBe(app.RequestedAmount, $"RequestedAmount mismatch for Id={app.Id}");
+            rec.TotalProjectBudget.ShouldBe(app.TotalProjectBudget, $"TotalProjectBudget mismatch for Id={app.Id}");
+            rec.EconomicRegion.ShouldBe(app.EconomicRegion, $"EconomicRegion mismatch for Id={app.Id}");
+            rec.City.ShouldBe(app.City, $"City mismatch for Id={app.Id}");
+            rec.SubmissionDate.ShouldBe(app.SubmissionDate, $"SubmissionDate mismatch for Id={app.Id}");
+            rec.OwnerId.ShouldBe(app.OwnerId, $"OwnerId mismatch for Id={app.Id}");
+            rec.ApplicantId.ShouldBe(app.ApplicantId, $"ApplicantId mismatch for Id={app.Id}");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_StatusAndCategory_Match_WithFullDetailsAsync()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var fullDetails = await _applicationRepository.WithFullDetailsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue);
+
+        var listRecords = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: null);
+
+        foreach (var app in fullDetails)
+        {
+            var rec = listRecords.First(r => r.Id == app.Id);
+
+            rec.Status.ShouldBe(app.ApplicationStatus.InternalStatus,
+                $"Status (InternalStatus) mismatch for Id={app.Id}");
+            rec.Category.ShouldBe(app.ApplicationForm.Category ?? string.Empty,
+                $"Category mismatch for Id={app.Id}");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_ApplicantFields_Match_WithFullDetailsAsync()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var fullDetails = await _applicationRepository.WithFullDetailsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue);
+
+        var listRecords = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: null);
+
+        foreach (var app in fullDetails)
+        {
+            var rec = listRecords.First(r => r.Id == app.Id);
+            var applicant = app.Applicant;
+
+            rec.ApplicantName.ShouldBe(applicant.ApplicantName,
+                $"ApplicantName mismatch for Id={app.Id}");
+            rec.ApplicantOrgName.ShouldBe(applicant.OrgName,
+                $"ApplicantOrgName mismatch for Id={app.Id}");
+            rec.ApplicantOrgNumber.ShouldBe(applicant.OrgNumber,
+                $"ApplicantOrgNumber mismatch for Id={app.Id}");
+            rec.ApplicantOrgStatus.ShouldBe(applicant.OrgStatus,
+                $"ApplicantOrgStatus mismatch for Id={app.Id}");
+            rec.ApplicantSector.ShouldBe(applicant.Sector,
+                $"ApplicantSector mismatch for Id={app.Id}");
+            rec.ApplicantSubSector.ShouldBe(applicant.SubSector,
+                $"ApplicantSubSector mismatch for Id={app.Id}");
+            rec.ApplicantOrganizationType.ShouldBe(applicant.OrganizationType,
+                $"ApplicantOrganizationType mismatch for Id={app.Id}");
+            rec.ApplicantOrganizationSize.ShouldBe(applicant.OrganizationSize,
+                $"ApplicantOrganizationSize mismatch for Id={app.Id}");
+            rec.ApplicantIndigenousOrgInd.ShouldBe(applicant.IndigenousOrgInd,
+                $"ApplicantIndigenousOrgInd mismatch for Id={app.Id}");
+            rec.ApplicantRedStop.ShouldBe(applicant.RedStop,
+                $"ApplicantRedStop mismatch for Id={app.Id}");
+            rec.ApplicantUnityApplicantId.ShouldBe(applicant.UnityApplicantId,
+                $"ApplicantUnityApplicantId mismatch for Id={app.Id}");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_CollectionCounts_Match_WithFullDetailsAsync()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var fullDetails = await _applicationRepository.WithFullDetailsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue);
+
+        var listRecords = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: null);
+
+        foreach (var app in fullDetails)
+        {
+            var rec = listRecords.First(r => r.Id == app.Id);
+
+            rec.Tags.Count.ShouldBe(
+                app.ApplicationTags?.Count ?? 0,
+                $"Tag count mismatch for Id={app.Id}");
+            rec.Assignments.Count.ShouldBe(
+                app.ApplicationAssignments?.Count ?? 0,
+                $"Assignment count mismatch for Id={app.Id}");
+            rec.Links.Count.ShouldBe(
+                app.ApplicationLinks?.Count ?? 0,
+                $"Link count mismatch for Id={app.Id}");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_ContactFields_Match_WithFullDetailsAsync()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var fullDetails = await _applicationRepository.WithFullDetailsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue);
+
+        var listRecords = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: null);
+
+        foreach (var app in fullDetails)
+        {
+            var rec = listRecords.First(r => r.Id == app.Id);
+
+            rec.ContactFullName.ShouldBe(app.ApplicantAgent?.Name,
+                $"ContactFullName mismatch for Id={app.Id}");
+            rec.ContactTitle.ShouldBe(app.ApplicantAgent?.Title,
+                $"ContactTitle mismatch for Id={app.Id}");
+            rec.ContactEmail.ShouldBe(app.ApplicantAgent?.Email,
+                $"ContactEmail mismatch for Id={app.Id}");
+            rec.ContactBusinessPhone.ShouldBe(app.ApplicantAgent?.Phone,
+                $"ContactBusinessPhone mismatch for Id={app.Id}");
+            rec.ContactCellPhone.ShouldBe(app.ApplicantAgent?.Phone2,
+                $"ContactCellPhone mismatch for Id={app.Id}");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_OwnerFields_Match_WithFullDetailsAsync()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var fullDetails = await _applicationRepository.WithFullDetailsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue);
+
+        var listRecords = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: null);
+
+        foreach (var app in fullDetails)
+        {
+            var rec = listRecords.First(r => r.Id == app.Id);
+
+            if (app.Owner != null)
+            {
+                rec.OwnerPersonId.ShouldBe(app.Owner.Id,
+                    $"OwnerPersonId mismatch for Id={app.Id}");
+                rec.OwnerFullName.ShouldBe(app.Owner.FullName,
+                    $"OwnerFullName mismatch for Id={app.Id}");
+            }
+            else
+            {
+                rec.OwnerPersonId.ShouldBeNull($"Expected null OwnerPersonId for Id={app.Id}");
+                rec.OwnerFullName.ShouldBeNull($"Expected null OwnerFullName for Id={app.Id}");
+            }
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_KnownApplication1_HasExpectedFieldValues()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var listRecords = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: null);
+
+        var rec = listRecords.FirstOrDefault(r => r.Id == GrantManagerTestData.Application1_Id);
+        rec.ShouldNotBeNull("Application1 seed data should be present in list records");
+
+        rec.ProjectName.ShouldBe("Application For Integration Test Funding");
+        rec.ReferenceNo.ShouldBe("TEST12345");
+        rec.RequestedAmount.ShouldBe(3456.13m);
+        rec.ApplicantId.ShouldBe(GrantManagerTestData.Applicant1_Id);
+        rec.ApplicantName.ShouldBe("Integration Tester 1");
+        rec.Status.ShouldBe("Submitted");
+        rec.SubmissionDate.ShouldBe(new DateTime(2023, 1, 1, 12, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_KnownApplication2_HasExpectedFieldValues()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var listRecords = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: null);
+
+        var rec = listRecords.FirstOrDefault(r => r.Id == GrantManagerTestData.Application2_Id);
+        rec.ShouldNotBeNull("Application2 seed data should be present in list records");
+
+        rec.ProjectName.ShouldBe("Application 2 For Integration Test Funding");
+        rec.ReferenceNo.ShouldBe("TEST67890");
+        rec.RequestedAmount.ShouldBe(5000m);
+        rec.ApplicantId.ShouldBe(GrantManagerTestData.Applicant1_Id);
+        rec.ApplicantName.ShouldBe("Integration Tester 1");
+        rec.Status.ShouldBe("Submitted");
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_WithTagsRequestedField_ExcludesContactAndOwnerData()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var listRecords = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: new List<string> { "applicationTag" });
+
+        listRecords.ShouldNotBeEmpty();
+
+        foreach (var rec in listRecords)
+        {
+            rec.ContactFullName.ShouldBeNull(
+                $"ContactFullName should not be loaded when only 'applicationTag' is requested for Id={rec.Id}");
+            rec.OwnerPersonId.ShouldBeNull(
+                $"OwnerPersonId should not be loaded when only 'applicationTag' is requested for Id={rec.Id}");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_WithAssigneesRequestedField_ExcludesContactAndOwnerData()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var listRecords = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: new List<string> { "assignees" });
+
+        listRecords.ShouldNotBeEmpty();
+
+        foreach (var rec in listRecords)
+        {
+            rec.ContactFullName.ShouldBeNull(
+                $"ContactFullName should not be loaded when only 'assignees' is requested for Id={rec.Id}");
+            rec.OwnerPersonId.ShouldBeNull(
+                $"OwnerPersonId should not be loaded when only 'assignees' is requested for Id={rec.Id}");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_WithContactFieldRequested_ExcludesTagsAssignmentsLinks()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var listRecords = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: new List<string> { "contactEmail" });
+
+        listRecords.ShouldNotBeEmpty();
+
+        foreach (var rec in listRecords)
+        {
+            rec.Tags.ShouldBeEmpty(
+                $"Tags should not be loaded when only contact fields are requested for Id={rec.Id}");
+            rec.Assignments.ShouldBeEmpty(
+                $"Assignments should not be loaded when only contact fields are requested for Id={rec.Id}");
+            rec.Links.ShouldBeEmpty(
+                $"Links should not be loaded when only contact fields are requested for Id={rec.Id}");
+            rec.OwnerPersonId.ShouldBeNull(
+                $"OwnerPersonId should not be loaded when only contact fields are requested for Id={rec.Id}");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_WithOwnerRequestedField_ExcludesTagsAssignmentsLinks()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var listRecords = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: new List<string> { "Owner" });
+
+        listRecords.ShouldNotBeEmpty();
+
+        foreach (var rec in listRecords)
+        {
+            rec.Tags.ShouldBeEmpty(
+                $"Tags should not be loaded when only 'Owner' is requested for Id={rec.Id}");
+            rec.Assignments.ShouldBeEmpty(
+                $"Assignments should not be loaded when only 'Owner' is requested for Id={rec.Id}");
+            rec.Links.ShouldBeEmpty(
+                $"Links should not be loaded when only 'Owner' is requested for Id={rec.Id}");
+            rec.ContactFullName.ShouldBeNull(
+                $"ContactFullName should not be loaded when only 'Owner' is requested for Id={rec.Id}");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_WithEmptyRequestedFields_ExcludesAllOptionalData()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var listRecords = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: new List<string>());
+
+        listRecords.ShouldNotBeEmpty();
+
+        foreach (var rec in listRecords)
+        {
+            rec.Tags.ShouldBeEmpty(
+                $"Tags should not be loaded when requestedFields is empty for Id={rec.Id}");
+            rec.Assignments.ShouldBeEmpty(
+                $"Assignments should not be loaded when requestedFields is empty for Id={rec.Id}");
+            rec.Links.ShouldBeEmpty(
+                $"Links should not be loaded when requestedFields is empty for Id={rec.Id}");
+            rec.ContactFullName.ShouldBeNull(
+                $"ContactFullName should not be loaded when requestedFields is empty for Id={rec.Id}");
+            rec.OwnerPersonId.ShouldBeNull(
+                $"OwnerPersonId should not be loaded when requestedFields is empty for Id={rec.Id}");
+        }
+    }
+}

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/GrantApplicationListTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/GrantApplicationListTests.cs
@@ -1,0 +1,296 @@
+﻿using Shouldly;
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Unity.GrantManager.Applications;
+
+using Volo.Abp.Uow;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Unity.GrantManager.GrantApplications;
+
+public class GrantApplicationListTests : GrantManagerApplicationTestBase
+{
+    private readonly IGrantApplicationAppService _appService;
+    private readonly IApplicationRepository _applicationRepository;
+    private readonly IUnitOfWorkManager _unitOfWorkManager;
+
+    public GrantApplicationListTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+        _appService = GetRequiredService<IGrantApplicationAppService>();
+        _applicationRepository = GetRequiredService<IApplicationRepository>();
+        _unitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
+    }
+
+
+    // GetApplicationListRecordsAsync -- requestedFields flag logic
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_NullRequestedFields_ReturnsSeededApplicationsWithBaseFields()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var result = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: null);
+
+        result.ShouldNotBeNull();
+        result.Count.ShouldBeGreaterThanOrEqualTo(1);
+        result.ShouldAllBe(r => r.Status != null);
+        result.ShouldAllBe(r => r.ApplicantName != null);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_WithNonContactNonOwnerFields_OmitsAgentAndOwnerData()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var result = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: ["projectName", "referenceNo"]);
+
+        result.ShouldNotBeNull();
+        result.Count.ShouldBeGreaterThanOrEqualTo(1);
+
+        // Agent fields should be null -- not requested
+        result.ShouldAllBe(r => r.ContactFullName == null);
+        result.ShouldAllBe(r => r.ContactEmail == null);
+        result.ShouldAllBe(r => r.ContactTitle == null);
+
+        // Owner fields should be null -- not requested
+        result.ShouldAllBe(r => r.OwnerFullName == null);
+
+        // Collections should be empty -- not requested
+        result.ShouldAllBe(r => r.Tags.Count == 0);
+        result.ShouldAllBe(r => r.Assignments.Count == 0);
+        result.ShouldAllBe(r => r.Links.Count == 0);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_WithContactFields_RunsAgentPath_AssignmentsAndLinksOmitted()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var result = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: ["contactFullName", "contactEmail"]);
+
+        result.ShouldNotBeNull();
+        result.Count.ShouldBeGreaterThanOrEqualTo(1);
+        result.ShouldAllBe(r => r.ApplicantName != null);
+        result.ShouldAllBe(r => r.Tags.Count == 0);
+        result.ShouldAllBe(r => r.Assignments.Count == 0);
+        result.ShouldAllBe(r => r.Links.Count == 0);
+        result.ShouldAllBe(r => r.OwnerFullName == null);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_WithTagField_RunsTagsPath_AgentAndOwnerOmitted()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var result = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: ["applicationTag"]);
+
+        result.ShouldNotBeNull();
+        result.Count.ShouldBeGreaterThanOrEqualTo(1);
+        result.ShouldAllBe(r => r.Tags != null);
+        result.ShouldAllBe(r => r.ContactFullName == null);
+        result.ShouldAllBe(r => r.OwnerFullName == null);
+        result.ShouldAllBe(r => r.Assignments.Count == 0);
+        result.ShouldAllBe(r => r.Links.Count == 0);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_WithOwnerField_RunsOwnerPath_AgentAndTagsOmitted()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var result = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: ["Owner"]);
+
+        result.ShouldNotBeNull();
+        result.Count.ShouldBeGreaterThanOrEqualTo(1);
+        result.ShouldAllBe(r => r.ContactFullName == null);
+        result.ShouldAllBe(r => r.Tags.Count == 0);
+        result.ShouldAllBe(r => r.Assignments.Count == 0);
+        result.ShouldAllBe(r => r.Links.Count == 0);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_WithAssigneesField_RunsAssignmentsPath_TagsOmitted()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var result = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: ["assignees"]);
+
+        result.ShouldNotBeNull();
+        result.Count.ShouldBeGreaterThanOrEqualTo(1);
+        result.ShouldAllBe(r => r.Assignments != null);
+        result.ShouldAllBe(r => r.Tags.Count == 0);
+        result.ShouldAllBe(r => r.Links.Count == 0);
+        result.ShouldAllBe(r => r.ContactFullName == null);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_WithApplicationLinksField_RunsLinksPath_TagsOmitted()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var result = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            requestedFields: ["applicationLinks"]);
+
+        result.ShouldNotBeNull();
+        result.Count.ShouldBeGreaterThanOrEqualTo(1);
+        result.ShouldAllBe(r => r.Links != null);
+        result.ShouldAllBe(r => r.Tags.Count == 0);
+        result.ShouldAllBe(r => r.Assignments.Count == 0);
+        result.ShouldAllBe(r => r.ContactFullName == null);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_WithFutureDateFilter_ReturnsEmpty()
+    {
+        using var uow = _unitOfWorkManager.Begin();
+
+        var result = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            submittedFromDate: DateTime.UtcNow.AddYears(10));
+
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetApplicationListRecordsAsync_WithDateRangeMatchingSeededData_ReturnsApplications()
+    {
+        // Seeded applications have SubmissionDate = 2023-01-01
+        using var uow = _unitOfWorkManager.Begin();
+
+        var result = await _applicationRepository.GetApplicationListRecordsAsync(
+            skipCount: 0,
+            maxResultCount: int.MaxValue,
+            submittedFromDate: new DateTime(2022, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            submittedToDate: new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        result.ShouldNotBeNull();
+        result.Count.ShouldBeGreaterThanOrEqualTo(1);
+    }
+
+
+    // GetListAsync -- totalCount == items.Count and requestedFields pass-through
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetListAsync_TotalCount_EqualsItemsCount()
+    {
+        var result = await _appService.GetListAsync(new GrantApplicationListInputDto());
+
+        result.ShouldNotBeNull();
+        result.TotalCount.ShouldBe(result.Items.Count);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetListAsync_ReturnsAtLeastOneItem()
+    {
+        var result = await _appService.GetListAsync(new GrantApplicationListInputDto());
+
+        result.Items.Count.ShouldBeGreaterThanOrEqualTo(1);
+        result.TotalCount.ShouldBeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetListAsync_WithFutureDateFilter_ReturnsEmptyPagedResult()
+    {
+        var result = await _appService.GetListAsync(new GrantApplicationListInputDto
+        {
+            SubmittedFromDate = DateTime.UtcNow.AddYears(10)
+        });
+
+        result.ShouldNotBeNull();
+        result.Items.Count.ShouldBe(0);
+        result.TotalCount.ShouldBe(0);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetListAsync_WithNullRequestedFields_AllItemsHaveBaseFields()
+    {
+        var result = await _appService.GetListAsync(new GrantApplicationListInputDto
+        {
+            RequestedFields = null
+        });
+
+        result.ShouldNotBeNull();
+        result.Items.Count.ShouldBeGreaterThanOrEqualTo(1);
+        result.TotalCount.ShouldBe(result.Items.Count);
+        result.Items.ShouldAllBe(dto => !string.IsNullOrEmpty(dto.Status));
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetListAsync_WithContactRequestedFields_TotalCountMatchesItems()
+    {
+        var result = await _appService.GetListAsync(new GrantApplicationListInputDto
+        {
+            RequestedFields = new List<string> { "contactFullName", "contactEmail" }
+        });
+
+        result.ShouldNotBeNull();
+        result.TotalCount.ShouldBe(result.Items.Count);
+        result.Items.ShouldAllBe(dto => !string.IsNullOrEmpty(dto.Status));
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetListAsync_WithoutContactRequestedFields_ContactFieldsAreNull()
+    {
+        var result = await _appService.GetListAsync(new GrantApplicationListInputDto
+        {
+            RequestedFields = new List<string> { "projectName", "referenceNo" }
+        });
+
+        result.ShouldNotBeNull();
+        result.Items.ShouldAllBe(dto => dto.ContactFullName == null);
+        result.Items.ShouldAllBe(dto => dto.ContactEmail == null);
+        result.Items.ShouldAllBe(dto => dto.ContactTitle == null);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetListAsync_TotalCountEqualsItemsCount_IsConsistentAcrossMultipleCalls()
+    {
+        var result1 = await _appService.GetListAsync(new GrantApplicationListInputDto());
+        var result2 = await _appService.GetListAsync(new GrantApplicationListInputDto());
+
+        result1.TotalCount.ShouldBe(result1.Items.Count);
+        result2.TotalCount.ShouldBe(result2.Items.Count);
+        result1.TotalCount.ShouldBe(result2.TotalCount);
+    }
+}


### PR DESCRIPTION
Optimized the main GrantApplications table to only pull necessary columns/data.

- Added RequestedFields to the DTO and repository
- Added ApplicationListRecord
- Backend joins related entities only when needed
- Selecting a joined column for display will reload necessary data.

Recreated post .NET10 update