### PR TITLE
AB#33055 fix AI generate cooldown wait state

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/RateLimit/AIRateLimitStateDto.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/RateLimit/AIRateLimitStateDto.cs
@@ -3,4 +3,5 @@ namespace Unity.AI.RateLimit;
 public class AIRateLimitStateDto
 {
     public int RetryAfterSeconds { get; set; }
+    public bool IsGenerating { get; set; }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/RateLimit/IAIGenerationActivityProvider.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/RateLimit/IAIGenerationActivityProvider.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace Unity.AI.RateLimit;
+
+public interface IAIGenerationActivityProvider
+{
+    Task<bool> HasActiveGenerationAsync();
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/RateLimit/IAIRateLimiter.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/RateLimit/IAIRateLimiter.cs
@@ -22,8 +22,8 @@ public interface IAIRateLimiter
     Task StampAsync(Guid? userId);
 
     /// <summary>
-    /// Returns the remaining cooldown for the current user. RetryAfterSeconds is 0 when
-    /// the user can generate immediately.
+    /// Returns the current user's shared AI generation state. RetryAfterSeconds is 0 when
+    /// the user can generate immediately, unless a generation is still active.
     /// </summary>
     Task<AIRateLimitStateDto> GetStateAsync();
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/RateLimit/AIRateLimiter.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/RateLimit/AIRateLimiter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
 using Medallion.Threading;
@@ -20,7 +21,8 @@ public class AIRateLimiter(
     IDistributedCache cache,
     ICurrentUser currentUser,
     IConfiguration configuration,
-    IDistributedLockProvider distributedLockProvider) : IAIRateLimiter, ITransientDependency
+    IDistributedLockProvider distributedLockProvider,
+    IEnumerable<IAIGenerationActivityProvider> generationActivityProviders) : IAIRateLimiter, ITransientDependency
 {
     private const string CooldownKeyPrefix = "ai-generation:cooldown:";
     private const string CooldownLockPrefix = "ai-generation:cooldown-lock:";
@@ -81,7 +83,7 @@ public class AIRateLimiter(
     {
         if (currentUser.Id is not Guid userId)
         {
-            return new AIRateLimitStateDto { RetryAfterSeconds = 0 };
+            return new AIRateLimitStateDto { RetryAfterSeconds = 0, IsGenerating = false };
         }
 
         var userLock = distributedLockProvider.CreateLock(CooldownLockPrefix + userId);
@@ -89,9 +91,23 @@ public class AIRateLimiter(
         {
             return new AIRateLimitStateDto
             {
-                RetryAfterSeconds = await GetRemainingSecondsAsync(userId)
+                RetryAfterSeconds = await GetRemainingSecondsAsync(userId),
+                IsGenerating = await HasActiveGenerationAsync()
             };
         }
+    }
+
+    private async Task<bool> HasActiveGenerationAsync()
+    {
+        foreach (var provider in generationActivityProviders)
+        {
+            if (await provider.HasActiveGenerationAsync())
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private async Task<int> GetRemainingSecondsAsync(Guid userId)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/AIGenerationActivityProvider.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/AIGenerationActivityProvider.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Unity.AI.RateLimit;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.Linq;
+using Volo.Abp.MultiTenancy;
+using Volo.Abp.Users;
+
+namespace Unity.GrantManager.GrantApplications.Automation;
+
+public class AIGenerationActivityProvider(
+    IRepository<AIGenerationRequest, Guid> generationRequestRepository,
+    ICurrentUser currentUser,
+    ICurrentTenant currentTenant,
+    IAsyncQueryableExecuter asyncExecuter) : IAIGenerationActivityProvider, ITransientDependency
+{
+    public async Task<bool> HasActiveGenerationAsync()
+    {
+        if (currentUser.Id is not Guid userId)
+        {
+            return false;
+        }
+
+        var query = await generationRequestRepository.GetQueryableAsync();
+        return await asyncExecuter.AnyAsync(query.Where(x =>
+            x.CreatorId == userId &&
+            x.TenantId == currentTenant.Id &&
+            (x.Status == AIGenerationRequestStatus.Queued || x.Status == AIGenerationRequestStatus.Running)));
+    }
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.cshtml
@@ -422,7 +422,7 @@
                         <h6 class="fw-bold m-0">Application Analysis</h6>
                         @if (aiApplicationAnalysisGenerateEnabled)
                         {
-                            <button type="button" class="btn unt-btn-outline-primary btn-outline-primary ai-generate-btn" id="regenerateApplicationAnalysis">
+                            <button type="button" class="btn unt-btn-outline-primary btn-outline-primary ai-generate-btn" id="regenerateApplicationAnalysis" data-ai-cooldown-checking="1" data-ai-rate-limit-disabled="1" disabled>
                                 <span class="ai-button-content">
                                     <i class="unt-icon-sm fa-solid fa-wand-sparkles"></i>
                                     <span>Generate</span>

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
@@ -288,6 +288,7 @@ $(function () {
             }
 
             updateSubtotal();
+            globalThis.syncAIRateLimitButtons?.();
         };
 
         if (refreshResult && typeof refreshResult.then === 'function') {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-analysis.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-analysis.js
@@ -455,10 +455,9 @@ globalThis.queueApplicationAnalysis = function(triggerButton = null) {
             const status = globalThis.AIGenerationButtonState?.resolveStatus(request?.status) ?? '';
 
             if (status === 'Completed') {
-                globalThis.AIGenerationButtonState?.restore($button);
-                $button.html(existingHtml).prop('disabled', false);
+                globalThis.AIGenerationButtonState?.restoreForCooldownCheck($button, existingHtml);
                 loadAIAnalysis();
-                globalThis.refreshAIRateLimitState?.();
+                globalThis.syncAIRateLimitButtons?.();
                 return;
             }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-analysis.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-analysis.js
@@ -468,6 +468,7 @@ globalThis.queueApplicationAnalysis = function(triggerButton = null) {
             aiAnalysisMonitor?.stop();
             globalThis.AIGenerationButtonState?.restore($button);
             $button.html(existingHtml).prop('disabled', false);
+            globalThis.syncAIRateLimitButtons?.();
             abp.message.error('Failed to queue AI analysis. Please try again.');
         });
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-generation-button-state.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-generation-button-state.js
@@ -15,6 +15,15 @@
         $button.html(html).prop('disabled', false);
     }
 
+    function restoreButtonForCooldownCheck($button, html) {
+        global.AIGenerationButtonState.restore($button);
+        $button
+            .html(html)
+            .attr('data-ai-cooldown-checking', '1')
+            .attr('data-ai-rate-limit-disabled', '1')
+            .prop('disabled', true);
+    }
+
     global.AIGenerationButtonState = {
         resolveStatus(status) {
             switch (Number(status)) {
@@ -47,6 +56,9 @@
                 opacity: '',
             }).removeClass('disabled');
         },
+        restoreForCooldownCheck($button, html) {
+            restoreButtonForCooldownCheck($button, html);
+        },
         monitor(options) {
             const intervalMs = options.intervalMs || 15000;
             const maxFailures = options.maxFailures || 3;
@@ -75,9 +87,9 @@
 
                         if (!request || request.isActive === false || status === 'Completed') {
                             stop();
-                            restoreButton(options.$button, options.originalHtml);
+                            restoreButtonForCooldownCheck(options.$button, options.originalHtml);
                             options.onComplete?.(request);
-                            global.refreshAIRateLimitState?.();
+                            global.syncAIRateLimitButtons?.();
                             return;
                         }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-generation-button-state.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-generation-button-state.js
@@ -1,15 +1,4 @@
 (function (global) {
-    const generatingStyles = {
-        'background-color': '#f1f3f5',
-        'border-color': '#adb5bd',
-        color: '#495057',
-        opacity: '1',
-    };
-
-    function applyStyles($button, styles) {
-        $button.css(styles);
-    }
-
     function restoreButton($button, html) {
         global.AIGenerationButtonState.restore($button);
         $button.html(html).prop('disabled', false);
@@ -40,21 +29,10 @@
             }
         },
         setGenerating($button) {
-            $button.removeAttr('data-ai-cooldown-active');
-            $button.attr('data-ai-generating', '1');
-            $button
-                .html('<span class="ai-button-content"><span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span><span>Generating...</span></span>')
-                .prop('disabled', true);
-            applyStyles($button, generatingStyles);
+            global.setAIGenerationButtonsGenerating?.();
         },
         restore($button) {
-            $button.removeAttr('data-ai-generating');
-            $button.css({
-                'background-color': '',
-                'border-color': '',
-                color: '',
-                opacity: '',
-            }).removeClass('disabled');
+            $button.removeClass('disabled');
         },
         restoreForCooldownCheck($button, html) {
             restoreButtonForCooldownCheck($button, html);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-rate-limit.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-rate-limit.js
@@ -1,9 +1,6 @@
-/* AB#32290 — per-user 60s cooldown for AI Generate buttons.
- * Server stamps the cooldown; this module only mirrors that state in the UI.
- * Strategy: on load, fetch the user's remaining seconds and disable every
- * .ai-generate-btn with a countdown. After any generate click resolves we
- * re-fetch (a successful click sets a new cooldown; a failed/blocked click
- * may report the existing one). KISS — no per-button logic, no mutex.
+/* AB#32290 — shared per-user AI Generate button state.
+ * Server owns active-generation and cooldown state; this module mirrors it
+ * across every .ai-generate-btn so all AI surfaces behave consistently.
  */
 (function () {
     const BUTTON_SELECTOR = '.ai-generate-btn';
@@ -11,10 +8,13 @@
     const ATTR_COOLDOWN = 'data-ai-cooldown-active';
     const ATTR_CHECKING = 'data-ai-cooldown-checking';
     const ATTR_OWNED_DISABLED = 'data-ai-rate-limit-disabled';
+    const ATTR_SHARED_GENERATING = 'data-ai-shared-generating';
 
     let countdownTimer = null;
+    let statePollTimer = null;
     let lastFetchAt = 0;
     let remainingSeconds = 0;
+    let currentState = { mode: 'checking' };
 
     function buttons() {
         return document.querySelectorAll(BUTTON_SELECTOR);
@@ -37,10 +37,7 @@
     }
 
     function disable(btn, seconds) {
-        if (btn.getAttribute('data-ai-generating') === '1') {
-            return;
-        }
-
+        btn.removeAttribute(ATTR_SHARED_GENERATING);
         rememberLabel(btn);
         if (!btn.disabled || btn.getAttribute(ATTR_OWNED_DISABLED) === '1') {
             btn.setAttribute(ATTR_OWNED_DISABLED, '1');
@@ -52,8 +49,15 @@
     }
 
     function restore(btn) {
-        if (btn.getAttribute(ATTR_COOLDOWN) !== '1') return;
+        if (
+            btn.getAttribute(ATTR_COOLDOWN) !== '1' &&
+            btn.getAttribute(ATTR_SHARED_GENERATING) !== '1'
+        ) {
+            return;
+        }
+
         btn.removeAttribute(ATTR_COOLDOWN);
+        btn.removeAttribute(ATTR_SHARED_GENERATING);
         if (btn.getAttribute(ATTR_OWNED_DISABLED) === '1') {
             btn.removeAttribute(ATTR_OWNED_DISABLED);
             btn.removeAttribute('disabled');
@@ -64,10 +68,7 @@
     }
 
     function setChecking(btn) {
-        if (
-            btn.getAttribute(ATTR_CHECKING) === '1' ||
-            btn.getAttribute('data-ai-generating') === '1'
-        ) {
+        if (btn.getAttribute(ATTR_CHECKING) === '1') {
             return;
         }
 
@@ -91,7 +92,8 @@
     }
 
     function disableUntilChecked() {
-        buttons().forEach(setChecking);
+        currentState = { mode: 'checking' };
+        renderState();
     }
 
     function clearCheckingButtons() {
@@ -105,28 +107,105 @@
         }
     }
 
+    function clearStatePollTimer() {
+        if (statePollTimer) {
+            clearTimeout(statePollTimer);
+            statePollTimer = null;
+        }
+    }
+
+    function setOwnedDisabled(btn) {
+        if (!btn.disabled || btn.getAttribute(ATTR_OWNED_DISABLED) === '1') {
+            btn.setAttribute(ATTR_OWNED_DISABLED, '1');
+            btn.setAttribute('disabled', 'disabled');
+        }
+    }
+
+    function applyGenerating() {
+        currentState = { mode: 'generating' };
+        renderState();
+
+        clearStatePollTimer();
+        statePollTimer = setTimeout(() => fetchState(true), 2000);
+    }
+
+    function renderGenerating() {
+        clearCheckingButtons();
+        clearTimer();
+        remainingSeconds = 0;
+        buttons().forEach(btn => {
+            rememberLabel(btn);
+            btn.removeAttribute(ATTR_COOLDOWN);
+            btn.setAttribute(ATTR_SHARED_GENERATING, '1');
+            setOwnedDisabled(btn);
+            btn.classList.add('disabled');
+            setLabel(btn, 'Generating...');
+        });
+    }
+
     function applyCooldownToButtons() {
         buttons().forEach(b => disable(b, remainingSeconds));
     }
 
     function applyCooldown(seconds) {
+        currentState = { mode: 'cooldown', seconds: Number(seconds) || 0 };
+        renderState();
+    }
+
+    function renderCooldown(seconds) {
         clearCheckingButtons();
         clearTimer();
-        remainingSeconds = Number(seconds) || 0;
+        clearStatePollTimer();
+        remainingSeconds = seconds;
         if (remainingSeconds <= 0) {
+            currentState = { mode: 'available' };
             buttons().forEach(restore);
             return;
         }
         applyCooldownToButtons();
         countdownTimer = setInterval(() => {
             remainingSeconds -= 1;
+            currentState = { mode: 'cooldown', seconds: remainingSeconds };
             if (remainingSeconds <= 0) {
                 clearTimer();
+                currentState = { mode: 'available' };
                 buttons().forEach(restore);
                 return;
             }
             applyCooldownToButtons();
         }, 1000);
+    }
+
+    function renderState() {
+        if (currentState.mode === 'generating') {
+            renderGenerating();
+            return;
+        }
+
+        if (currentState.mode === 'cooldown') {
+            renderCooldown(currentState.seconds);
+            return;
+        }
+
+        if (currentState.mode === 'checking') {
+            buttons().forEach(setChecking);
+            return;
+        }
+
+        clearCheckingButtons();
+        clearTimer();
+        clearStatePollTimer();
+        buttons().forEach(restore);
+    }
+
+    function retryStateFetch() {
+        clearStatePollTimer();
+        statePollTimer = setTimeout(() => fetchState(true), 2000);
+    }
+
+    function handleStateFetchFailure() {
+        renderState();
+        retryStateFetch();
     }
 
     async function fetchState(force = false) {
@@ -140,29 +219,33 @@
                 headers: { Accept: 'application/json' },
             });
             if (!res.ok) {
-                clearCheckingButtons();
+                handleStateFetchFailure();
                 return;
             }
             const data = await res.json();
+            if (data.isGenerating === true) {
+                applyGenerating();
+                return;
+            }
+
             applyCooldown(Number(data.retryAfterSeconds) || 0);
         } catch (_) {
             // Best-effort; the server is the source of truth.
-            clearCheckingButtons();
+            handleStateFetchFailure();
         }
     }
 
     globalThis.syncAIRateLimitButtons = () => {
-        disableUntilChecked();
+        renderState();
         fetchState(true);
     };
+    globalThis.setAIGenerationButtonsGenerating = applyGenerating;
     globalThis.refreshAIRateLimitState = globalThis.syncAIRateLimitButtons;
 
     document.addEventListener('click', (e) => {
         const btn = e.target.closest(BUTTON_SELECTOR);
         if (!btn) return;
-        // Re-check shortly after the click so a successful generate immediately
-        // shows the fresh 60s cooldown.
-        setTimeout(fetchState, 250);
+        applyGenerating();
     });
 
     document.addEventListener('DOMContentLoaded', () => {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-rate-limit.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-rate-limit.js
@@ -9,9 +9,12 @@
     const BUTTON_SELECTOR = '.ai-generate-btn';
     const ATTR_LABEL = 'data-original-label';
     const ATTR_COOLDOWN = 'data-ai-cooldown-active';
+    const ATTR_CHECKING = 'data-ai-cooldown-checking';
+    const ATTR_OWNED_DISABLED = 'data-ai-rate-limit-disabled';
 
     let countdownTimer = null;
     let lastFetchAt = 0;
+    let remainingSeconds = 0;
 
     function buttons() {
         return document.querySelectorAll(BUTTON_SELECTOR);
@@ -39,6 +42,9 @@
         }
 
         rememberLabel(btn);
+        if (!btn.disabled || btn.getAttribute(ATTR_OWNED_DISABLED) === '1') {
+            btn.setAttribute(ATTR_OWNED_DISABLED, '1');
+        }
         btn.setAttribute(ATTR_COOLDOWN, '1');
         btn.setAttribute('disabled', 'disabled');
         btn.classList.add('disabled');
@@ -48,10 +54,48 @@
     function restore(btn) {
         if (btn.getAttribute(ATTR_COOLDOWN) !== '1') return;
         btn.removeAttribute(ATTR_COOLDOWN);
-        btn.removeAttribute('disabled');
+        if (btn.getAttribute(ATTR_OWNED_DISABLED) === '1') {
+            btn.removeAttribute(ATTR_OWNED_DISABLED);
+            btn.removeAttribute('disabled');
+        }
         btn.classList.remove('disabled');
         const original = btn.getAttribute(ATTR_LABEL);
         if (original) setLabel(btn, original);
+    }
+
+    function setChecking(btn) {
+        if (
+            btn.getAttribute(ATTR_CHECKING) === '1' ||
+            btn.getAttribute('data-ai-generating') === '1'
+        ) {
+            return;
+        }
+
+        btn.setAttribute(ATTR_CHECKING, '1');
+        if (!btn.disabled || btn.getAttribute(ATTR_OWNED_DISABLED) === '1') {
+            btn.setAttribute(ATTR_OWNED_DISABLED, '1');
+            btn.setAttribute('disabled', 'disabled');
+        }
+    }
+
+    function clearChecking(btn) {
+        if (btn.getAttribute(ATTR_CHECKING) !== '1') {
+            return;
+        }
+
+        btn.removeAttribute(ATTR_CHECKING);
+        if (btn.getAttribute(ATTR_OWNED_DISABLED) === '1') {
+            btn.removeAttribute(ATTR_OWNED_DISABLED);
+            btn.removeAttribute('disabled');
+        }
+    }
+
+    function disableUntilChecked() {
+        buttons().forEach(setChecking);
+    }
+
+    function clearCheckingButtons() {
+        buttons().forEach(clearChecking);
     }
 
     function clearTimer() {
@@ -61,24 +105,27 @@
         }
     }
 
+    function applyCooldownToButtons() {
+        buttons().forEach(b => disable(b, remainingSeconds));
+    }
+
     function applyCooldown(seconds) {
+        clearCheckingButtons();
         clearTimer();
-        if (!seconds || seconds <= 0) {
+        remainingSeconds = Number(seconds) || 0;
+        if (remainingSeconds <= 0) {
             buttons().forEach(restore);
             return;
         }
-        let remaining = seconds;
-        buttons().forEach(b => disable(b, remaining));
+        applyCooldownToButtons();
         countdownTimer = setInterval(() => {
-            remaining -= 1;
-            if (remaining <= 0) {
+            remainingSeconds -= 1;
+            if (remainingSeconds <= 0) {
                 clearTimer();
                 buttons().forEach(restore);
                 return;
             }
-            buttons().forEach(b => {
-                if (b.getAttribute(ATTR_COOLDOWN) === '1') setLabel(b, `Wait ${remaining}s`);
-            });
+            applyCooldownToButtons();
         }, 1000);
     }
 
@@ -92,15 +139,23 @@
                 credentials: 'same-origin',
                 headers: { Accept: 'application/json' },
             });
-            if (!res.ok) return;
+            if (!res.ok) {
+                clearCheckingButtons();
+                return;
+            }
             const data = await res.json();
             applyCooldown(Number(data.retryAfterSeconds) || 0);
         } catch (_) {
             // Best-effort; the server is the source of truth.
+            clearCheckingButtons();
         }
     }
 
-    globalThis.refreshAIRateLimitState = () => fetchState(true);
+    globalThis.syncAIRateLimitButtons = () => {
+        disableUntilChecked();
+        fetchState(true);
+    };
+    globalThis.refreshAIRateLimitState = globalThis.syncAIRateLimitButtons;
 
     document.addEventListener('click', (e) => {
         const btn = e.target.closest(BUTTON_SELECTOR);
@@ -110,6 +165,13 @@
         setTimeout(fetchState, 250);
     });
 
-    document.addEventListener('DOMContentLoaded', () => fetchState());
-    if (document.readyState !== 'loading') fetchState();
+    document.addEventListener('DOMContentLoaded', () => {
+        disableUntilChecked();
+        fetchState();
+    });
+
+    if (document.readyState !== 'loading') {
+        disableUntilChecked();
+        fetchState();
+    }
 })();

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentScoresWidget/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentScoresWidget/Default.cshtml
@@ -26,7 +26,7 @@
                 <div class="d-flex justify-content-end flex-wrap gap-2 scoresheet-top-btn-group">
                     @if (Model.IsAIScoringEnabled && Model.IsAiAssessment)
                     {
-                        <button type="button" class="btn unt-btn-outline-primary btn-outline-primary ai-generate-btn" id="regenerateAiScoresheetBtn" onclick="queueApplicationScoring()">
+                        <button type="button" class="btn unt-btn-outline-primary btn-outline-primary ai-generate-btn" id="regenerateAiScoresheetBtn" onclick="queueApplicationScoring()" data-ai-cooldown-checking="1" data-ai-rate-limit-disabled="1" disabled>
                             <span class="ai-button-content">
                                 <i class="unt-icon-sm fa-solid fa-wand-sparkles"></i>
                                 <span>Generate</span>

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentScoresWidget/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentScoresWidget/Default.js
@@ -85,6 +85,7 @@ abp.widgets.AssessmentScoresWidget = function ($wrapper) {
         init: function () {
             restoreAssessmentScoresWidgetState($wrapper[0]);
             updateSubtotal();
+            globalThis.syncAIRateLimitButtons?.();
         },
     };
 };
@@ -697,10 +698,9 @@ function queueApplicationScoring(triggerButton = null) {
             const status = globalThis.AIGenerationButtonState?.resolveStatus(request?.status) ?? '';
 
             if (status === 'Completed') {
-                globalThis.AIGenerationButtonState?.restore($button);
-                $button.html(existingHtml).prop('disabled', false);
+                globalThis.AIGenerationButtonState?.restoreForCooldownCheck($button, existingHtml);
                 PubSub.publish('refresh_assessment_scores', null);
-                globalThis.refreshAIRateLimitState?.();
+                globalThis.syncAIRateLimitButtons?.();
                 return;
             }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentScoresWidget/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentScoresWidget/Default.js
@@ -712,5 +712,6 @@ function queueApplicationScoring(triggerButton = null) {
             );
             globalThis.AIGenerationButtonState?.restore($button);
             $button.html(existingHtml).prop('disabled', false);
+            globalThis.syncAIRateLimitButtons?.();
         });
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/ChefsAttachments.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/ChefsAttachments.js
@@ -214,7 +214,7 @@ $(function () {
                         abp.notify.success('AI summaries generated successfully.');
                         globalThis.AIGenerationButtonState?.restore($activeButton);
                         $activeButton.html(existingHTML).prop('disabled', false);
-                        globalThis.refreshAIRateLimitState?.();
+                        globalThis.syncAIRateLimitButtons?.();
                         return;
                     }
 
@@ -226,6 +226,7 @@ $(function () {
                     globalThis.AIGenerationButtonState?.restore($activeButton);
                     $activeButton.html(existingHTML).prop('disabled', false);
                     setGenerateSummariesEnabled();
+                    globalThis.syncAIRateLimitButtons?.();
                 });
         });
     }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ReviewList/ReviewList.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ReviewList/ReviewList.js
@@ -61,6 +61,7 @@ $(function () {
         },
         generateAiButton: {
             extend: 'unityWorkflow',
+            className: 'btn btn-light rounded-1 ai-generate-btn',
             text: generateAiButtonText,
             action: generateAiButtonAction
         },
@@ -237,6 +238,7 @@ $(function () {
         let generateButtons = new $.fn.dataTable.Buttons(reviewListTable, assessmentGenerateButtonGroup);
         generateButtons.container().appendTo("#AdjudicationTeamLeadActionBar");
         reviewListTable.buttons('Generate:name').enable();
+        globalThis.syncAIRateLimitButtons?.();
         resumeActiveReviewListAiButton(reviewListTable);
     }
 
@@ -474,9 +476,9 @@ function generateAiButtonAction(e, dt, button, config) {
             const status = globalThis.AIGenerationButtonState?.resolveStatus(request?.status) ?? '';
 
             if (status === 'Completed') {
-                restoreReviewListAiButton($button);
+                restoreReviewListAiButtonForCooldownCheck($button);
                 refreshReviewListAfterAiScoring();
-                globalThis.refreshAIRateLimitState?.();
+                globalThis.syncAIRateLimitButtons?.();
                 return;
             }
 
@@ -496,6 +498,14 @@ function restoreReviewListAiButton($button) {
 
     globalThis.AIGenerationButtonState?.restore($button);
     $button.html(generateAiButtonText(null, null, null)).prop('disabled', false);
+}
+
+function restoreReviewListAiButtonForCooldownCheck($button) {
+    if (!$button?.length) {
+        return;
+    }
+
+    globalThis.AIGenerationButtonState?.restoreForCooldownCheck($button, generateAiButtonText(null, null, null));
 }
 
 function resumeActiveReviewListAiButton(reviewListTable) {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ReviewList/ReviewList.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ReviewList/ReviewList.js
@@ -487,6 +487,7 @@ function generateAiButtonAction(e, dt, button, config) {
         .fail(function () {
             abp.message.error('Failed to queue AI scoring. Please try again.');
             restoreReviewListAiButton($button);
+            globalThis.syncAIRateLimitButtons?.();
         })
         ;
 }

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/RateLimit/AIRateLimiterTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/RateLimit/AIRateLimiterTests.cs
@@ -34,13 +34,27 @@ public class AIRateLimiterTests
             }).Build();
     }
 
-    private AIRateLimiter NewLimiter() => new(_cache, _currentUser, _configuration, new TestDistributedLockProvider());
+    private AIRateLimiter NewLimiter(params IAIGenerationActivityProvider[] activityProviders) =>
+        new(_cache, _currentUser, _configuration, new TestDistributedLockProvider(), activityProviders);
 
     [Fact]
     public async Task GetStateAsync_Returns_Zero_When_NoCooldown()
     {
         var state = await NewLimiter().GetStateAsync();
         state.RetryAfterSeconds.ShouldBe(0);
+        state.IsGenerating.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetStateAsync_Returns_Generating_When_ActivityProvider_HasActiveGeneration()
+    {
+        var activityProvider = Substitute.For<IAIGenerationActivityProvider>();
+        activityProvider.HasActiveGenerationAsync().Returns(true);
+
+        var state = await NewLimiter(activityProvider).GetStateAsync();
+
+        state.RetryAfterSeconds.ShouldBe(0);
+        state.IsGenerating.ShouldBeTrue();
     }
 
     [Fact]
@@ -119,7 +133,7 @@ public class AIRateLimiterTests
             {
                 ["Azure:Generation:CooldownSeconds"] = "1"
             }).Build();
-        var limiter = new AIRateLimiter(_cache, _currentUser, config, new TestDistributedLockProvider());
+        var limiter = new AIRateLimiter(_cache, _currentUser, config, new TestDistributedLockProvider(), []);
 
         await limiter.StampAsync();
         await Task.Delay(TimeSpan.FromSeconds(1.2), CancellationToken.None);
@@ -142,7 +156,7 @@ public class AIRateLimiterTests
             .AddInMemoryCollection(values)
             .Build();
 
-        var limiter = new AIRateLimiter(_cache, _currentUser, config, new TestDistributedLockProvider());
+        var limiter = new AIRateLimiter(_cache, _currentUser, config, new TestDistributedLockProvider(), []);
 
         var ex = await Should.ThrowAsync<AbpException>(() => limiter.StampAsync());
         ex.Message.ShouldContain("Azure:Generation:CooldownSeconds");


### PR DESCRIPTION
## Summary

AB#33055 fixes AI Generate buttons not consistently showing the shared `Generating...` and `Wait Ns` states across Grant Application AI surfaces.

## Changes

- Adds active generation state to the shared AI rate-limit endpoint.
- Updates AI Generate buttons to use one shared client state: checking, generating, cooldown, or available.
- Syncs AI Analysis, Attachment Summary, Assessment Scores, and Review List Generate buttons through the shared state.
- Keeps the current button state and retries when the shared AI state endpoint cannot be reached.
- Preserves existing disabled states owned by each UI surface.