### PR TITLE
Bugfix/ab#33047 collapse dismissed ai analysis sections

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.css
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.css
@@ -538,11 +538,6 @@ form label.error {
     line-height: 1.6;
 }
 
-.ai-analysis-section.compact .ai-analysis-section-body {
-    padding-top: 10px;
-    padding-bottom: 10px;
-}
-
 .ai-analysis-section.header-only .ai-analysis-section-body {
     display: none;
 }
@@ -643,6 +638,12 @@ form label.error {
 .ai-analysis-collapse-toggle:hover {
     color: #1f2937;
     background-color: #eef2f6;
+}
+
+.ai-analysis-collapse-toggle:disabled {
+    color: #9ca3af;
+    cursor: default;
+    pointer-events: none;
 }
 
 .ai-analysis-collapse-toggle:focus,

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-analysis.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-analysis.js
@@ -134,12 +134,18 @@ function createFindingItem(item, type, hidden) {
 
 function updateVisibleItemLayout($items) {
     const $allItems = $items.children('.ai-analysis-detail-item');
-    const $visibleItems = $allItems.filter(function() {
-        return this.style.display !== 'none';
-    });
+    const $visibleItems = getVisibleAnalysisItems($items);
 
     $allItems.removeClass('last-visible');
     $visibleItems.last().addClass('last-visible');
+}
+
+function getVisibleAnalysisItems($items) {
+    return $items
+        .children('.ai-analysis-detail-item')
+        .filter(function() {
+            return this.style.display !== 'none';
+        });
 }
 
 function formatSectionTitle(title, count) {
@@ -179,13 +185,9 @@ function setSectionCollapsed($section, $collapseToggle, isCollapsed) {
 }
 
 function syncSectionCollapseWithVisibleItems($section, $items, $collapseToggle) {
-    const hasVisibleItems = $items
-        .children('.ai-analysis-detail-item')
-        .filter(function() {
-            return this.style.display !== 'none';
-        })
-        .length > 0;
+    const hasVisibleItems = getVisibleAnalysisItems($items).length > 0;
 
+    $collapseToggle.prop('disabled', !hasVisibleItems);
     setSectionCollapsed($section, $collapseToggle, !hasVisibleItems);
 }
 
@@ -193,6 +195,10 @@ function configureCollapseToggle($section, $collapseToggle) {
     $collapseToggle
         .off('click')
         .on('click', function() {
+            if ($(this).prop('disabled')) {
+                return;
+            }
+
             const isCollapsed = $section.toggleClass('collapsed').hasClass('collapsed');
             setSectionCollapsed($section, $(this), isCollapsed);
         });

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-analysis.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-analysis.js
@@ -164,21 +164,37 @@ function configureSectionStatus($status, text, statusClass) {
         .show();
 }
 
-function configureCollapseToggle($section, $collapseToggle) {
+function setSectionCollapsed($section, $collapseToggle, isCollapsed) {
     const labels = getAnalysisLabels();
+    const $icon = $collapseToggle.find('i');
+
+    $section.toggleClass('collapsed', isCollapsed);
+    $collapseToggle
+        .attr('aria-expanded', (!isCollapsed).toString())
+        .attr('title', isCollapsed ? labels.expandTitle : labels.collapseTitle);
+
+    $icon
+        .toggleClass('fa-chevron-down', !isCollapsed)
+        .toggleClass('fa-chevron-up', isCollapsed);
+}
+
+function syncSectionCollapseWithVisibleItems($section, $items, $collapseToggle) {
+    const hasVisibleItems = $items
+        .children('.ai-analysis-detail-item')
+        .filter(function() {
+            return this.style.display !== 'none';
+        })
+        .length > 0;
+
+    setSectionCollapsed($section, $collapseToggle, !hasVisibleItems);
+}
+
+function configureCollapseToggle($section, $collapseToggle) {
     $collapseToggle
         .off('click')
         .on('click', function() {
             const isCollapsed = $section.toggleClass('collapsed').hasClass('collapsed');
-            const $icon = $(this).find('i');
-
-            $(this)
-                .attr('aria-expanded', (!isCollapsed).toString())
-                .attr('title', isCollapsed ? labels.expandTitle : labels.collapseTitle);
-
-            $icon
-                .toggleClass('fa-chevron-down', !isCollapsed)
-                .toggleClass('fa-chevron-up', isCollapsed);
+            setSectionCollapsed($section, $(this), isCollapsed);
         });
 }
 
@@ -214,7 +230,7 @@ function appendSectionItems($items, section, isDismissedVisible) {
     updateVisibleItemLayout($items);
 }
 
-function configureDismissedItemsToggle($items, $toggle, section, isDismissedVisible) {
+function configureDismissedItemsToggle($section, $items, $toggle, $collapseToggle, section, isDismissedVisible) {
     const labels = getAnalysisLabels();
     const hiddenCount = section.hiddenItems.length;
 
@@ -239,6 +255,7 @@ function configureDismissedItemsToggle($items, $toggle, section, isDismissedVisi
             dismissedSectionVisibility[section.itemType] = shouldShow;
             $items.find('.dismissed-item').toggle(shouldShow);
             updateVisibleItemLayout($items);
+            syncSectionCollapseWithVisibleItems($section, $items, $collapseToggle);
             $toggle.text(shouldShow ? labels.hideDismissed : labels.showDismissed);
         });
 }
@@ -250,7 +267,6 @@ function renderSection(section) {
 
     $section
         .addClass(section.sectionClass)
-        .toggleClass('compact', section.activeItems.length === 0)
         .toggleClass('header-only', !section.hasItems);
 
     const $items = $section.find('[data-element="items"]');
@@ -264,7 +280,8 @@ function renderSection(section) {
     $collapseToggle.toggle(section.hasItems);
 
     appendSectionItems($items, section, isDismissedVisible);
-    configureDismissedItemsToggle($items, $toggle, section, isDismissedVisible);
+    configureDismissedItemsToggle($section, $items, $toggle, $collapseToggle, section, isDismissedVisible);
+    syncSectionCollapseWithVisibleItems($section, $items, $collapseToggle);
 
     return $section;
 }


### PR DESCRIPTION
## Summary

Fixes AI Application Analysis sections so they collapse when no items are visible and cannot be expanded into an empty body.

## Changes

- Reuses a single visible-item lookup for analysis item layout and collapse checks.
- Disables the section collapse toggle when all items are dismissed/hidden.
- Adds a disabled visual state for the collapse toggle.