### PR TITLE
bugfix/AB#32773 - Fix Payment and Applications Tag Modal Permissions

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentTags/PaymentTags.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentTags/PaymentTags.js
@@ -51,7 +51,6 @@ $(function () {
 
         this.arr.push({ Id: id, Name: tagText });
 
-        let tagInput = this;
 
         let tag = document.createElement('span');
         tag.className = this.options.tagClass + ' ' + tagClass;
@@ -65,9 +64,9 @@ $(function () {
                 e.preventDefault();
                 let tag = this.parentNode;
 
-                let tagIndex = Array.from(tagInput.wrapper.childNodes).indexOf(tag);
+                let tagIndex = Array.from(this.wrapper.childNodes).indexOf(tag);
                 if (tagIndex !== -1) {
-                    tagInput.deleteTag(tag, tagIndex);
+                    this.deleteTag(tag, tagIndex);
                 }
             })
 
@@ -82,23 +81,21 @@ $(function () {
     }
 
     TagsInput.prototype.deleteTag = function (tag, i) {
-        let self = this;
-
-        if (this.arr[i] && this.arr[i].Name === 'Uncommon Tags') {
+        if (this.arr[i]?.Name === 'Uncommon Tags') {
             abp.message.confirm('Are you sure you want to delete all the uncommon tags?')
                 .then(function (confirmed) {
                     if (confirmed) {
                         tag.remove();
-                        self.arr.splice(i, 1);
-                        self.orignal_input.value = JSON.stringify(self.arr);
-                        updateSelectedTagsInput(self.arr);
+                        this.arr.splice(i, 1);
+                        this.orignal_input.value = JSON.stringify(this.arr);
+                        updateSelectedTagsInput(this.arr);
                         
                         // Expand input if no tags remain
-                        if (self.arr.length === 0) {
-                            self.input.classList.add('expanded');
+                        if (this.arr.length === 0) {
+                            this.input.classList.add('expanded');
                         }
                         
-                        return self;
+                        return this;
                     }
                 });
         } else {
@@ -134,10 +131,8 @@ $(function () {
     }
 
     TagsInput.prototype.addData = function (array) {
-        let plugin = this;
-
         array.forEach(function (string) {
-            plugin.addTag(string);
+            this.addTag(string);
         })
         return this;
     }
@@ -154,14 +149,13 @@ $(function () {
         this.orignal_input.removeAttribute('hidden');
 
         delete this.orignal_input;
-        let self = this;
 
         Object.keys(this).forEach(function (key) {
-            if (self[key] instanceof HTMLElement)
-                self[key].remove();
+            if (this[key] instanceof HTMLElement)
+                this[key].remove();
 
             if (key != 'options')
-                delete self[key];
+                delete this[key];
         });
 
         this.initialized = false;
@@ -355,5 +349,5 @@ $(function () {
         duplicate: false
     }
 
-    window.PaymentTagsInput = TagsInput;
+    globalThis.PaymentTagsInput = TagsInput;
 });

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentTags/PaymentTags.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentTags/PaymentTags.js
@@ -60,9 +60,9 @@ $(function () {
             let closeIcon = document.createElement('a');
             closeIcon.innerHTML = '&times;';
 
-            closeIcon.addEventListener('click', function (e) {
+            closeIcon.addEventListener('click', (e) => {
                 e.preventDefault();
-                let tag = this.parentNode;
+                let tag = e.currentTarget.parentNode;
 
                 let tagIndex = Array.from(this.wrapper.childNodes).indexOf(tag);
                 if (tagIndex !== -1) {
@@ -83,7 +83,7 @@ $(function () {
     TagsInput.prototype.deleteTag = function (tag, i) {
         if (this.arr[i]?.Name === 'Uncommon Tags') {
             abp.message.confirm('Are you sure you want to delete all the uncommon tags?')
-                .then(function (confirmed) {
+                .then((confirmed) => {
                     if (confirmed) {
                         tag.remove();
                         this.arr.splice(i, 1);
@@ -131,7 +131,7 @@ $(function () {
     }
 
     TagsInput.prototype.addData = function (array) {
-        array.forEach(function (string) {
+        array.forEach((string) => {
             this.addTag(string);
         })
         return this;
@@ -150,7 +150,7 @@ $(function () {
 
         delete this.orignal_input;
 
-        Object.keys(this).forEach(function (key) {
+        Object.keys(this).forEach((key) => {
             if (this[key] instanceof HTMLElement)
                 this[key].remove();
 

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentTags/PaymentTags.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentTags/PaymentTags.js
@@ -355,5 +355,5 @@ $(function () {
         duplicate: false
     }
 
-    window.TagsInput = TagsInput;
+    window.PaymentTagsInput = TagsInput;
 });

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/PaymentActionBar/Default.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Views/Shared/Components/PaymentActionBar/Default.js
@@ -5,7 +5,7 @@ $(function () {
     });
 
     tagPaymentModal.onOpen(async function () {
-        let tagInput = new TagsInput({
+        let tagInput = new PaymentTagsInput({
             selector: 'SelectedTags',
             duplicate: false,
             max: 50

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationTags/ApplicationTags.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationTags/ApplicationTags.js
@@ -59,9 +59,9 @@ $(function () {
             let closeIcon = document.createElement('a');
             closeIcon.innerHTML = '&times;';
 
-            closeIcon.addEventListener('click', function (e) {
+            closeIcon.addEventListener('click', (e) => {
                 e.preventDefault();
-                let tag = this.parentNode;
+                let tag = e.currentTarget.parentNode;
 
                 let tagIndex = Array.from(this.wrapper.childNodes).indexOf(tag);
                 if (tagIndex !== -1) {
@@ -82,7 +82,7 @@ $(function () {
     TagsInput.prototype.deleteTag = function (tag, i) {
         if (this.arr[i]?.Name === 'Uncommon Tags') {
             abp.message.confirm('Are you sure you want to delete all the uncommon tags?')
-                .then(function (confirmed) {
+                .then((confirmed) => {
                     if (confirmed) {
                         tag.remove();
                         this.arr.splice(i, 1);
@@ -130,7 +130,7 @@ $(function () {
     }
 
     TagsInput.prototype.addData = function (array) {
-        array.forEach(function (string) {
+        array.forEach((string) => {
             this.addTag(string);
         })
         return this;
@@ -149,7 +149,7 @@ $(function () {
 
         delete this.orignal_input;
 
-        Object.keys(this).forEach(function (key) {
+        Object.keys(this).forEach((key) => {
             if (this[key] instanceof HTMLElement)
                 this[key].remove();
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationTags/ApplicationTags.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationTags/ApplicationTags.js
@@ -51,8 +51,6 @@ $(function () {
 
         this.arr.push({ Id: id, Name: tagText });
 
-        let tagInput = this;
-
         let tag = document.createElement('span');
         tag.className = this.options.tagClass + ' ' + tagClass;
         tag.innerText = tagText;
@@ -65,9 +63,9 @@ $(function () {
                 e.preventDefault();
                 let tag = this.parentNode;
 
-                let tagIndex = Array.from(tagInput.wrapper.childNodes).indexOf(tag);
+                let tagIndex = Array.from(this.wrapper.childNodes).indexOf(tag);
                 if (tagIndex !== -1) {
-                    tagInput.deleteTag(tag, tagIndex);
+                    this.deleteTag(tag, tagIndex);
                 }
             })
 
@@ -82,23 +80,21 @@ $(function () {
     }
 
     TagsInput.prototype.deleteTag = function (tag, i) {
-        let self = this;
-
-        if (this.arr[i] && this.arr[i].Name === 'Uncommon Tags') {
+        if (this.arr[i]?.Name === 'Uncommon Tags') {
             abp.message.confirm('Are you sure you want to delete all the uncommon tags?')
                 .then(function (confirmed) {
                     if (confirmed) {
                         tag.remove();
-                        self.arr.splice(i, 1);
-                        self.orignal_input.value = JSON.stringify(self.arr);
-                        updateSelectedTagsInput(self.arr);
+                        this.arr.splice(i, 1);
+                        this.orignal_input.value = JSON.stringify(this.arr);
+                        updateSelectedTagsInput(this.arr);
                         
                         // Expand input if no tags remain
-                        if (self.arr.length === 0) {
-                            self.input.classList.add('expanded');
+                        if (this.arr.length === 0) {
+                            this.input.classList.add('expanded');
                         }
                         
-                        return self;
+                        return this;
                     }
                 });
         } else {
@@ -134,10 +130,8 @@ $(function () {
     }
 
     TagsInput.prototype.addData = function (array) {
-        let plugin = this;
-
         array.forEach(function (string) {
-            plugin.addTag(string);
+            this.addTag(string);
         })
         return this;
     }
@@ -154,14 +148,13 @@ $(function () {
         this.orignal_input.removeAttribute('hidden');
 
         delete this.orignal_input;
-        let self = this;
 
         Object.keys(this).forEach(function (key) {
-            if (self[key] instanceof HTMLElement)
-                self[key].remove();
+            if (this[key] instanceof HTMLElement)
+                this[key].remove();
 
             if (key != 'options')
-                delete self[key];
+                delete this[key];
         });
 
         this.initialized = false;
@@ -353,5 +346,5 @@ $(function () {
         duplicate: false
     }
 
-    window.TagsInput = TagsInput;
+    globalThis.TagsInput = TagsInput;
 });

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationTags/ApplicationTagsSelectionModal.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationTags/ApplicationTagsSelectionModal.cshtml
@@ -1,7 +1,6 @@
 ﻿@page
 @using Newtonsoft.Json
 @using Unity.Modules.Shared
-@using Volo.Abp.AspNetCore.Mvc.UI.Bootstrap.TagHelpers.Modal
 @using Volo.Abp.Authorization.Permissions
 
 @model Unity.GrantManager.Web.Pages.ApplicationTags.ApplicationTagsModalModel
@@ -49,7 +48,14 @@
         }
     </abp-modal-body>
         <abp-modal-footer>
-            <button class="btn btn-primary" data-busy-text="Saving..." type="submit" id="assignTagsModelSaveBtn">Save</button>
+            @if (await PermissionChecker.IsGrantedAsync(UnitySelector.Application.Tags.Create) || await PermissionChecker.IsGrantedAsync(UnitySelector.Application.Tags.Delete))
+            {
+                <button class="btn btn-primary" data-busy-text="Saving..." type="submit" id="assignTagsModelSaveBtn">Save</button>
+            } 
+            else 
+            {
+                <button class="btn btn-primary" data-busy-text="Saving..." type="submit" id="assignTagsModelSaveBtn" disabled>Save</button>
+            }
             <button class="btn btn-secondary" data-bs-dismiss="modal" type="button">Cancel</button>
         </abp-modal-footer>
 </abp-modal>

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ActionBar/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ActionBar/Default.js
@@ -218,7 +218,7 @@ $(function () {
         
         userTagsInput.setSuggestions(suggestionsArray);
         userTagsInput.addData(tagInputArray);
-        document.getElementById("user-tags-input").setAttribute("data-touched", "false");
+        document.getElementById("user-tags-input").dataset.touched = "false";
     });
     tagApplicationModal.onResult(function () {
         abp.notify.success(


### PR DESCRIPTION
## Pull request overview

This PR fixes tag modal permission collisions between application and payment tagging by separating the payment tag input global from the application tag input global.

**Changes:**
- Renames the payment tag input constructor usage to `PaymentTagsInput`.
- Exposes application and payment tag inputs under distinct `globalThis` names.
- Tweaks tag/input internals and a `data-touched` assignment.

### Reviewed changes

| File | Description |
| ---- | ----------- |
| `Views/Shared/Components/ActionBar/Default.js` | Updates `data-touched` assignment for user tags input. |
| `Pages/ApplicationTags/ApplicationTags.js` | Keeps application tag input global and refactors internal instance references. |
| `modules/Unity.Payments/.../PaymentActionBar/Default.js` | Instantiates the renamed payment tag input constructor. |
| `modules/Unity.Payments/.../PaymentTags/PaymentTags.js` | Exposes payment tag input under `PaymentTagsInput` and refactors internal instance references. |