### PR TITLE
AB#32900 make AI generation runtime cancellation-ready

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/AI/Extraction/ITextExtractionService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/AI/Extraction/ITextExtractionService.cs
@@ -1,10 +1,11 @@
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Unity.AI.Extraction
 {
     public interface ITextExtractionService
     {
-        Task<string> ExtractTextAsync(string fileName, Stream fileContent, string contentType);
+        Task<string> ExtractTextAsync(string fileName, Stream fileContent, string contentType, CancellationToken cancellationToken = default);
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/AI/IAIService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/AI/IAIService.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Unity.AI.Requests;
 using Unity.AI.Responses;
@@ -8,8 +9,8 @@ namespace Unity.AI
     {
         Task<bool> IsAvailableAsync();
 
-        Task<AttachmentSummaryResponse> GenerateAttachmentSummaryAsync(AttachmentSummaryRequest request);
-        Task<ApplicationAnalysisResponse> GenerateApplicationAnalysisAsync(ApplicationAnalysisRequest request);
-        Task<ApplicationScoringResponse> GenerateApplicationScoringAsync(ApplicationScoringRequest request);
+        Task<AttachmentSummaryResponse> GenerateAttachmentSummaryAsync(AttachmentSummaryRequest request, CancellationToken cancellationToken = default);
+        Task<ApplicationAnalysisResponse> GenerateApplicationAnalysisAsync(ApplicationAnalysisRequest request, CancellationToken cancellationToken = default);
+        Task<ApplicationScoringResponse> GenerateApplicationScoringAsync(ApplicationScoringRequest request, CancellationToken cancellationToken = default);
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Extraction/TextExtractionService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Extraction/TextExtractionService.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using UglyToad.PdfPig;
@@ -32,7 +33,7 @@ namespace Unity.AI.Extraction
             _logger = logger;
         }
 
-        public Task<string> ExtractTextAsync(string fileName, Stream fileContent, string contentType)
+        public Task<string> ExtractTextAsync(string fileName, Stream fileContent, string contentType, CancellationToken cancellationToken = default)
         {
             if (fileContent == null)
             {
@@ -42,6 +43,7 @@ namespace Unity.AI.Extraction
 
             try
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var normalizedContentType = contentType?.ToLowerInvariant() ?? string.Empty;
                 var extension = Path.GetExtension(fileName)?.ToLowerInvariant() ?? string.Empty;
 
@@ -53,12 +55,12 @@ namespace Unity.AI.Extraction
 
                 var rawText = extension switch
                 {
-                    ".txt" or ".csv" or ".json" or ".xml" => ExtractTextFromTextFile(fileContent),
-                    ".pdf" => ExtractTextFromPdfFile(fileName, fileContent),
-                    ".docx" => ExtractTextFromWordDocx(fileName, fileContent),
-                    ".xls" or ".xlsx" => ExtractTextFromExcelFile(fileName, fileContent),
-                    ".pptx" => ExtractTextFromPowerPointFile(fileName, fileContent),
-                    _ => ExtractByContentType(fileName, fileContent, normalizedContentType)
+                    ".txt" or ".csv" or ".json" or ".xml" => ExtractTextFromTextFile(fileContent, cancellationToken),
+                    ".pdf" => ExtractTextFromPdfFile(fileName, fileContent, cancellationToken),
+                    ".docx" => ExtractTextFromWordDocx(fileName, fileContent, cancellationToken),
+                    ".xls" or ".xlsx" => ExtractTextFromExcelFile(fileName, fileContent, cancellationToken),
+                    ".pptx" => ExtractTextFromPowerPointFile(fileName, fileContent, cancellationToken),
+                    _ => ExtractByContentType(fileName, fileContent, normalizedContentType, cancellationToken)
                 };
 
                 if (string.IsNullOrEmpty(rawText))
@@ -69,6 +71,10 @@ namespace Unity.AI.Extraction
 
                 return Task.FromResult(NormalizeAndLimitText(rawText, fileName));
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error extracting text from {FileName}", fileName);
@@ -76,29 +82,33 @@ namespace Unity.AI.Extraction
             }
         }
 
-        private string ExtractByContentType(string fileName, Stream fileContent, string normalizedContentType)
+        private string ExtractByContentType(
+            string fileName,
+            Stream fileContent,
+            string normalizedContentType,
+            CancellationToken cancellationToken)
         {
             if (normalizedContentType.Contains("text/"))
             {
-                return ExtractTextFromTextFile(fileContent);
+                return ExtractTextFromTextFile(fileContent, cancellationToken);
             }
             if (normalizedContentType.Contains("pdf"))
             {
-                return ExtractTextFromPdfFile(fileName, fileContent);
+                return ExtractTextFromPdfFile(fileName, fileContent, cancellationToken);
             }
             if (normalizedContentType.Contains("word") ||
                 normalizedContentType.Contains("msword") ||
                 normalizedContentType.Contains("officedocument.wordprocessingml"))
             {
-                return ExtractTextFromWordDocx(fileName, fileContent);
+                return ExtractTextFromWordDocx(fileName, fileContent, cancellationToken);
             }
             if (normalizedContentType.Contains("excel") || normalizedContentType.Contains("spreadsheet"))
             {
-                return ExtractTextFromExcelFile(fileName, fileContent);
+                return ExtractTextFromExcelFile(fileName, fileContent, cancellationToken);
             }
             if (normalizedContentType.Contains("presentation") || normalizedContentType.Contains("powerpoint"))
             {
-                return ExtractTextFromPowerPointFile(fileName, fileContent);
+                return ExtractTextFromPowerPointFile(fileName, fileContent, cancellationToken);
             }
             return string.Empty;
         }
@@ -111,7 +121,7 @@ namespace Unity.AI.Extraction
             }
         }
 
-        private string ExtractTextFromTextFile(Stream fileContent)
+        private string ExtractTextFromTextFile(Stream fileContent, CancellationToken cancellationToken)
         {
             try
             {
@@ -122,6 +132,7 @@ namespace Unity.AI.Extraction
                 int read;
                 while ((read = reader.Read(buffer, 0, buffer.Length)) > 0)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     var remaining = MaxExtractedTextLength - builder.Length;
                     if (remaining <= 0) break;
                     builder.Append(buffer, 0, Math.Min(read, remaining));
@@ -142,7 +153,7 @@ namespace Unity.AI.Extraction
             }
         }
 
-        private string ExtractTextFromPdfFile(string fileName, Stream fileContent)
+        private string ExtractTextFromPdfFile(string fileName, Stream fileContent, CancellationToken cancellationToken)
         {
             try
             {
@@ -156,6 +167,7 @@ namespace Unity.AI.Extraction
 
                 foreach (var pageText in pageTexts)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     if (builder.Length >= MaxExtractedTextLength)
                     {
                         break;
@@ -178,15 +190,15 @@ namespace Unity.AI.Extraction
             }
         }
 
-        private string ExtractTextFromWordDocx(string fileName, Stream fileContent)
+        private string ExtractTextFromWordDocx(string fileName, Stream fileContent, CancellationToken cancellationToken)
         {
             try
             {
                 RewindIfPossible(fileContent);
                 using var document = new XWPFDocument(fileContent);
                 var builder = new StringBuilder();
-                var processedParagraphCount = AppendDocxParagraphText(document, builder);
-                var processedTableRowCount = AppendDocxTableText(document, builder);
+                var processedParagraphCount = AppendDocxParagraphText(document, builder, cancellationToken);
+                var processedTableRowCount = AppendDocxTableText(document, builder, cancellationToken);
 
                 _logger.LogDebug(
                     "Extracted Word text from {ProcessedParagraphCount} paragraphs and {ProcessedTableRowCount} table rows for {FileName}",
@@ -202,7 +214,10 @@ namespace Unity.AI.Extraction
             }
         }
 
-        private static int AppendDocxParagraphText(XWPFDocument document, StringBuilder builder)
+        private static int AppendDocxParagraphText(
+            XWPFDocument document,
+            StringBuilder builder,
+            CancellationToken cancellationToken)
         {
             var processedParagraphCount = 0;
             var paragraphTexts = document.Paragraphs
@@ -212,6 +227,7 @@ namespace Unity.AI.Extraction
 
             foreach (var paragraphText in paragraphTexts)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (builder.Length >= MaxExtractedTextLength)
                 {
                     break;
@@ -227,7 +243,10 @@ namespace Unity.AI.Extraction
             return processedParagraphCount;
         }
 
-        private static int AppendDocxTableText(XWPFDocument document, StringBuilder builder)
+        private static int AppendDocxTableText(
+            XWPFDocument document,
+            StringBuilder builder,
+            CancellationToken cancellationToken)
         {
             if (builder.Length >= MaxExtractedTextLength)
             {
@@ -237,8 +256,10 @@ namespace Unity.AI.Extraction
             var processedTableRowCount = 0;
             foreach (var table in document.Tables)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 foreach (var row in table.Rows.Take(MaxDocxTableRows))
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     if (builder.Length >= MaxExtractedTextLength)
                     {
                         return processedTableRowCount;
@@ -252,6 +273,7 @@ namespace Unity.AI.Extraction
                     var rowHadValue = false;
                     foreach (var cellText in cellTexts)
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
                         rowHadValue = true;
                         if (TryAppendWithTrailingNewline(builder, cellText))
                         {
@@ -269,7 +291,7 @@ namespace Unity.AI.Extraction
             return processedTableRowCount;
         }
 
-        private string ExtractTextFromExcelFile(string fileName, Stream fileContent)
+        private string ExtractTextFromExcelFile(string fileName, Stream fileContent, CancellationToken cancellationToken)
         {
             try
             {
@@ -282,13 +304,14 @@ namespace Unity.AI.Extraction
 
                 for (var sheetIndex = 0; sheetIndex < sheetCount; sheetIndex++)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     if (builder.Length >= MaxExtractedTextLength)
                     {
                         break;
                     }
 
                     var sheet = workbook.GetSheetAt(sheetIndex);
-                    var (rowsProcessed, limitReached) = TryAppendExcelSheet(sheet, builder);
+                    var (rowsProcessed, limitReached) = TryAppendExcelSheet(sheet, builder, cancellationToken);
                     if (rowsProcessed > 0)
                     {
                         processedSheetCount++;
@@ -315,7 +338,7 @@ namespace Unity.AI.Extraction
             }
         }
 
-        private string ExtractTextFromPowerPointFile(string fileName, Stream fileContent)
+        private string ExtractTextFromPowerPointFile(string fileName, Stream fileContent, CancellationToken cancellationToken)
         {
             try
             {
@@ -328,6 +351,7 @@ namespace Unity.AI.Extraction
 
                 foreach (var slideEntry in slideEntries)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     if (builder.Length >= MaxExtractedTextLength)
                     {
                         break;
@@ -398,7 +422,10 @@ namespace Unity.AI.Extraction
             return orderedEntries;
         }
 
-        private static (int RowsProcessed, bool LimitReached) TryAppendExcelSheet(ISheet? sheet, StringBuilder builder)
+        private static (int RowsProcessed, bool LimitReached) TryAppendExcelSheet(
+            ISheet? sheet,
+            StringBuilder builder,
+            CancellationToken cancellationToken)
         {
             if (sheet == null)
             {
@@ -408,12 +435,13 @@ namespace Unity.AI.Extraction
             var processedRows = 0;
             foreach (IRow row in sheet)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (processedRows >= MaxExcelRowsPerSheet || builder.Length >= MaxExtractedTextLength)
                 {
                     break;
                 }
 
-                var (rowHadValue, limitReached) = TryAppendExcelRow(row, builder);
+                var (rowHadValue, limitReached) = TryAppendExcelRow(row, builder, cancellationToken);
                 if (rowHadValue)
                 {
                     processedRows++;
@@ -428,11 +456,15 @@ namespace Unity.AI.Extraction
             return (processedRows, builder.Length >= MaxExtractedTextLength);
         }
 
-        private static (bool RowHadValue, bool LimitReached) TryAppendExcelRow(IRow row, StringBuilder builder)
+        private static (bool RowHadValue, bool LimitReached) TryAppendExcelRow(
+            IRow row,
+            StringBuilder builder,
+            CancellationToken cancellationToken)
         {
             var rowHasValue = false;
             foreach (var cell in row.Cells.Take(MaxExcelCellsPerRow))
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var value = GetCellText(cell);
                 if (string.IsNullOrWhiteSpace(value))
                 {

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationAnalysisService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationAnalysisService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Unity.AI.Models;
 using Unity.AI.Prompts;
@@ -28,7 +29,7 @@ namespace Unity.AI.Operations
             "applicantAgent"
         };
 
-        public async Task<string> RegenerateAndSaveAsync(Guid applicationId, string? promptVersion = null)
+        public async Task<string> RegenerateAndSaveAsync(Guid applicationId, string? promptVersion = null, CancellationToken cancellationToken = default)
         {
             var application = await applicationRepository.GetAsync(applicationId);
             var formSubmission = await applicationFormSubmissionRepository.GetByApplicationAsync(applicationId);
@@ -56,7 +57,7 @@ namespace Unity.AI.Operations
                 Data = PromptDataPayloadBuilder.BuildPromptDataPayload(application, formSubmission, formSchema, logger),
                 Attachments = attachmentSummaries,
                 PromptVersion = promptVersion,
-            });
+            }, cancellationToken);
 
             var analysisJson = JsonSerializer.Serialize(analysis, AIJsonDefaults.Indented);
             application.AIAnalysis = analysisJson;

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Unity.Flex.Domain.Scoresheets;
 using Unity.AI.Models;
@@ -25,7 +26,7 @@ namespace Unity.AI.Operations
         AIExecutionModeResolver executionModeResolver,
         ILogger<ApplicationScoringService> logger) : IApplicationScoringService, ITransientDependency
     {
-        public async Task<string> RegenerateAndSaveAsync(Guid applicationId, string? promptVersion = null)
+        public async Task<string> RegenerateAndSaveAsync(Guid applicationId, string? promptVersion = null, CancellationToken cancellationToken = default)
         {
             var application = await applicationRepository.GetAsync(applicationId);
             var applicationForm = await applicationFormRepository.GetAsync(application.ApplicationFormId);
@@ -60,8 +61,8 @@ namespace Unity.AI.Operations
             var perSectionResults = await AIExecutionStrategy.RunAsync(
                 sections,
                 mode,
-                section => ProcessSectionAsync(applicationId, section, promptData, attachmentSummaries, promptVersion),
-                batch => ProcessSectionsAsync(applicationId, batch, promptData, attachmentSummaries, promptVersion));
+                section => ProcessSectionAsync(applicationId, section, promptData, attachmentSummaries, promptVersion, cancellationToken),
+                batch => ProcessSectionsAsync(applicationId, batch, promptData, attachmentSummaries, promptVersion, cancellationToken));
 
             var allSectionResults = new Dictionary<string, object>();
             foreach (var sectionResult in perSectionResults)
@@ -84,7 +85,8 @@ namespace Unity.AI.Operations
             ScoresheetSection section,
             JsonElement promptData,
             List<AIAttachmentItem> attachmentSummaries,
-            string? promptVersion)
+            string? promptVersion,
+            CancellationToken cancellationToken)
         {
             var sectionResults = new Dictionary<string, object>();
             try
@@ -97,12 +99,16 @@ namespace Unity.AI.Operations
                     SectionSchema = JsonSerializer.SerializeToElement(BuildSectionQuestionsData(section), AIJsonDefaults.IndentedCamelCase),
                     PromptVersion = promptVersion,
                 };
-                var applicationScoringResponse = await aiService.GenerateApplicationScoringAsync(applicationScoringRequest);
+                var applicationScoringResponse = await aiService.GenerateApplicationScoringAsync(applicationScoringRequest, cancellationToken);
 
                 if (applicationScoringResponse.Answers.Count > 0)
                 {
                     CopyAnswers(applicationScoringResponse.Answers, sectionResults);
                 }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -116,7 +122,8 @@ namespace Unity.AI.Operations
             IReadOnlyCollection<ScoresheetSection> sections,
             JsonElement promptData,
             List<AIAttachmentItem> attachmentSummaries,
-            string? promptVersion)
+            string? promptVersion,
+            CancellationToken cancellationToken)
         {
             var sectionResults = new Dictionary<string, object>();
             try
@@ -134,12 +141,16 @@ namespace Unity.AI.Operations
                     SectionSchema = JsonSerializer.SerializeToElement(questions, AIJsonDefaults.IndentedCamelCase),
                     PromptVersion = promptVersion,
                 };
-                var applicationScoringResponse = await aiService.GenerateApplicationScoringAsync(applicationScoringRequest);
+                var applicationScoringResponse = await aiService.GenerateApplicationScoringAsync(applicationScoringRequest, cancellationToken);
 
                 if (applicationScoringResponse.Answers.Count > 0)
                 {
                     CopyAnswers(applicationScoringResponse.Answers, sectionResults);
                 }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception ex)
             {

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AttachmentSummaryService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AttachmentSummaryService.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Unity.AI.Extraction;
 using Unity.AI.Requests;
@@ -21,13 +22,13 @@ public class AttachmentSummaryService(
 {
     private const string SummaryGenerationFailedMessage = "AI summary generation failed.";
 
-    public async Task<string> GenerateAndSaveAsync(Guid attachmentId, string? promptVersion = null)
+    public async Task<string> GenerateAndSaveAsync(Guid attachmentId, string? promptVersion = null, CancellationToken cancellationToken = default)
     {
         var attachment = await applicationChefsFileAttachmentRepository.GetAsync(attachmentId);
         var fileName = string.IsNullOrWhiteSpace(attachment.FileName) ? "unknown" : attachment.FileName;
 
-        await using var attachmentStream = await OpenAttachmentStreamAsync(attachment, fileName);
-        var extractedText = await textExtractionService.ExtractTextAsync(fileName, attachmentStream.Content, attachmentStream.ContentType);
+        await using var attachmentStream = await OpenAttachmentStreamAsync(attachment, fileName, cancellationToken);
+        var extractedText = await textExtractionService.ExtractTextAsync(fileName, attachmentStream.Content, attachmentStream.ContentType, cancellationToken);
 
         var summaryResponse = await aiService.GenerateAttachmentSummaryAsync(new AttachmentSummaryRequest
         {
@@ -35,7 +36,7 @@ public class AttachmentSummaryService(
             ContentType = attachmentStream.ContentType,
             ExtractedText = extractedText,
             PromptVersion = promptVersion,
-        });
+        }, cancellationToken);
 
         attachment.AISummary = summaryResponse.Summary;
         await applicationChefsFileAttachmentRepository.UpdateAsync(attachment);
@@ -43,7 +44,7 @@ public class AttachmentSummaryService(
         return summaryResponse.Summary;
     }
 
-    public async Task<List<string>> GenerateAndSaveAsync(IEnumerable<Guid> attachmentIds, string? promptVersion = null)
+    public async Task<List<string>> GenerateAndSaveAsync(IEnumerable<Guid> attachmentIds, string? promptVersion = null, CancellationToken cancellationToken = default)
     {
         var ids = attachmentIds as IReadOnlyCollection<Guid> ?? attachmentIds.ToList();
         var mode = executionModeResolver.ResolveMode(AIExecutionModeResolver.AttachmentSummaryOperation);
@@ -58,26 +59,36 @@ public class AttachmentSummaryService(
         return await AIExecutionStrategy.RunAsync(
             ids,
             mode,
-            id => GenerateOrFallbackAsync(id, promptVersion),
-            batch => GenerateSequentiallyAsync(batch, promptVersion));
+            id => GenerateOrFallbackAsync(id, promptVersion, cancellationToken),
+            batch => GenerateSequentiallyAsync(batch, promptVersion, cancellationToken));
     }
 
-    private async Task<List<string>> GenerateSequentiallyAsync(IReadOnlyCollection<Guid> attachmentIds, string? promptVersion)
+    private async Task<List<string>> GenerateSequentiallyAsync(
+        IReadOnlyCollection<Guid> attachmentIds,
+        string? promptVersion,
+        CancellationToken cancellationToken)
     {
         var summaries = new List<string>(attachmentIds.Count);
         foreach (var attachmentId in attachmentIds)
         {
-            summaries.Add(await GenerateOrFallbackAsync(attachmentId, promptVersion));
+            summaries.Add(await GenerateOrFallbackAsync(attachmentId, promptVersion, cancellationToken));
         }
 
         return summaries;
     }
 
-    private async Task<string> GenerateOrFallbackAsync(Guid attachmentId, string? promptVersion)
+    private async Task<string> GenerateOrFallbackAsync(
+        Guid attachmentId,
+        string? promptVersion,
+        CancellationToken cancellationToken)
     {
         try
         {
-            return await GenerateAndSaveAsync(attachmentId, promptVersion);
+            return await GenerateAndSaveAsync(attachmentId, promptVersion, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -86,16 +97,19 @@ public class AttachmentSummaryService(
         }
     }
 
-    public async Task<List<string>> GenerateForApplicationAsync(Guid applicationId, string? promptVersion = null)
+    public async Task<List<string>> GenerateForApplicationAsync(Guid applicationId, string? promptVersion = null, CancellationToken cancellationToken = default)
     {
         var attachmentIds = (await applicationChefsFileAttachmentRepository.GetListAsync(a => a.ApplicationId == applicationId))
             .Select(a => a.Id)
             .ToList();
 
-        return await GenerateAndSaveAsync(attachmentIds, promptVersion);
+        return await GenerateAndSaveAsync(attachmentIds, promptVersion, cancellationToken);
     }
 
-    private async Task<ChefsFileAttachmentStream> OpenAttachmentStreamAsync(ApplicationChefsFileAttachment attachment, string fileName)
+    private async Task<ChefsFileAttachmentStream> OpenAttachmentStreamAsync(
+        ApplicationChefsFileAttachment attachment,
+        string fileName,
+        CancellationToken cancellationToken)
     {
         if (!Guid.TryParse(attachment.ChefsSubmissionId, out var submissionId) ||
             !Guid.TryParse(attachment.ChefsFileId, out var fileId))
@@ -108,8 +122,13 @@ public class AttachmentSummaryService(
 
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var stream = await chefsFileAttachmentStreamProvider.OpenAsync(submissionId, fileId, fileName);
             return stream ?? ChefsFileAttachmentStream.Empty;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/IApplicationAnalysisService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/IApplicationAnalysisService.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Unity.AI.Operations
 {
     public interface IApplicationAnalysisService
     {
-        Task<string> RegenerateAndSaveAsync(Guid applicationId, string? promptVersion = null);
+        Task<string> RegenerateAndSaveAsync(Guid applicationId, string? promptVersion = null, CancellationToken cancellationToken = default);
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/IApplicationScoringService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/IApplicationScoringService.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Unity.AI.Operations
 {
     public interface IApplicationScoringService
     {
-        Task<string> RegenerateAndSaveAsync(Guid applicationId, string? promptVersion = null);
+        Task<string> RegenerateAndSaveAsync(Guid applicationId, string? promptVersion = null, CancellationToken cancellationToken = default);
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/IAttachmentSummaryService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/IAttachmentSummaryService.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Unity.AI.Operations;
 
 public interface IAttachmentSummaryService
 {
-    Task<string> GenerateAndSaveAsync(Guid attachmentId, string? promptVersion = null);
-    Task<List<string>> GenerateAndSaveAsync(IEnumerable<Guid> attachmentIds, string? promptVersion = null);
-    Task<List<string>> GenerateForApplicationAsync(Guid applicationId, string? promptVersion = null);
+    Task<string> GenerateAndSaveAsync(Guid attachmentId, string? promptVersion = null, CancellationToken cancellationToken = default);
+    Task<List<string>> GenerateAndSaveAsync(IEnumerable<Guid> attachmentIds, string? promptVersion = null, CancellationToken cancellationToken = default);
+    Task<List<string>> GenerateForApplicationAsync(Guid applicationId, string? promptVersion = null, CancellationToken cancellationToken = default);
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Unity.AI.Models;
 using Unity.AI.Prompts;
@@ -65,7 +66,7 @@ namespace Unity.AI.Runtime
             return Task.FromResult(true);
         }
 
-        public async Task<ApplicationAnalysisResponse> GenerateApplicationAnalysisAsync(ApplicationAnalysisRequest request)
+        public async Task<ApplicationAnalysisResponse> GenerateApplicationAnalysisAsync(ApplicationAnalysisRequest request, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(request);
             var promptVersion = OpenAIPromptRenderer.ResolvePromptVersion(request.PromptVersion ?? ResolvePromptVersionSetting(ApplicationAnalysisPromptType));
@@ -87,17 +88,19 @@ namespace Unity.AI.Runtime
                 schema,
                 data,
                 attachments);
-            await LogPromptInputAsync(ApplicationAnalysisPromptType, promptVersion, systemPrompt, applicationAnalysisContent);
+            await LogPromptInputAsync(ApplicationAnalysisPromptType, promptVersion, systemPrompt, applicationAnalysisContent, cancellationToken);
             var result = await GenerateWithRetryAsync(
                 () => _openAITransportService.GenerateSummaryAsync(
                     applicationAnalysisContent,
                     systemPrompt,
                     ApplicationAnalysisCompletionTokens,
                     operationName: ApplicationAnalysisPromptType,
-                    promptVersion: promptVersion),
+                    promptVersion: promptVersion,
+                    cancellationToken: cancellationToken),
                 AIProviderPayloadValidator.IsValidApplicationAnalysisJson,
-                "application analysis");
-            await LogPromptOutputAsync(ApplicationAnalysisPromptType, promptVersion, result.CaptureOutput);
+                "application analysis",
+                cancellationToken);
+            await LogPromptOutputAsync(ApplicationAnalysisPromptType, promptVersion, result.CaptureOutput, cancellationToken);
 
             if (result.Outcome != AIOperationOutcome.Success)
             {
@@ -107,7 +110,7 @@ namespace Unity.AI.Runtime
             return OpenAIResponseParser.ParseApplicationAnalysisResponse(result.Content);
         }
 
-        public async Task<AttachmentSummaryResponse> GenerateAttachmentSummaryAsync(AttachmentSummaryRequest request)
+        public async Task<AttachmentSummaryResponse> GenerateAttachmentSummaryAsync(AttachmentSummaryRequest request, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(request);
             var fileName = request.FileName ?? string.Empty;
@@ -138,7 +141,7 @@ namespace Unity.AI.Runtime
                 var attachment = JsonSerializer.Serialize(attachmentPayload, AIJsonDefaults.Indented);
                 var contentToAnalyze = OpenAIPromptRenderer.BuildAttachmentSummaryUserPrompt(promptVersion, attachment);
 
-                await LogPromptInputAsync(AttachmentSummaryPromptType, promptVersion, prompt, contentToAnalyze);
+                await LogPromptInputAsync(AttachmentSummaryPromptType, promptVersion, prompt, contentToAnalyze, cancellationToken);
                 var result = await GenerateWithRetryAsync(
                     () => _openAITransportService.GenerateSummaryAsync(
                         contentToAnalyze,
@@ -146,10 +149,12 @@ namespace Unity.AI.Runtime
                         AttachmentSummaryCompletionTokens,
                         operationName: AttachmentSummaryPromptType,
                         promptVersion: promptVersion,
-                        fileName: fileName),
+                        fileName: fileName,
+                        cancellationToken: cancellationToken),
                     AIProviderPayloadValidator.IsValidAttachmentSummaryText,
-                    "attachment summary");
-                await LogPromptOutputAsync(AttachmentSummaryPromptType, promptVersion, result.CaptureOutput);
+                    "attachment summary",
+                    cancellationToken);
+                await LogPromptOutputAsync(AttachmentSummaryPromptType, promptVersion, result.CaptureOutput, cancellationToken);
 
                 if (result.Outcome != AIOperationOutcome.Success)
                 {
@@ -164,6 +169,10 @@ namespace Unity.AI.Runtime
                     Summary = ExtractSummaryFromJson(result.Content)
                 };
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error generating attachment summary for {FileName}", fileName);
@@ -174,7 +183,7 @@ namespace Unity.AI.Runtime
             }
         }
 
-        public async Task<ApplicationScoringResponse> GenerateApplicationScoringAsync(ApplicationScoringRequest request)
+        public async Task<ApplicationScoringResponse> GenerateApplicationScoringAsync(ApplicationScoringRequest request, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(request);
             var promptVersion = OpenAIPromptRenderer.ResolvePromptVersion(request.PromptVersion ?? ResolvePromptVersionSetting(ApplicationScoringPromptType));
@@ -214,17 +223,19 @@ namespace Unity.AI.Runtime
                     response);
                 var systemPrompt = OpenAIPromptRenderer.BuildApplicationScoringSystemPrompt(promptVersion);
 
-                await LogPromptInputAsync(ApplicationScoringPromptType, promptVersion, systemPrompt, applicationScoringContent);
+                await LogPromptInputAsync(ApplicationScoringPromptType, promptVersion, systemPrompt, applicationScoringContent, cancellationToken);
                 var result = await GenerateWithRetryAsync(
                 () => _openAITransportService.GenerateSummaryAsync(
                     applicationScoringContent,
                     systemPrompt,
                     ApplicationScoringCompletionTokens,
                     operationName: ApplicationScoringPromptType,
-                    promptVersion: promptVersion),
+                    promptVersion: promptVersion,
+                    cancellationToken: cancellationToken),
                     content => AIProviderPayloadValidator.IsValidApplicationScoringJson(content, section),
-                    $"application scoring section {request.SectionName}");
-                await LogPromptOutputAsync(ApplicationScoringPromptType, promptVersion, result.CaptureOutput);
+                    $"application scoring section {request.SectionName}",
+                    cancellationToken);
+                await LogPromptOutputAsync(ApplicationScoringPromptType, promptVersion, result.CaptureOutput, cancellationToken);
 
                 if (result.Outcome != AIOperationOutcome.Success)
                 {
@@ -232,6 +243,10 @@ namespace Unity.AI.Runtime
                 }
 
                 return OpenAIResponseParser.ParseApplicationScoringResponse(result.Content, questionIdAliasMap);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -243,12 +258,14 @@ namespace Unity.AI.Runtime
         private async Task<AIOperationResult> GenerateWithRetryAsync(
             Func<Task<AIOperationResult>> operation,
             Func<string, bool> validator,
-            string operationName)
+            string operationName,
+            CancellationToken cancellationToken = default)
         {
             var lastResult = AIOperationResult.InvalidOutput();
 
             for (var attempt = 1; attempt <= MaxAiAttempts; attempt++)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 lastResult = await operation();
 
                 if (lastResult.Outcome == AIOperationOutcome.Success && validator(lastResult.Content))
@@ -320,21 +337,21 @@ namespace Unity.AI.Runtime
             return _configuration["Azure:OpenAI:PromptVersion"];
         }
 
-        private async Task LogPromptInputAsync(string promptType, string promptVersion, string? systemPrompt, string userPrompt)
+        private async Task LogPromptInputAsync(string promptType, string promptVersion, string? systemPrompt, string userPrompt, CancellationToken cancellationToken = default)
         {
             var formattedInput = FormatPromptInputForLog(systemPrompt, userPrompt);
             _logger.LogInformation("AI {PromptType} ({PromptVersion}) input payload: {PromptInput}", promptType, promptVersion, formattedInput);
-            await WritePromptLogFileAsync(promptType, promptVersion, "INPUT", formattedInput);
+            await WritePromptLogFileAsync(promptType, promptVersion, "INPUT", formattedInput, cancellationToken);
         }
 
-        private async Task LogPromptOutputAsync(string promptType, string promptVersion, string output)
+        private async Task LogPromptOutputAsync(string promptType, string promptVersion, string output, CancellationToken cancellationToken = default)
         {
             var formattedOutput = FormatPromptOutputForLog(output);
             _logger.LogInformation("AI {PromptType} ({PromptVersion}) model output payload: {ModelOutput}", promptType, promptVersion, formattedOutput);
-            await WritePromptLogFileAsync(promptType, promptVersion, "OUTPUT", formattedOutput);
+            await WritePromptLogFileAsync(promptType, promptVersion, "OUTPUT", formattedOutput, cancellationToken);
         }
 
-        private async Task WritePromptLogFileAsync(string promptType, string promptVersion, string payloadType, string payload)
+        private async Task WritePromptLogFileAsync(string promptType, string promptVersion, string payloadType, string payload, CancellationToken cancellationToken = default)
         {
             if (!CanWritePromptFileLog())
             {
@@ -349,7 +366,11 @@ namespace Unity.AI.Runtime
 
                 var logPath = Path.Combine(logDirectory, PromptLogFileName);
                 var entry = $"{now} [{promptType}] [{promptVersion}] {payloadType}\n{payload}\n\n";
-                await File.AppendAllTextAsync(logPath, entry);
+                await File.AppendAllTextAsync(logPath, entry, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception ex)
             {

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAITransportService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAITransportService.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Volo.Abp.DependencyInjection;
 
@@ -26,7 +27,8 @@ public class OpenAITransportService(
         double? temperature = null,
         string? operationName = null,
         string? promptVersion = null,
-        string? fileName = null)
+        string? fileName = null,
+        CancellationToken cancellationToken = default)
     {
         var providerName = _configurationResolver.ResolveProviderName(operationName);
         if (!string.Equals(providerName, "OpenAI", StringComparison.Ordinal))
@@ -73,8 +75,8 @@ public class OpenAITransportService(
             };
             request.Headers.TryAddWithoutValidation("Authorization", apiKey);
 
-            var response = await _httpClient.SendAsync(request);
-            var responseContent = await response.Content.ReadAsStringAsync();
+            using var response = await _httpClient.SendAsync(request, cancellationToken);
+            var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
             var metadata = TryExtractProviderMetadata(responseContent);
             var providerResponse = BuildProviderResponseFromMetadata(
                 string.Empty,
@@ -117,6 +119,10 @@ public class OpenAITransportService(
                 _logger.LogWarning(ex, "AI response payload had an invalid output shape");
                 return AIOperationResult.InvalidOutput(providerResponse);
             }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/AttachmentSummaryServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/AttachmentSummaryServiceTests.cs
@@ -4,6 +4,7 @@ using NSubstitute;
 using Shouldly;
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Unity.AI;
 using Unity.AI.Extraction;
@@ -13,16 +14,11 @@ using Unity.AI.Responses;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Intakes;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Unity.GrantManager.AI.Operations;
 
-public class AttachmentSummaryServiceTests : GrantManagerApplicationTestBase
+public class AttachmentSummaryServiceTests
 {
-    public AttachmentSummaryServiceTests(ITestOutputHelper outputHelper) : base(outputHelper)
-    {
-    }
-
     [Fact]
     public async Task GenerateAndSaveAsync_Uses_Streamed_Attachment_Text()
     {
@@ -75,5 +71,42 @@ public class AttachmentSummaryServiceTests : GrantManagerApplicationTestBase
 
         await attachmentRepository.Received(1).UpdateAsync(attachment);
         stream.CanRead.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GenerateAndSaveAsync_Should_Propagate_Cancellation()
+    {
+        var attachmentId = Guid.NewGuid();
+        var submissionId = Guid.NewGuid();
+        var fileId = Guid.NewGuid();
+        var stream = new MemoryStream([1, 2, 3]);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await cancellationTokenSource.CancelAsync();
+
+        var attachment = new ApplicationChefsFileAttachment
+        {
+            ApplicationId = Guid.NewGuid(),
+            FileName = "test.txt",
+            ChefsSubmissionId = submissionId.ToString(),
+            ChefsFileId = fileId.ToString()
+        };
+
+        var attachmentRepository = Substitute.For<IApplicationChefsFileAttachmentRepository>();
+        attachmentRepository.GetAsync(attachmentId).Returns(attachment);
+
+        var streamProvider = Substitute.For<IChefsFileAttachmentStreamProvider>();
+        streamProvider.OpenAsync(submissionId, fileId, "test.txt")
+            .Returns(new ChefsFileAttachmentStream(stream, "text/plain"));
+
+        var service = new AttachmentSummaryService(
+            attachmentRepository,
+            streamProvider,
+            Substitute.For<ITextExtractionService>(),
+            Substitute.For<IAIService>(),
+            new AIExecutionModeResolver(new ConfigurationBuilder().Build()),
+            NullLogger<AttachmentSummaryService>.Instance);
+
+        await Should.ThrowAsync<OperationCanceledException>(() =>
+            service.GenerateAndSaveAsync(attachmentId, "v1", cancellationTokenSource.Token));
     }
 }


### PR DESCRIPTION
## Pull request overview

Threads `CancellationToken` through Unity.AI service async chains so aborted callers can stop downstream AI work on the next supported cancellation boundary. Default parameters preserve existing call sites.

**Changes:**
- `IAIService` + `OpenAIRuntimeService` generation methods accept `CancellationToken`.
- `OpenAITransportService`, `ITextExtractionService`, `AttachmentSummaryService`, `ApplicationAnalysisService`, and `ApplicationScoringService` updated.
- Token threaded into OpenAI HTTP calls, response reads, prompt file logging, retry-loop cancellation checks, and AI operation calls.
- `OperationCanceledException` is allowed to propagate instead of being converted into fallback AI responses.