### PR TITLE
AB#33006 enable GPT-5 mini profile compatibility

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIConfigurationResolver.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIConfigurationResolver.cs
@@ -7,6 +7,9 @@ namespace Unity.AI.Runtime;
 
 public class OpenAIConfigurationResolver(IConfiguration configuration) : ITransientDependency
 {
+    private static readonly string[] SupportedReasoningEfforts = ["minimal", "low", "medium", "high"];
+    private static readonly string[] SupportedVerbosityValues = ["low", "medium", "high"];
+
     private readonly IConfiguration _configuration = configuration;
 
     public string ResolveProviderName(string? operationName = null)
@@ -48,6 +51,16 @@ public class OpenAIConfigurationResolver(IConfiguration configuration) : ITransi
         }
 
         return null;
+    }
+
+    public string? ResolveConfiguredReasoningEffort(string? operationName = null)
+    {
+        return ResolveOptionalProfileValue(operationName, "ReasoningEffort", SupportedReasoningEfforts);
+    }
+
+    public string? ResolveConfiguredVerbosity(string? operationName = null)
+    {
+        return ResolveOptionalProfileValue(operationName, "Verbosity", SupportedVerbosityValues);
     }
 
     public int ResolveCompletionTokens(string operationName)
@@ -127,6 +140,26 @@ public class OpenAIConfigurationResolver(IConfiguration configuration) : ITransi
     private static string ProfileKey(string providerName, string profileName, string settingName)
     {
         return $"Azure:{providerName}:Profiles:{profileName}:{settingName}";
+    }
+
+    private string? ResolveOptionalProfileValue(string? operationName, string settingName, string[] supportedValues)
+    {
+        var providerName = ResolveProviderName(operationName);
+        var profileName = ResolveProfileName(operationName);
+        var configuredValue = OptionalProfile(providerName, profileName, settingName);
+        if (configuredValue == null)
+        {
+            return null;
+        }
+
+        var trimmedValue = configuredValue.Trim();
+        if (Array.Exists(supportedValues, supportedValue => string.Equals(supportedValue, trimmedValue, StringComparison.Ordinal)))
+        {
+            return trimmedValue;
+        }
+
+        throw new InvalidOperationException(
+            $"AI {settingName} value '{configuredValue}' is not supported. Use one of: {string.Join(", ", supportedValues)}.");
     }
 
     private static string CombineEndpointAndPath(string endpoint, string profilePath)

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAITransportService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAITransportService.cs
@@ -54,10 +54,23 @@ public class OpenAITransportService(
                 [_configurationResolver.ResolveMaxTokensParameterNameForOperation(operationName)] = maxTokens
             };
 
-            var resolvedTemperature = temperature ?? _configurationResolver.ResolveConfiguredTemperature(operationName);
+            var profileTemperature = _configurationResolver.ResolveConfiguredTemperature(operationName);
+            var resolvedTemperature = profileTemperature.HasValue ? temperature ?? profileTemperature : null;
             if (resolvedTemperature.HasValue)
             {
                 requestPayload["temperature"] = resolvedTemperature.Value;
+            }
+
+            var reasoningEffort = _configurationResolver.ResolveConfiguredReasoningEffort(operationName);
+            if (!string.IsNullOrWhiteSpace(reasoningEffort))
+            {
+                requestPayload["reasoning_effort"] = reasoningEffort;
+            }
+
+            var verbosity = _configurationResolver.ResolveConfiguredVerbosity(operationName);
+            if (!string.IsNullOrWhiteSpace(verbosity))
+            {
+                requestPayload["verbosity"] = verbosity;
             }
 
             var json = JsonSerializer.Serialize(requestPayload);
@@ -117,6 +130,11 @@ public class OpenAITransportService(
         catch (OperationCanceledException)
         {
             throw;
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(ex, "AI request configuration is invalid.");
+            return AIOperationResult.PermanentFailure(new AIProviderResult(ex.Message));
         }
         catch (Exception ex)
         {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.json
@@ -154,7 +154,7 @@
     "Operations": {
       "Defaults": {
         "Provider": "OpenAI",
-        "Profile": "Gpt4oMini",
+        "Profile": "Gpt5Mini",
         "PromptVersion": "v1",
         "ExecutionMode": "Sequential"
       },
@@ -179,7 +179,9 @@
         },
         "Gpt5Mini": {
           "ApiUrl": "/openai/deployments/gpt-5-mini/chat/completions?api-version=2024-10-01-preview",
-          "MaxTokensParameter": "max_completion_tokens"
+          "MaxTokensParameter": "max_completion_tokens",
+          "ReasoningEffort": "minimal",
+          "Verbosity": "low"
         }
       }
     },

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAIConfigurationResolverTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAIConfigurationResolverTests.cs
@@ -175,4 +175,54 @@ public class OpenAIConfigurationResolverTests
 
         resolver.ResolveConfiguredTemperature().ShouldBeNull();
     }
+
+    [Fact]
+    public void ResolveConfiguredReasoningEffort_Should_Return_ProfileValue()
+    {
+        var configuration = BuildProfileConfiguration("ReasoningEffort", "minimal");
+        var resolver = new OpenAIConfigurationResolver(configuration);
+
+        resolver.ResolveConfiguredReasoningEffort().ShouldBe("minimal");
+    }
+
+    [Fact]
+    public void ResolveConfiguredVerbosity_Should_Return_ProfileValue()
+    {
+        var configuration = BuildProfileConfiguration("Verbosity", "low");
+        var resolver = new OpenAIConfigurationResolver(configuration);
+
+        resolver.ResolveConfiguredVerbosity().ShouldBe("low");
+    }
+
+    [Fact]
+    public void ResolveConfiguredReasoningEffort_Should_ReturnNull_WhenProfileSettingMissing()
+    {
+        var configuration = BuildProfileConfiguration("Temperature", "0.3");
+        var resolver = new OpenAIConfigurationResolver(configuration);
+
+        resolver.ResolveConfiguredReasoningEffort().ShouldBeNull();
+    }
+
+    [Fact]
+    public void ResolveConfiguredVerbosity_Should_RejectUnsupportedValue()
+    {
+        var configuration = BuildProfileConfiguration("Verbosity", "verbose");
+        var resolver = new OpenAIConfigurationResolver(configuration);
+
+        var exception = Should.Throw<System.InvalidOperationException>(() => resolver.ResolveConfiguredVerbosity());
+        exception.Message.ShouldContain("Verbosity");
+        exception.Message.ShouldContain("low, medium, high");
+    }
+
+    private static IConfiguration BuildProfileConfiguration(string settingName, string settingValue)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Azure:Operations:Defaults:Provider"] = "OpenAI",
+                ["Azure:Operations:Defaults:Profile"] = "Gpt5Mini",
+                [$"Azure:OpenAI:Profiles:Gpt5Mini:{settingName}"] = settingValue
+            })
+            .Build();
+    }
 }

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAITransportServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAITransportServiceTests.cs
@@ -1,0 +1,131 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Unity.AI.Runtime;
+using Xunit;
+
+namespace Unity.GrantManager.AI.Runtime;
+
+public class OpenAITransportServiceTests
+{
+    [Fact]
+    public async Task GenerateSummaryAsync_Should_Include_ProfileReasoningEffortAndVerbosity()
+    {
+        var handler = new CaptureRequestHandler();
+        var resolver = CreateResolver(new Dictionary<string, string?>
+        {
+            ["Azure:OpenAI:Profiles:Gpt5Mini:ReasoningEffort"] = "minimal",
+            ["Azure:OpenAI:Profiles:Gpt5Mini:Verbosity"] = "low"
+        });
+
+        var service = new OpenAITransportService(
+            new HttpClient(handler),
+            resolver,
+            NullLogger<OpenAITransportService>.Instance);
+
+        await service.GenerateSummaryAsync("content", "system", 100);
+
+        using var payload = JsonDocument.Parse(handler.RequestContent);
+        payload.RootElement.GetProperty("reasoning_effort").GetString().ShouldBe("minimal");
+        payload.RootElement.GetProperty("verbosity").GetString().ShouldBe("low");
+        payload.RootElement.TryGetProperty("temperature", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GenerateSummaryAsync_Should_Omit_RequestTemperature_When_ProfileDoesNotSupportTemperature()
+    {
+        var handler = new CaptureRequestHandler();
+        var service = new OpenAITransportService(
+            new HttpClient(handler),
+            CreateResolver(),
+            NullLogger<OpenAITransportService>.Instance);
+
+        await service.GenerateSummaryAsync("content", "system", 100, temperature: 0.2);
+
+        using var payload = JsonDocument.Parse(handler.RequestContent);
+        payload.RootElement.TryGetProperty("temperature", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GenerateSummaryAsync_Should_ReturnPermanentFailure_When_ProfileOptionIsInvalid()
+    {
+        var handler = new CaptureRequestHandler();
+        var service = new OpenAITransportService(
+            new HttpClient(handler),
+            CreateResolver(new Dictionary<string, string?>
+            {
+                ["Azure:OpenAI:Profiles:Gpt5Mini:Verbosity"] = "verbose"
+            }),
+            NullLogger<OpenAITransportService>.Instance);
+
+        var result = await service.GenerateSummaryAsync("content", "system", 100);
+
+        result.Outcome.ShouldBe(AIOperationOutcome.PermanentFailure);
+        handler.SendCount.ShouldBe(0);
+    }
+
+    private static OpenAIConfigurationResolver CreateResolver(Dictionary<string, string?>? overrides = null)
+    {
+        var values = new Dictionary<string, string?>
+        {
+            ["Azure:Operations:Defaults:Provider"] = "OpenAI",
+            ["Azure:Operations:Defaults:Profile"] = "Gpt5Mini",
+            ["Azure:OpenAI:ApiKey"] = "test-key",
+            ["Azure:OpenAI:Endpoint"] = "https://example.test",
+            ["Azure:OpenAI:Profiles:Gpt5Mini:ApiUrl"] = "/openai/deployments/gpt-5-mini/chat/completions",
+            ["Azure:OpenAI:Profiles:Gpt5Mini:MaxTokensParameter"] = "max_completion_tokens"
+        };
+
+        if (overrides != null)
+        {
+            foreach (var item in overrides)
+            {
+                values[item.Key] = item.Value;
+            }
+        }
+
+        return new OpenAIConfigurationResolver(new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build());
+    }
+
+    private sealed class CaptureRequestHandler : HttpMessageHandler
+    {
+        public string RequestContent { get; private set; } = string.Empty;
+
+        public int SendCount { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            SendCount++;
+            RequestContent = request.Content == null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+
+            const string response = """
+                {
+                  "choices": [
+                    {
+                      "message": {
+                        "content": "generated"
+                      },
+                      "finish_reason": "stop"
+                    }
+                  ]
+                }
+                """;
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(response, Encoding.UTF8, "application/json")
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add GPT-5 mini as a configured AI profile and make it the default profile.
- Keep GPT-4o-mini available as a configured profile with temperature support.
- Add GPT-5-specific reasoning effort and verbosity request settings.

## Changes
- Configure `Azure:Operations:Defaults:Profile` to use `Gpt5Mini`.
- Add `ReasoningEffort` and `Verbosity` profile settings for GPT-5 mini.
- Keep temperature profile-scoped so GPT-5 mini can omit unsupported temperature settings.
- Include configured `reasoning_effort` and `verbosity` in OpenAI request payloads when present.
- Add resolver/payload tests for model-specific request settings.