### PR TITLE
AB#32591 persist scoresheet panel state

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
@@ -309,19 +309,51 @@ $(function () {
         wrapper: '#assessmentScoresWidgetArea',
         filterCallback: function () {
             return {
-                assessmentId: decodeURIComponent($('#AssessmentId').val()),
+                assessmentId:
+                    selectedReviewDetails?.id ||
+                    decodeURIComponent($('#AssessmentId').val()),
                 currentUserId: decodeURIComponent(abp.currentUser.id),
             };
         },
     });
 
+    let assessmentScoresRefreshToken = 0;
+    function getAssessmentScoresWidgetElement() {
+        return document.getElementById('assessmentScoresWidgetArea');
+    }
+
+    function refreshAssessmentScoresWidget() {
+        const refreshToken = ++assessmentScoresRefreshToken;
+        globalThis.saveAssessmentScoresWidgetState?.(
+            getAssessmentScoresWidgetElement()
+        );
+
+        const refreshResult = assessmentScoresWidgetManager.refresh();
+
+        const afterRefresh = () => {
+            if (refreshToken !== assessmentScoresRefreshToken) {
+                return;
+            }
+
+            updateSubtotal();
+        };
+
+        if (refreshResult && typeof refreshResult.then === 'function') {
+            refreshResult.then(afterRefresh);
+        } else {
+            setTimeout(afterRefresh, 0);
+        }
+    }
+
     PubSub.subscribe('refresh_assessment_scores', (msg, data) => {
-        assessmentScoresWidgetManager.refresh();
-        updateSubtotal();
+        refreshAssessmentScoresWidget();
     });
 
     PubSub.subscribe('select_application_review', (msg, data) => {
         if (data) {
+            globalThis.saveAssessmentScoresWidgetState?.(
+                getAssessmentScoresWidgetElement()
+            );
             selectedReviewDetails = data;
             setDetailsContext('assessment');
             let selectElement = document.getElementById(
@@ -332,8 +364,7 @@ $(function () {
                 review: selectedReviewDetails,
             });
             assessmentUserDetailsWidgetManager.refresh();
-            assessmentScoresWidgetManager.refresh();
-            updateSubtotal();
+            refreshAssessmentScoresWidget();
             checkCurrentUser(data);
         } else {
             setDetailsContext('application');
@@ -341,6 +372,10 @@ $(function () {
     });
 
     PubSub.subscribe('deselect_application_review', (msg, data) => {
+        globalThis.saveAssessmentScoresWidgetState?.(
+            getAssessmentScoresWidgetElement()
+        );
+        assessmentScoresRefreshToken++;
         setDetailsContext('application');
     });
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentScoresWidget/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentScoresWidget/Default.js
@@ -1,3 +1,94 @@
+const assessmentScoresWidgetPanelStates = {};
+
+function getAssessmentScoresScrollContainer(wrapper) {
+    return (
+        wrapper.closest('.details-scrollable') ||
+        document.getElementById('detailsTabContent') ||
+        document.documentElement
+    );
+}
+
+function restoreAssessmentScoresScrollPosition(wrapper, scrollTop) {
+    if (!Number.isFinite(scrollTop)) {
+        return;
+    }
+
+    const container = getAssessmentScoresScrollContainer(wrapper);
+    const maxScroll = Math.max(
+        0,
+        container.scrollHeight - container.clientHeight
+    );
+    container.scrollTop = Math.min(scrollTop, maxScroll);
+}
+
+function getAssessmentScoresWidgetStateKey(wrapper) {
+    return wrapper.querySelector('#AssessmentId')?.value;
+}
+
+function saveAssessmentScoresWidgetState(wrapper) {
+    if (!wrapper) {
+        return;
+    }
+
+    const key = getAssessmentScoresWidgetStateKey(wrapper);
+    if (!key) {
+        return;
+    }
+
+    const scrollContainer = getAssessmentScoresScrollContainer(wrapper);
+    const scrollTop = scrollContainer.scrollTop;
+    const expandedCollapseIds = Array.from(
+        wrapper.querySelectorAll(
+            '#assessment-scoresheet .accordion-collapse.show'
+        )
+    )
+        .map((accordion) => accordion.id)
+        .filter(Boolean);
+
+    assessmentScoresWidgetPanelStates[key] = {
+        expandedCollapseIds,
+        scrollTop,
+    };
+}
+
+function restoreAssessmentScoresWidgetState(wrapper) {
+    const key = getAssessmentScoresWidgetStateKey(wrapper);
+    const state = assessmentScoresWidgetPanelStates[key];
+    if (!state) {
+        restoreAssessmentScoresScrollPosition(wrapper, 0);
+        return;
+    }
+
+    state.expandedCollapseIds.forEach((id) => {
+        const accordion = document.getElementById(id);
+        if (!accordion || !wrapper.contains(accordion)) {
+            return;
+        }
+
+        accordion.classList.add('show');
+        const accordionButton = accordion.previousElementSibling?.querySelector(
+            '.accordion-button'
+        );
+        accordionButton?.classList.remove('collapsed');
+        accordionButton?.setAttribute('aria-expanded', 'true');
+    });
+
+    requestAnimationFrame(() =>
+        restoreAssessmentScoresScrollPosition(wrapper, state.scrollTop)
+    );
+}
+
+globalThis.saveAssessmentScoresWidgetState = saveAssessmentScoresWidgetState;
+
+abp.widgets.AssessmentScoresWidget = function ($wrapper) {
+    return {
+        init: function () {
+            restoreAssessmentScoresWidgetState($wrapper[0]);
+            updateSubtotal();
+        },
+    };
+};
+
 function saveScoresSection(formId, sectionId) {
     const assessmentId = $('#AssessmentId').val();
     const secSaveButton = document.getElementById(


### PR DESCRIPTION
## Pull request overview

Implements AB#32591 by preserving Assessment Scores widget state while reviewers switch between scoresheets/application reviews.

This keeps the change scoped to the existing scoresheet panel. It does not redesign the panel, persist state across full page reloads, or save unrelated form/sensitive data.

**Changes:**
- Adds an in-page Assessment Scores widget state cache keyed by assessment ID.
- Saves expanded scoresheet drawer IDs and the current details-panel scroll position before switching reviews.
- Restores saved drawers and scroll position when returning to a previously viewed scoresheet.
- Resets the scoresheet scroll position to the top when no saved state exists.
- Keeps Assessment Scores widget refreshes aligned to the selected review, including stale refresh protection.
