### PR TITLE
AB#33307 fix prompt renderer data placeholders

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIPromptRenderer.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIPromptRenderer.cs
@@ -261,8 +261,9 @@ public class OpenAIPromptRenderer : ITransientDependency
         var template = GetRequiredPromptTemplate(version, templateName);
         var replacements = new Dictionary<string, string>(runtimeReplacements, StringComparer.Ordinal);
         var baseTemplateName = GetTemplateBaseName(templateName);
+        var placeholders = GetTemplatePlaceholders(template);
 
-        foreach (var placeholder in GetTemplatePlaceholders(template))
+        foreach (var placeholder in placeholders)
         {
             if (replacements.ContainsKey(placeholder))
             {
@@ -280,17 +281,19 @@ public class OpenAIPromptRenderer : ITransientDependency
             }
         }
 
-        var rendered = template;
-        foreach (var replacement in replacements)
-        {
-            rendered = rendered.Replace($"{{{{{replacement.Key}}}}}", replacement.Value ?? string.Empty, StringComparison.Ordinal);
-        }
-
-        var unresolved = GetTemplatePlaceholders(rendered);
+        var unresolved = placeholders
+            .Where(placeholder => !replacements.ContainsKey(placeholder))
+            .ToList();
         if (unresolved.Count > 0)
         {
             throw new InvalidOperationException(
                 $"Unresolved prompt placeholders in '{templateName}.txt' for prompt version '{version}': {string.Join(", ", unresolved.OrderBy(item => item))}");
+        }
+
+        var rendered = template;
+        foreach (var placeholder in placeholders)
+        {
+            rendered = rendered.Replace($"{{{{{placeholder}}}}}", replacements[placeholder] ?? string.Empty, StringComparison.Ordinal);
         }
 
         resolutionStack.Remove(templateName);
@@ -369,7 +372,7 @@ public class OpenAIPromptRenderer : ITransientDependency
             }
 
             var placeholder = template.Substring(start + 2, end - start - 2).Trim();
-            if (!string.IsNullOrWhiteSpace(placeholder))
+            if (IsPromptPlaceholder(placeholder))
             {
                 placeholders.Add(placeholder);
             }
@@ -378,5 +381,11 @@ public class OpenAIPromptRenderer : ITransientDependency
         }
 
         return placeholders;
+    }
+
+    private static bool IsPromptPlaceholder(string placeholder)
+    {
+        return !string.IsNullOrWhiteSpace(placeholder) &&
+               placeholder.All(character => char.IsUpper(character) || char.IsDigit(character) || character == '_');
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIPromptRenderer.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIPromptRenderer.cs
@@ -261,7 +261,7 @@ public class OpenAIPromptRenderer : ITransientDependency
         var template = GetRequiredPromptTemplate(version, templateName);
         var replacements = new Dictionary<string, string>(runtimeReplacements, StringComparer.Ordinal);
         var baseTemplateName = GetTemplateBaseName(templateName);
-        var placeholders = GetTemplatePlaceholders(template);
+        var placeholders = GetTemplatePlaceholders(template, version, templateName);
 
         foreach (var placeholder in placeholders)
         {
@@ -352,9 +352,10 @@ public class OpenAIPromptRenderer : ITransientDependency
         return templateName.Substring(0, separatorIndex);
     }
 
-    private static HashSet<string> GetTemplatePlaceholders(string template)
+    private static HashSet<string> GetTemplatePlaceholders(string template, string version, string templateName)
     {
         var placeholders = new HashSet<string>(StringComparer.Ordinal);
+        var invalidPlaceholders = new List<string>();
         var searchIndex = 0;
 
         while (searchIndex < template.Length)
@@ -376,8 +377,18 @@ public class OpenAIPromptRenderer : ITransientDependency
             {
                 placeholders.Add(placeholder);
             }
+            else
+            {
+                invalidPlaceholders.Add(placeholder);
+            }
 
             searchIndex = end + 2;
+        }
+
+        if (invalidPlaceholders.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"Invalid prompt placeholders in '{templateName}.txt' for prompt version '{version}': {string.Join(", ", invalidPlaceholders.OrderBy(item => item))}");
         }
 
         return placeholders;

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAIPromptRendererTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAIPromptRendererTests.cs
@@ -1,5 +1,8 @@
 using Shouldly;
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
 using Unity.AI.Runtime;
 using Xunit;
 
@@ -67,5 +70,40 @@ public class OpenAIPromptRendererTests
         result.ShouldContain("{{ item.SectorName }}");
         result.ShouldContain("{{ item.topic_source_id }}");
         result.ShouldContain("{{FORMIO_VALUE}}");
+    }
+
+    [Fact]
+    public void RenderPromptTemplate_Should_Reject_Non_Prompt_Placeholders_In_Template_Text()
+    {
+        var templateCache = GetPromptTemplateCache();
+        templateCache["v1/unit-test.invalid"] = "Bad template token: {{ item.label }}";
+
+        var exception = Should.Throw<TargetInvocationException>(() =>
+            RenderPromptTemplate("v1", "unit-test.invalid", new Dictionary<string, string>()));
+
+        exception.InnerException.ShouldBeOfType<InvalidOperationException>();
+        exception.InnerException!.Message.ShouldContain("Invalid prompt placeholders");
+        exception.InnerException.Message.ShouldContain("item.label");
+    }
+
+    private static string RenderPromptTemplate(
+        string version,
+        string templateName,
+        IReadOnlyDictionary<string, string> runtimeReplacements)
+    {
+        var method = typeof(OpenAIPromptRenderer).GetMethod(
+            "RenderPromptTemplate",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        method.ShouldNotBeNull();
+        return (string)method.Invoke(null, [version, templateName, runtimeReplacements])!;
+    }
+
+    private static ConcurrentDictionary<string, string> GetPromptTemplateCache()
+    {
+        var field = typeof(OpenAIPromptRenderer).GetField(
+            "PromptTemplateCache",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        field.ShouldNotBeNull();
+        return (ConcurrentDictionary<string, string>)field.GetValue(null)!;
     }
 }

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAIPromptRendererTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAIPromptRendererTests.cs
@@ -42,4 +42,30 @@ public class OpenAIPromptRendererTests
         prompt.ShouldContain("If ATTACHMENTS is empty, use DATA only");
         prompt.ShouldNotContain("No attachments provided.");
     }
+
+    [Fact]
+    public void BuildApplicationAnalysisUserPrompt_Should_Not_Treat_FormIo_Mustache_Data_As_Prompt_Placeholders()
+    {
+        const string data = """
+            {
+              "template": "<span>{{ item.label }}</span>",
+              "fileNameTemplate": "{{fileName}}",
+              "sector": "{{ item.SectorName }}",
+              "topicSourceId": "{{ item.topic_source_id }}",
+              "uppercaseTemplateValue": "{{FORMIO_VALUE}}"
+            }
+            """;
+
+        var result = OpenAIPromptRenderer.BuildApplicationAnalysisUserPrompt(
+            "v1",
+            "{}",
+            data,
+            "[]");
+
+        result.ShouldContain("{{ item.label }}");
+        result.ShouldContain("{{fileName}}");
+        result.ShouldContain("{{ item.SectorName }}");
+        result.ShouldContain("{{ item.topic_source_id }}");
+        result.ShouldContain("{{FORMIO_VALUE}}");
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes AI prompt rendering so runtime application data containing FormIO/CHEFS `{{...}}` strings is not treated as unresolved AI prompt placeholders.
- Keeps fail-fast validation for unresolved placeholders that are actually declared in AI prompt templates/fragments.
- Adds regression coverage for application analysis data containing mustache-style form template values.

## Validation
- `dotnet test applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/Unity.GrantManager.Application.Tests.csproj --filter OpenAIPromptRendererTests`
