### PR TITLE
bugfix/AB#32785 - Fix tag menu slider overflow and height issues

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ConfigurationManagement/Index.css
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ConfigurationManagement/Index.css
@@ -46,6 +46,21 @@
     width: 95%;
 }
 
+#tags-div.config-management {
+    overflow: visible;
+    max-height: none;
+}
+
+#tags-div .dt-scroll-body {
+    overflow-y: visible !important;
+    max-height: none !important;
+}
+
+#tags-div .dt-container {
+    max-height: none !important;
+    overflow-y: visible !important;
+}
+
 /* When scroll-managed components are embedded in the config container,
    constrain their height so the container's padding is visible at the bottom */
 .config-management .scoresheet-scrollable-content,
@@ -57,6 +72,11 @@
     margin: auto;
     display: flex;
     align-items: flex-start;
+}
+
+.unity-app-container:has(.config-page-layout) {
+    height: auto;
+    min-height: 100%;
 }
 
 .hide {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ConfigurationManagement/Index.css
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ConfigurationManagement/Index.css
@@ -51,14 +51,10 @@
     max-height: none;
 }
 
-#tags-div .dt-scroll-body {
-    overflow-y: visible !important;
-    max-height: none !important;
-}
-
+#tags-div .dt-scroll-body,
 #tags-div .dt-container {
-    max-height: none !important;
     overflow-y: visible !important;
+    max-height: none !important;
 }
 
 /* When scroll-managed components are embedded in the config container,

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ConfigurationManagement/Index.css
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ConfigurationManagement/Index.css
@@ -46,11 +46,7 @@
     width: 95%;
 }
 
-#tags-div.config-management {
-    overflow: visible;
-    max-height: none;
-}
-
+#tags-div.config-management,
 #tags-div .dt-scroll-body,
 #tags-div .dt-container {
     overflow-y: visible !important;

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Settings/TagManagement/TagManagement.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Settings/TagManagement/TagManagement.js
@@ -219,8 +219,6 @@ $(function () {
         serverSide: false,
         paging: false,
         searching: true,
-        scrollCollapse: true,
-        scrollX: true,
         ordering: true,
         ajax: (requestData, callback, settings) => getUnifiedTagSummaryAjax(requestData, callback, settings),
         columnDefs: defineTagSummaryColumnDefs()

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/yarn.lock
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/yarn.lock
@@ -305,7 +305,7 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
-"@popperjs/core@^2.11.8", "@popperjs/core@^2.9.0":
+"@popperjs/core@^2.9.0":
   version "2.11.8"
   resolved "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
@@ -357,7 +357,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.16.0:
+acorn@^8.16.0:
   version "8.16.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
@@ -427,7 +427,7 @@ bootstrap-select@~1.13.18:
   resolved "https://registry.npmjs.org/bootstrap-select/-/bootstrap-select-1.13.18.tgz"
   integrity sha512-V1IzK4rxBq5FrJtkzSH6RmFLFBsjx50byFbfAf8jYyXROWs7ZpprGjdHeoyq2HSsHyjJhMMwjsQhRoYAfxCGow==
 
-bootstrap@^5.3.3, bootstrap@>=3.0.0:
+bootstrap@^5.3.3:
   version "5.3.3"
   resolved "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz"
   integrity sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==
@@ -541,7 +541,7 @@ datatables.net-colreorder-bs5@~2.1.1:
     datatables.net-colreorder "2.1.2"
     jquery ">=1.7"
 
-datatables.net-colreorder@~2.1.1, datatables.net-colreorder@2.1.2:
+datatables.net-colreorder@2.1.2, datatables.net-colreorder@~2.1.1:
   version "2.1.2"
   resolved "https://registry.npmjs.org/datatables.net-colreorder/-/datatables.net-colreorder-2.1.2.tgz"
   integrity sha512-lIsUyOt2nBm4sD2cSzDKZcIVrGgrZkh90Z2f03s8p7DYcZSfXMHAhFBrDYf9/eAK6wJnODN8EDMsrtPHfgoSXA==
@@ -566,7 +566,7 @@ datatables.net-fixedheader-bs5@~4.0.6:
     datatables.net-fixedheader "4.0.6"
     jquery ">=1.7"
 
-datatables.net-fixedheader@~4.0.6, datatables.net-fixedheader@4.0.6:
+datatables.net-fixedheader@4.0.6, datatables.net-fixedheader@~4.0.6:
   version "4.0.6"
   resolved "https://registry.npmjs.org/datatables.net-fixedheader/-/datatables.net-fixedheader-4.0.6.tgz"
   integrity sha512-icYg/qKDpqGDrAVRWfsjt0xQdngk48R7LWkS9t8kaZFp9c4xrLFcmmPtRLgPp5/S4JHZbbsxmVkF16kscjNZjg==
@@ -600,7 +600,7 @@ datatables.net-staterestore-dt@~1.4.2:
     datatables.net-staterestore "1.4.3"
     jquery ">=1.7"
 
-datatables.net-staterestore@~1.4.2, datatables.net-staterestore@1.4.3:
+datatables.net-staterestore@1.4.3, datatables.net-staterestore@~1.4.2:
   version "1.4.3"
   resolved "https://registry.npmjs.org/datatables.net-staterestore/-/datatables.net-staterestore-1.4.3.tgz"
   integrity sha512-XSkCHwi+MZ8C5ZbZ1qlvIdIOs8YEJX4BVOk3GUMoSIta6xD4UsKTDV0SxfJWRYsNnDQwvCibQD0yJhK4Vk4xTw==
@@ -608,7 +608,7 @@ datatables.net-staterestore@~1.4.2, datatables.net-staterestore@1.4.3:
     datatables.net "1.11 - 2"
     jquery ">=1.7"
 
-datatables.net@^2, datatables.net@^2.1.8, "datatables.net@1.11 - 2", datatables.net@2.3.8:
+"datatables.net@1.11 - 2", datatables.net@2.3.8, datatables.net@^2, datatables.net@^2.1.8:
   version "2.3.8"
   resolved "https://registry.npmjs.org/datatables.net/-/datatables.net-2.3.8.tgz"
   integrity sha512-uhViowhlDlheAuo5a8TrkQqADsjrtGeOyvrigvr4t0+K3MyAWqClORXWAYIcN9VLX6iIX0C8O9gwJNd01hITRg==
@@ -730,7 +730,7 @@ eslint-visitor-keys@^5.0.1:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz"
   integrity sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
 
-eslint@^10.3.0, "eslint@^6.0.0 || ^7.0.0 || >=8.0.0":
+eslint@^10.3.0:
   version "10.3.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz"
   integrity sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==
@@ -1040,12 +1040,12 @@ jquery-validation-unobtrusive@^4.0.0:
     jquery "^3.6.0"
     jquery-validation ">=1.19"
 
-jquery-validation@^1.21.0, jquery-validation@>=1.19:
+jquery-validation@>=1.19, jquery-validation@^1.21.0:
   version "1.21.0"
   resolved "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.21.0.tgz"
   integrity sha512-xNot0rlUIgu7duMcQ5qb6MGkGL/Z1PQaRJQoZAURW9+a/2PGOUxY36o/WyNeP2T9R6jvWB8Z9lUVvvQWI/Zs5w==
 
-"jquery@^1.7 || ^2.0 || ^3.1", jquery@^3.6.0, jquery@>=1.10, jquery@>=1.12.0, jquery@>=1.2.6, "jquery@>=1.5.0 <4.0", jquery@>=1.6, jquery@>=1.7, jquery@>=1.7.2, "jquery@>=3.4.0 <4.0.0", jquery@~3.7.1, "jquery@1.9.1 - 3":
+jquery@>=1.10, jquery@>=1.12.0, jquery@>=1.2.6, "jquery@>=1.5.0 <4.0", jquery@>=1.6, jquery@>=1.7, jquery@>=1.7.2, "jquery@>=3.4.0 <4.0.0", jquery@^3.6.0, jquery@~3.7.1:
   version "3.7.1"
   resolved "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz"
   integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
@@ -1253,7 +1253,7 @@ path-key@^3.1.0:
   resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-popper.js@^1.16.1, popper.js@~1.16.1:
+popper.js@~1.16.1:
   version "1.16.1"
   resolved "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
@@ -1369,17 +1369,17 @@ spark-md5@^2.0.2:
   resolved "https://registry.npmjs.org/spark-md5/-/spark-md5-2.0.2.tgz"
   integrity sha512-9WfT+FYBEvlrOOBEs484/zmbtSX4BlGjzXih1qIEWA1yhHbcqgcMHkiwXoWk2Sq1aJjLpcs6ZKV7JxrDNjIlNg==
 
+string-hash@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz"
+  integrity sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
-
-string-hash@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz"
-  integrity sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==
 
 sweetalert2@^11.14.1:
   version "11.26.17"


### PR DESCRIPTION
## Pull request overview

This PR addresses layout overflow issues in the Configuration Management Tags pane by removing DataTables horizontal scroll behavior and allowing the Tags section/page container to grow naturally.

**Changes:**
- Removed `scrollCollapse` and `scrollX` from the "global tags" DataTable configuration.
- Added Tags-specific CSS overrides to prevent DataTables/container height clipping.
- Included incidental `yarn.lock` descriptor reordering, flagged as a nit.

### Reviewed changes

| File | Description |
| ---- | ----------- |
| `applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Settings/TagManagement/TagManagement.js` | Updates the Tags DataTable configuration to avoid DataTables-managed horizontal scrolling. |
| `applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ConfigurationManagement/Index.css` | Adds scoped layout overrides so the Tags pane and app container can expand instead of clipping content. |