### PR TITLE
AB#32898 consolidate AI JSON serializer defaults

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationAnalysisService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationAnalysisService.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Unity.AI.Models;
 using Unity.AI.Prompts;
 using Unity.AI.Requests;
+using Unity.AI.Runtime;
 using Unity.GrantManager.Applications;
 using Volo.Abp.DependencyInjection;
 
@@ -21,11 +22,6 @@ namespace Unity.AI.Operations
         IAIService aiService,
         ILogger<ApplicationAnalysisService> logger) : IApplicationAnalysisService, ITransientDependency
     {
-        private readonly JsonSerializerOptions _jsonOptionsIndented = new()
-        {
-            WriteIndented = true
-        };
-
         private const string ComponentsKey = "components";
         private static readonly HashSet<string> ExcludedSchemaKeys = new(StringComparer.OrdinalIgnoreCase)
         {
@@ -62,7 +58,7 @@ namespace Unity.AI.Operations
                 PromptVersion = promptVersion,
             });
 
-            var analysisJson = JsonSerializer.Serialize(analysis, _jsonOptionsIndented);
+            var analysisJson = JsonSerializer.Serialize(analysis, AIJsonDefaults.Indented);
             application.AIAnalysis = analysisJson;
             await applicationRepository.UpdateAsync(application);
             return analysisJson;

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
@@ -8,6 +8,7 @@ using Unity.Flex.Domain.Scoresheets;
 using Unity.AI.Models;
 using Unity.AI.Prompts;
 using Unity.AI.Requests;
+using Unity.AI.Runtime;
 using Unity.GrantManager.Applications;
 using Volo.Abp.DependencyInjection;
 
@@ -24,17 +25,6 @@ namespace Unity.AI.Operations
         AIExecutionModeResolver executionModeResolver,
         ILogger<ApplicationScoringService> logger) : IApplicationScoringService, ITransientDependency
     {
-        private readonly JsonSerializerOptions _jsonOptions = new()
-        {
-            WriteIndented = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-        };
-
-        private readonly JsonSerializerOptions _jsonOptionsIndented = new()
-        {
-            WriteIndented = true
-        };
-
         public async Task<string> RegenerateAndSaveAsync(Guid applicationId, string? promptVersion = null)
         {
             var application = await applicationRepository.GetAsync(applicationId);
@@ -82,7 +72,7 @@ namespace Unity.AI.Operations
                 }
             }
 
-            var combinedResults = JsonSerializer.Serialize(allSectionResults, _jsonOptionsIndented);
+            var combinedResults = JsonSerializer.Serialize(allSectionResults, AIJsonDefaults.Indented);
             var validatedJson = ValidateApplicationScoringJson(combinedResults);
             application.AIScoresheetAnswers = validatedJson;
             await applicationRepository.UpdateAsync(application);
@@ -104,7 +94,7 @@ namespace Unity.AI.Operations
                     Data = promptData,
                     Attachments = attachmentSummaries,
                     SectionName = section.Name,
-                    SectionSchema = JsonSerializer.SerializeToElement(BuildSectionQuestionsData(section), _jsonOptions),
+                    SectionSchema = JsonSerializer.SerializeToElement(BuildSectionQuestionsData(section), AIJsonDefaults.IndentedCamelCase),
                     PromptVersion = promptVersion,
                 };
                 var applicationScoringResponse = await aiService.GenerateApplicationScoringAsync(applicationScoringRequest);
@@ -141,7 +131,7 @@ namespace Unity.AI.Operations
                     Data = promptData,
                     Attachments = attachmentSummaries,
                     SectionName = "All Sections",
-                    SectionSchema = JsonSerializer.SerializeToElement(questions, _jsonOptions),
+                    SectionSchema = JsonSerializer.SerializeToElement(questions, AIJsonDefaults.IndentedCamelCase),
                     PromptVersion = promptVersion,
                 };
                 var applicationScoringResponse = await aiService.GenerateApplicationScoringAsync(applicationScoringRequest);
@@ -182,7 +172,7 @@ namespace Unity.AI.Operations
 
         private void CopyAnswers(Dictionary<string, ApplicationScoringAnswer> answers, Dictionary<string, object> results)
         {
-            var answersJson = JsonSerializer.Serialize(answers, _jsonOptions);
+            var answersJson = JsonSerializer.Serialize(answers, AIJsonDefaults.IndentedCamelCase);
             using var answersDoc = JsonDocument.Parse(answersJson);
             foreach (var property in answersDoc.RootElement.EnumerateObject())
             {

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIJsonDefaults.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIJsonDefaults.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+
+namespace Unity.AI.Runtime;
+
+internal static class AIJsonDefaults
+{
+    internal static readonly JsonSerializerOptions Indented = new() { WriteIndented = true };
+
+    internal static readonly JsonSerializerOptions IndentedCamelCase = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    static AIJsonDefaults()
+    {
+        Indented.MakeReadOnly();
+        IndentedCamelCase.MakeReadOnly();
+    }
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIPromptRenderer.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIPromptRenderer.cs
@@ -26,7 +26,7 @@ public class OpenAIPromptRenderer : ITransientDependency
             [PromptVersionV1] = PromptVersionV1
         };
     private static readonly ConcurrentDictionary<string, string> PromptTemplateCache = new(StringComparer.OrdinalIgnoreCase);
-    private static readonly JsonSerializerOptions JsonLogOptions = new() { WriteIndented = true };
+
 
     public static string BuildApplicationAnalysisSystemPrompt(string version)
     {
@@ -111,7 +111,7 @@ public class OpenAIPromptRenderer : ITransientDependency
                 return "{}";
             }
 
-            return JsonSerializer.Serialize(template, JsonLogOptions);
+            return JsonSerializer.Serialize(template, AIJsonDefaults.Indented);
         }
         catch (JsonException)
         {
@@ -125,7 +125,7 @@ public class OpenAIPromptRenderer : ITransientDependency
 
         if (string.IsNullOrWhiteSpace(sectionJson))
         {
-            return JsonSerializer.Serialize(new { name = sectionName, questions = sectionJson }, JsonLogOptions);
+            return JsonSerializer.Serialize(new { name = sectionName, questions = sectionJson }, AIJsonDefaults.Indented);
         }
 
         try
@@ -133,7 +133,7 @@ public class OpenAIPromptRenderer : ITransientDependency
             using var sectionDoc = JsonDocument.Parse(sectionJson);
             if (sectionDoc.RootElement.ValueKind != JsonValueKind.Array)
             {
-                return JsonSerializer.Serialize(new { name = sectionName, questions = sectionDoc.RootElement.Clone() }, JsonLogOptions);
+                return JsonSerializer.Serialize(new { name = sectionName, questions = sectionDoc.RootElement.Clone() }, AIJsonDefaults.Indented);
             }
 
             var aliasedQuestions = new List<Dictionary<string, object?>>();
@@ -174,11 +174,11 @@ public class OpenAIPromptRenderer : ITransientDependency
             }
 
             questionIdAliasMap = aliasMap;
-            return JsonSerializer.Serialize(new { name = sectionName, questions = aliasedQuestions }, JsonLogOptions);
+            return JsonSerializer.Serialize(new { name = sectionName, questions = aliasedQuestions }, AIJsonDefaults.Indented);
         }
         catch (JsonException)
         {
-            return JsonSerializer.Serialize(new { name = sectionName, questions = sectionJson }, JsonLogOptions);
+            return JsonSerializer.Serialize(new { name = sectionName, questions = sectionJson }, AIJsonDefaults.Indented);
         }
     }
 

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
@@ -44,7 +44,7 @@ namespace Unity.AI.Runtime
         private const string PromptLogDirectoryName = "logs";
         private static readonly string PromptLogFileName = $"ai-prompts-{DateTime.UtcNow:yyyyMMdd-HHmmss}-{Environment.ProcessId}.log";
 
-        private static readonly JsonSerializerOptions JsonLogOptions = new() { WriteIndented = true };
+
 
         public OpenAIRuntimeService(
             IConfiguration configuration,
@@ -86,8 +86,8 @@ namespace Unity.AI.Runtime
         {
             ArgumentNullException.ThrowIfNull(request);
             var promptVersion = OpenAIPromptRenderer.ResolvePromptVersion(request.PromptVersion ?? ResolvePromptVersionSetting(ApplicationAnalysisPromptType));
-            var data = JsonSerializer.Serialize(request.Data, JsonLogOptions);
-            var schema = JsonSerializer.Serialize(request.Schema, JsonLogOptions);
+            var data = JsonSerializer.Serialize(request.Data, AIJsonDefaults.Indented);
+            var schema = JsonSerializer.Serialize(request.Schema, AIJsonDefaults.Indented);
 
             var attachmentsPayload = request.Attachments
                 .Select(a => new
@@ -97,7 +97,7 @@ namespace Unity.AI.Runtime
                 })
                 .Cast<object>();
 
-            var attachments = JsonSerializer.Serialize(attachmentsPayload, JsonLogOptions);
+            var attachments = JsonSerializer.Serialize(attachmentsPayload, AIJsonDefaults.Indented);
             var systemPrompt = OpenAIPromptRenderer.BuildApplicationAnalysisSystemPrompt(promptVersion);
             var applicationAnalysisContent = OpenAIPromptRenderer.BuildApplicationAnalysisUserPrompt(
                 promptVersion,
@@ -152,7 +152,7 @@ namespace Unity.AI.Runtime
                     contentType,
                     text = attachmentText
                 };
-                var attachment = JsonSerializer.Serialize(attachmentPayload, JsonLogOptions);
+                var attachment = JsonSerializer.Serialize(attachmentPayload, AIJsonDefaults.Indented);
                 var contentToAnalyze = OpenAIPromptRenderer.BuildAttachmentSummaryUserPrompt(promptVersion, attachment);
 
                 await LogPromptInputAsync(AttachmentSummaryPromptType, promptVersion, prompt, contentToAnalyze);
@@ -195,8 +195,8 @@ namespace Unity.AI.Runtime
         {
             ArgumentNullException.ThrowIfNull(request);
             var promptVersion = OpenAIPromptRenderer.ResolvePromptVersion(request.PromptVersion ?? ResolvePromptVersionSetting(ApplicationScoringPromptType));
-            var dataJson = JsonSerializer.Serialize(request.Data, JsonLogOptions);
-            var sectionJson = JsonSerializer.Serialize(request.SectionSchema, JsonLogOptions);
+            var dataJson = JsonSerializer.Serialize(request.Data, AIJsonDefaults.Indented);
+            var sectionJson = JsonSerializer.Serialize(request.SectionSchema, AIJsonDefaults.Indented);
 
             var attachmentSummaries = request.Attachments
                 .Select(a => $"{a.Name}: {a.Summary}")
@@ -410,7 +410,7 @@ namespace Unity.AI.Runtime
 
             if (TryParseJsonObjectFromResponse(output, out var jsonObject))
             {
-                return JsonSerializer.Serialize(jsonObject, JsonLogOptions);
+                return JsonSerializer.Serialize(jsonObject, AIJsonDefaults.Indented);
             }
 
             return output.Trim();
@@ -500,7 +500,7 @@ namespace Unity.AI.Runtime
         {
             if (TryParseJsonObjectFromResponse(content, out var contentObject))
             {
-                return JsonSerializer.Serialize(contentObject, JsonLogOptions);
+                return JsonSerializer.Serialize(contentObject, AIJsonDefaults.Indented);
             }
 
             return content.Trim();


### PR DESCRIPTION
## Pull request overview

KISS pass: collapse repeated indented/camel-case `JsonSerializerOptions` instances in the AI runtime/operations code into a single shared `AIJsonDefaults` class. Removes duplication, prevents future drift, and keeps serialization defaults in one obvious place.

**Changes:**
- New `AIJsonDefaults` static class with `Indented` and `IndentedCamelCase` `static readonly` instances.
- `OpenAIRuntimeService`, `OpenAIPromptRenderer`, `ApplicationAnalysisService`, and `ApplicationScoringService` reference the shared instances.
- Compact provider/metadata JSON serialization remains unchanged.
- No behavior change; no public API change.