### PR TITLE
AB#32902 add AI runtime validation tests

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Properties/AssemblyInfo.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Unity.GrantManager.Application.Tests")]

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/AIProviderPayloadValidatorTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/AIProviderPayloadValidatorTests.cs
@@ -1,0 +1,123 @@
+using Shouldly;
+using Unity.AI.Runtime;
+using Xunit;
+
+namespace Unity.GrantManager.AI.Runtime;
+
+public class AIProviderPayloadValidatorTests
+{
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    [InlineData("Some summary text", true)]
+    public void IsValidAttachmentSummaryText_Should_RejectBlankAndAcceptContent(string? input, bool expected)
+    {
+        AIProviderPayloadValidator.IsValidAttachmentSummaryText(input!).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void IsValidApplicationAnalysisJson_Should_ReturnTrue_ForWellFormedPayload()
+    {
+        var json = """
+            {
+              "decision": "Approved",
+              "errors": [],
+              "warnings": [],
+              "summaries": [],
+              "recommendations": []
+            }
+            """;
+        AIProviderPayloadValidator.IsValidApplicationAnalysisJson(json).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not json")]
+    [InlineData("[]")]
+    public void IsValidApplicationAnalysisJson_Should_ReturnFalse_ForInvalidInput(string? input)
+    {
+        AIProviderPayloadValidator.IsValidApplicationAnalysisJson(input!).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsValidApplicationAnalysisJson_Should_ReturnFalse_WhenDecisionMissing()
+    {
+        var json = """{"errors":[],"warnings":[],"summaries":[],"recommendations":[]}""";
+        AIProviderPayloadValidator.IsValidApplicationAnalysisJson(json).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsValidApplicationAnalysisJson_Should_ReturnFalse_WhenErrorsIsNotArray()
+    {
+        var json = """{"decision":"ok","errors":"bad","warnings":[],"summaries":[],"recommendations":[]}""";
+        AIProviderPayloadValidator.IsValidApplicationAnalysisJson(json).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsValidApplicationAnalysisJson_Should_AcceptMarkdownWrappedJson()
+    {
+        var json = "```json\n{\"decision\":\"ok\",\"errors\":[],\"warnings\":[],\"summaries\":[],\"recommendations\":[]}\n```";
+        AIProviderPayloadValidator.IsValidApplicationAnalysisJson(json).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsValidApplicationScoringJson_Should_ReturnTrue_ForWellFormedPayload()
+    {
+        var sectionJson = """[{"id":"q1"},{"id":"q2"}]""";
+        var response = """
+            {
+              "q1": {"answer": "Yes", "confidence": 85},
+              "q2": {"answer": "No",  "confidence": 42}
+            }
+            """;
+        AIProviderPayloadValidator.IsValidApplicationScoringJson(response, sectionJson).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsValidApplicationScoringJson_Should_ReturnFalse_WhenSectionJsonIsEmpty()
+    {
+        AIProviderPayloadValidator.IsValidApplicationScoringJson("{}", "[]").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsValidApplicationScoringJson_Should_ReturnFalse_WhenAnswerMissing()
+    {
+        var sectionJson = """[{"id":"q1"}]""";
+        var response = """{"q1": {"confidence": 50}}""";
+        AIProviderPayloadValidator.IsValidApplicationScoringJson(response, sectionJson).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsValidApplicationScoringJson_Should_ReturnFalse_WhenConfidenceOutOfRange()
+    {
+        var sectionJson = """[{"id":"q1"}]""";
+        var response = """{"q1": {"answer": "Yes", "confidence": 150}}""";
+        AIProviderPayloadValidator.IsValidApplicationScoringJson(response, sectionJson).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsValidApplicationScoringJson_Should_ReturnFalse_WhenQuestionMissingFromResponse()
+    {
+        var sectionJson = """[{"id":"q1"},{"id":"q2"}]""";
+        var response = """{"q1": {"answer": "Yes", "confidence": 80}}""";
+        AIProviderPayloadValidator.IsValidApplicationScoringJson(response, sectionJson).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsValidApplicationScoringJson_Should_AcceptQuestionsWrappedInObject()
+    {
+        var sectionJson = """{"questions":[{"id":"q1"}]}""";
+        var response = """{"q1": {"answer": "Yes", "confidence": 75}}""";
+        AIProviderPayloadValidator.IsValidApplicationScoringJson(response, sectionJson).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsValidApplicationScoringJson_Should_ReturnFalse_WhenConfidenceIsNegative()
+    {
+        var sectionJson = """[{"id":"q1"}]""";
+        var response = """{"q1": {"answer": "Yes", "confidence": -1}}""";
+        AIProviderPayloadValidator.IsValidApplicationScoringJson(response, sectionJson).ShouldBeFalse();
+    }
+}

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/AIResponseJsonTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/AIResponseJsonTests.cs
@@ -1,0 +1,53 @@
+using Shouldly;
+using Unity.AI.Runtime;
+using Xunit;
+
+namespace Unity.GrantManager.AI.Runtime;
+
+public class AIResponseJsonTests
+{
+    [Theory]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+    [InlineData("   ", "")]
+    public void CleanJsonResponse_Should_ReturnEmpty_ForNullOrWhitespace(string? input, string expected)
+    {
+        AIResponseJson.CleanJsonResponse(input!).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void CleanJsonResponse_Should_StripMarkdownJsonFence_WithNewline()
+    {
+        var input = "```json\n{\"key\":\"value\"}\n```";
+        AIResponseJson.CleanJsonResponse(input).ShouldBe("{\"key\":\"value\"}");
+    }
+
+    [Fact]
+    public void CleanJsonResponse_Should_StripPlainFence_WithNewline()
+    {
+        var input = "```\n{\"key\":\"value\"}\n```";
+        AIResponseJson.CleanJsonResponse(input).ShouldBe("{\"key\":\"value\"}");
+    }
+
+    [Fact]
+    public void CleanJsonResponse_Should_StripTrailingFence_OnlyAfterContent()
+    {
+        var input = "{\"key\":\"value\"}```";
+        AIResponseJson.CleanJsonResponse(input).ShouldBe("{\"key\":\"value\"}");
+    }
+
+    [Fact]
+    public void CleanJsonResponse_Should_ReturnTrimmedJson_WithNoFences()
+    {
+        var input = "  {\"key\":\"value\"}  ";
+        AIResponseJson.CleanJsonResponse(input).ShouldBe("{\"key\":\"value\"}");
+    }
+
+    [Fact]
+    public void CleanJsonResponse_Should_HandleFenceWithoutNewline_UsingFirstJsonToken()
+    {
+        var input = "```json{\"key\":\"value\"}```";
+        var result = AIResponseJson.CleanJsonResponse(input);
+        result.ShouldBe("{\"key\":\"value\"}");
+    }
+}


### PR DESCRIPTION
## Pull request overview

Adds focused unit test coverage for AI runtime response-cleaning and payload-validation helpers. These helpers sit between raw model output and parser logic, so tests help lock down malformed-output handling without changing runtime behavior.

**Changes:**
- Adds `AIResponseJsonTests`.
- Adds `AIProviderPayloadValidatorTests`.
- Adds `InternalsVisibleTo("Unity.GrantManager.Application.Tests")` so internal runtime helpers can be tested directly.
- Covers blank/null input, markdown-wrapped JSON, malformed JSON, missing required fields, and scoring confidence bounds.