### PR TITLE
AB#33266 prevent empty AI generation requests

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/AI/Operations/IAIGenerationPrerequisiteValidator.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/AI/Operations/IAIGenerationPrerequisiteValidator.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Unity.AI.Operations;
+
+public interface IAIGenerationPrerequisiteValidator
+{
+    Task EnsureAttachmentSummaryAvailableAsync(Guid applicationId);
+
+    Task EnsureApplicationAnalysisAvailableAsync(Guid applicationId);
+
+    Task EnsureApplicationScoringAvailableAsync(Guid applicationId);
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AIGenerationPrerequisiteValidator.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AIGenerationPrerequisiteValidator.cs
@@ -1,7 +1,9 @@
+using Microsoft.Extensions.Localization;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Unity.Flex.Domain.Scoresheets;
+using Unity.AI.Localization;
 using Unity.GrantManager.Applications;
 using Volo.Abp;
 using Volo.Abp.DependencyInjection;
@@ -15,7 +17,8 @@ public class AIGenerationPrerequisiteValidator(
     IApplicationFormSubmissionRepository applicationFormSubmissionRepository,
     IApplicationChefsFileAttachmentRepository applicationChefsFileAttachmentRepository,
     IScoresheetRepository scoresheetRepository,
-    IAsyncQueryableExecuter asyncExecuter) : IAIGenerationPrerequisiteValidator, ITransientDependency
+    IAsyncQueryableExecuter asyncExecuter,
+    IStringLocalizer<AIResource> localizer) : IAIGenerationPrerequisiteValidator, ITransientDependency
 {
     public async Task EnsureAttachmentSummaryAvailableAsync(Guid applicationId)
     {
@@ -23,18 +26,16 @@ public class AIGenerationPrerequisiteValidator(
         var hasAttachments = await asyncExecuter.AnyAsync(attachmentQuery.Where(a => a.ApplicationId == applicationId));
         if (!hasAttachments)
         {
-            throw new UserFriendlyException("No attachments are available to summarize.");
+            throw new UserFriendlyException(localizer[AILocalizationKeys.NoAttachmentsAvailable]);
         }
     }
 
     public async Task EnsureApplicationAnalysisAvailableAsync(Guid applicationId)
     {
-        await applicationRepository.GetAsync(applicationId);
-
         var submission = await applicationFormSubmissionRepository.GetByApplicationAsync(applicationId);
         if (submission == null || string.IsNullOrWhiteSpace(submission.Submission))
         {
-            throw new UserFriendlyException("AI application analysis requires application submission data.");
+            throw new UserFriendlyException(localizer[AILocalizationKeys.ApplicationAnalysisRequiresSubmission]);
         }
     }
 
@@ -44,13 +45,13 @@ public class AIGenerationPrerequisiteValidator(
         var applicationForm = await applicationFormRepository.GetAsync(application.ApplicationFormId);
         if (applicationForm.ScoresheetId == null)
         {
-            throw new UserFriendlyException("AI scoring requires a configured scoresheet.");
+            throw new UserFriendlyException(localizer[AILocalizationKeys.ScoringRequiresScoresheet]);
         }
 
         var scoresheet = await scoresheetRepository.GetWithChildrenAsync(applicationForm.ScoresheetId.Value);
         if (scoresheet == null || !scoresheet.Sections.Any() || !scoresheet.Sections.SelectMany(s => s.Fields).Any())
         {
-            throw new UserFriendlyException("AI scoring requires a scoresheet with scoring fields.");
+            throw new UserFriendlyException(localizer[AILocalizationKeys.ScoringRequiresScoresheetFields]);
         }
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AIGenerationPrerequisiteValidator.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AIGenerationPrerequisiteValidator.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Unity.Flex.Domain.Scoresheets;
+using Unity.GrantManager.Applications;
+using Volo.Abp;
+using Volo.Abp.DependencyInjection;
+
+namespace Unity.AI.Operations;
+
+public class AIGenerationPrerequisiteValidator(
+    IApplicationRepository applicationRepository,
+    IApplicationFormRepository applicationFormRepository,
+    IApplicationFormSubmissionRepository applicationFormSubmissionRepository,
+    IApplicationChefsFileAttachmentRepository applicationChefsFileAttachmentRepository,
+    IScoresheetRepository scoresheetRepository) : IAIGenerationPrerequisiteValidator, ITransientDependency
+{
+    public async Task EnsureAttachmentSummaryAvailableAsync(Guid applicationId)
+    {
+        var attachments = await applicationChefsFileAttachmentRepository.GetListAsync(a => a.ApplicationId == applicationId);
+        if (attachments.Count == 0)
+        {
+            throw new UserFriendlyException("No attachments are available to summarize.");
+        }
+    }
+
+    public async Task EnsureApplicationAnalysisAvailableAsync(Guid applicationId)
+    {
+        await applicationRepository.GetAsync(applicationId);
+
+        var submission = await applicationFormSubmissionRepository.GetByApplicationAsync(applicationId);
+        if (submission == null || string.IsNullOrWhiteSpace(submission.Submission))
+        {
+            throw new UserFriendlyException("AI application analysis requires application submission data.");
+        }
+    }
+
+    public async Task EnsureApplicationScoringAvailableAsync(Guid applicationId)
+    {
+        var application = await applicationRepository.GetAsync(applicationId);
+        var applicationForm = await applicationFormRepository.GetAsync(application.ApplicationFormId);
+        if (applicationForm.ScoresheetId == null)
+        {
+            throw new UserFriendlyException("AI scoring requires a configured scoresheet.");
+        }
+
+        var scoresheet = await scoresheetRepository.GetWithChildrenAsync(applicationForm.ScoresheetId.Value);
+        if (scoresheet == null || !scoresheet.Sections.Any() || !scoresheet.Sections.SelectMany(s => s.Fields).Any())
+        {
+            throw new UserFriendlyException("AI scoring requires a scoresheet with scoring fields.");
+        }
+    }
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AIGenerationPrerequisiteValidator.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AIGenerationPrerequisiteValidator.cs
@@ -5,6 +5,7 @@ using Unity.Flex.Domain.Scoresheets;
 using Unity.GrantManager.Applications;
 using Volo.Abp;
 using Volo.Abp.DependencyInjection;
+using Volo.Abp.Linq;
 
 namespace Unity.AI.Operations;
 
@@ -13,12 +14,14 @@ public class AIGenerationPrerequisiteValidator(
     IApplicationFormRepository applicationFormRepository,
     IApplicationFormSubmissionRepository applicationFormSubmissionRepository,
     IApplicationChefsFileAttachmentRepository applicationChefsFileAttachmentRepository,
-    IScoresheetRepository scoresheetRepository) : IAIGenerationPrerequisiteValidator, ITransientDependency
+    IScoresheetRepository scoresheetRepository,
+    IAsyncQueryableExecuter asyncExecuter) : IAIGenerationPrerequisiteValidator, ITransientDependency
 {
     public async Task EnsureAttachmentSummaryAvailableAsync(Guid applicationId)
     {
-        var attachments = await applicationChefsFileAttachmentRepository.GetListAsync(a => a.ApplicationId == applicationId);
-        if (attachments.Count == 0)
+        var attachmentQuery = await applicationChefsFileAttachmentRepository.GetQueryableAsync();
+        var hasAttachments = await asyncExecuter.AnyAsync(attachmentQuery.Where(a => a.ApplicationId == applicationId));
+        if (!hasAttachments)
         {
             throw new UserFriendlyException("No attachments are available to summarize.");
         }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationAnalysisService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationAnalysisService.cs
@@ -21,6 +21,7 @@ namespace Unity.AI.Operations
         IApplicationFormVersionRepository applicationFormVersionRepository,
         IApplicationChefsFileAttachmentRepository applicationChefsFileAttachmentRepository,
         IAIService aiService,
+        IAIGenerationPrerequisiteValidator aiGenerationPrerequisiteValidator,
         ILogger<ApplicationAnalysisService> logger) : IApplicationAnalysisService, ITransientDependency
     {
         private const string ComponentsKey = "components";
@@ -31,6 +32,8 @@ namespace Unity.AI.Operations
 
         public async Task<string> RegenerateAndSaveAsync(Guid applicationId, string? promptVersion = null, CancellationToken cancellationToken = default)
         {
+            await aiGenerationPrerequisiteValidator.EnsureApplicationAnalysisAvailableAsync(applicationId);
+
             var application = await applicationRepository.GetAsync(applicationId);
             var formSubmission = await applicationFormSubmissionRepository.GetByApplicationAsync(applicationId);
             var attachments = await applicationChefsFileAttachmentRepository.GetListAsync(a => a.ApplicationId == applicationId);

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
@@ -23,11 +23,14 @@ namespace Unity.AI.Operations
         IApplicationChefsFileAttachmentRepository applicationChefsFileAttachmentRepository,
         IScoresheetRepository scoresheetRepository,
         IAIService aiService,
+        IAIGenerationPrerequisiteValidator aiGenerationPrerequisiteValidator,
         AIExecutionModeResolver executionModeResolver,
         ILogger<ApplicationScoringService> logger) : IApplicationScoringService, ITransientDependency
     {
         public async Task<string> RegenerateAndSaveAsync(Guid applicationId, string? promptVersion = null, CancellationToken cancellationToken = default)
         {
+            await aiGenerationPrerequisiteValidator.EnsureApplicationScoringAvailableAsync(applicationId);
+
             var application = await applicationRepository.GetAsync(applicationId);
             var applicationForm = await applicationFormRepository.GetAsync(application.ApplicationFormId);
             if (applicationForm.ScoresheetId == null)

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
@@ -11,6 +11,7 @@ using Unity.AI.Prompts;
 using Unity.AI.Requests;
 using Unity.AI.Runtime;
 using Unity.GrantManager.Applications;
+using Volo.Abp;
 using Volo.Abp.DependencyInjection;
 
 namespace Unity.AI.Operations
@@ -23,25 +24,22 @@ namespace Unity.AI.Operations
         IApplicationChefsFileAttachmentRepository applicationChefsFileAttachmentRepository,
         IScoresheetRepository scoresheetRepository,
         IAIService aiService,
-        IAIGenerationPrerequisiteValidator aiGenerationPrerequisiteValidator,
         AIExecutionModeResolver executionModeResolver,
         ILogger<ApplicationScoringService> logger) : IApplicationScoringService, ITransientDependency
     {
         public async Task<string> RegenerateAndSaveAsync(Guid applicationId, string? promptVersion = null, CancellationToken cancellationToken = default)
         {
-            await aiGenerationPrerequisiteValidator.EnsureApplicationScoringAvailableAsync(applicationId);
-
             var application = await applicationRepository.GetAsync(applicationId);
             var applicationForm = await applicationFormRepository.GetAsync(application.ApplicationFormId);
             if (applicationForm.ScoresheetId == null)
             {
-                return "{}";
+                throw new UserFriendlyException("AI scoring requires a configured scoresheet.");
             }
 
             var scoresheet = await scoresheetRepository.GetWithChildrenAsync(applicationForm.ScoresheetId.Value);
-            if (scoresheet == null)
+            if (scoresheet == null || !scoresheet.Sections.Any() || !scoresheet.Sections.SelectMany(s => s.Fields).Any())
             {
-                return "{}";
+                throw new UserFriendlyException("AI scoring requires a scoresheet with scoring fields.");
             }
 
             var attachments = await applicationChefsFileAttachmentRepository.GetListAsync(a => a.ApplicationId == applicationId);

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
@@ -10,9 +10,11 @@ using Unity.AI.Models;
 using Unity.AI.Prompts;
 using Unity.AI.Requests;
 using Unity.AI.Runtime;
+using Unity.AI.Localization;
 using Unity.GrantManager.Applications;
 using Volo.Abp;
 using Volo.Abp.DependencyInjection;
+using Microsoft.Extensions.Localization;
 
 namespace Unity.AI.Operations
 {
@@ -25,7 +27,8 @@ namespace Unity.AI.Operations
         IScoresheetRepository scoresheetRepository,
         IAIService aiService,
         AIExecutionModeResolver executionModeResolver,
-        ILogger<ApplicationScoringService> logger) : IApplicationScoringService, ITransientDependency
+        ILogger<ApplicationScoringService> logger,
+        IStringLocalizer<AIResource> localizer) : IApplicationScoringService, ITransientDependency
     {
         public async Task<string> RegenerateAndSaveAsync(Guid applicationId, string? promptVersion = null, CancellationToken cancellationToken = default)
         {
@@ -33,13 +36,13 @@ namespace Unity.AI.Operations
             var applicationForm = await applicationFormRepository.GetAsync(application.ApplicationFormId);
             if (applicationForm.ScoresheetId == null)
             {
-                throw new UserFriendlyException("AI scoring requires a configured scoresheet.");
+                throw new UserFriendlyException(localizer[AILocalizationKeys.ScoringRequiresScoresheet]);
             }
 
             var scoresheet = await scoresheetRepository.GetWithChildrenAsync(applicationForm.ScoresheetId.Value);
             if (scoresheet == null || !scoresheet.Sections.Any() || !scoresheet.Sections.SelectMany(s => s.Fields).Any())
             {
-                throw new UserFriendlyException("AI scoring requires a scoresheet with scoring fields.");
+                throw new UserFriendlyException(localizer[AILocalizationKeys.ScoringRequiresScoresheetFields]);
             }
 
             var attachments = await applicationChefsFileAttachmentRepository.GetListAsync(a => a.ApplicationId == applicationId);

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AttachmentSummaryService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AttachmentSummaryService.cs
@@ -1,10 +1,12 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Localization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Unity.AI.Extraction;
+using Unity.AI.Localization;
 using Unity.AI.Requests;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Intakes;
@@ -20,7 +22,8 @@ public class AttachmentSummaryService(
     IAIService aiService,
     IAIGenerationPrerequisiteValidator aiGenerationPrerequisiteValidator,
     AIExecutionModeResolver executionModeResolver,
-    ILogger<AttachmentSummaryService> logger) : IAttachmentSummaryService, ITransientDependency
+    ILogger<AttachmentSummaryService> logger,
+    IStringLocalizer<AIResource> localizer) : IAttachmentSummaryService, ITransientDependency
 {
     private const string SummaryGenerationFailedMessage = "AI summary generation failed.";
 
@@ -51,7 +54,7 @@ public class AttachmentSummaryService(
         var ids = attachmentIds as IReadOnlyCollection<Guid> ?? attachmentIds.ToList();
         if (ids.Count == 0)
         {
-            throw new UserFriendlyException("Select at least one attachment to generate summaries.");
+            throw new UserFriendlyException(localizer[AILocalizationKeys.SelectAttachmentForSummaries]);
         }
 
         var mode = executionModeResolver.ResolveMode(AIExecutionModeResolver.AttachmentSummaryOperation);

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AttachmentSummaryService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AttachmentSummaryService.cs
@@ -8,6 +8,7 @@ using Unity.AI.Extraction;
 using Unity.AI.Requests;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Intakes;
+using Volo.Abp;
 using Volo.Abp.DependencyInjection;
 
 namespace Unity.AI.Operations;
@@ -17,6 +18,7 @@ public class AttachmentSummaryService(
     IChefsFileAttachmentStreamProvider chefsFileAttachmentStreamProvider,
     ITextExtractionService textExtractionService,
     IAIService aiService,
+    IAIGenerationPrerequisiteValidator aiGenerationPrerequisiteValidator,
     AIExecutionModeResolver executionModeResolver,
     ILogger<AttachmentSummaryService> logger) : IAttachmentSummaryService, ITransientDependency
 {
@@ -47,6 +49,11 @@ public class AttachmentSummaryService(
     public async Task<List<string>> GenerateAndSaveAsync(IEnumerable<Guid> attachmentIds, string? promptVersion = null, CancellationToken cancellationToken = default)
     {
         var ids = attachmentIds as IReadOnlyCollection<Guid> ?? attachmentIds.ToList();
+        if (ids.Count == 0)
+        {
+            throw new UserFriendlyException("Select at least one attachment to generate summaries.");
+        }
+
         var mode = executionModeResolver.ResolveMode(AIExecutionModeResolver.AttachmentSummaryOperation);
         if (mode != AIExecutionMode.Sequential)
         {
@@ -103,6 +110,8 @@ public class AttachmentSummaryService(
         IReadOnlyCollection<Guid>? attachmentIds = null,
         CancellationToken cancellationToken = default)
     {
+        await aiGenerationPrerequisiteValidator.EnsureAttachmentSummaryAvailableAsync(applicationId);
+
         var applicationAttachmentIds = (await applicationChefsFileAttachmentRepository.GetListAsync(a => a.ApplicationId == applicationId))
             .Select(a => a.Id)
             .ToList();

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Domain.Shared/Localization/AI/en.json
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Domain.Shared/Localization/AI/en.json
@@ -23,6 +23,11 @@
     "AI:ApplicationAnalysisDisabled": "AI application analysis is not enabled.",
     "AI:ScoringDisabled": "AI scoring is not enabled.",
     "AI:GenerateAllDisabled": "AI generation is not enabled.",
+    "AI:NoAttachmentsAvailable": "No attachments are available to summarize.",
+    "AI:ApplicationAnalysisRequiresSubmission": "AI application analysis requires application submission data.",
+    "AI:ScoringRequiresScoresheet": "AI scoring requires a configured scoresheet.",
+    "AI:ScoringRequiresScoresheetFields": "AI scoring requires a scoresheet with scoring fields.",
+    "AI:SelectAttachmentForSummaries": "Select at least one attachment to generate summaries.",
 
     "AIPrompts": "AI Prompts",
     "AIPrompt": "AI Prompt",

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Domain.Shared/Localization/AILocalizationKeys.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Domain.Shared/Localization/AILocalizationKeys.cs
@@ -6,4 +6,9 @@ public static class AILocalizationKeys
     public const string ApplicationAnalysisDisabled = "AI:ApplicationAnalysisDisabled";
     public const string ScoringDisabled = "AI:ScoringDisabled";
     public const string GenerateAllDisabled = "AI:GenerateAllDisabled";
+    public const string NoAttachmentsAvailable = "AI:NoAttachmentsAvailable";
+    public const string ApplicationAnalysisRequiresSubmission = "AI:ApplicationAnalysisRequiresSubmission";
+    public const string ScoringRequiresScoresheet = "AI:ScoringRequiresScoresheet";
+    public const string ScoringRequiresScoresheetFields = "AI:ScoringRequiresScoresheetFields";
+    public const string SelectAttachmentForSummaries = "AI:SelectAttachmentForSummaries";
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/ApplicationAIGenerationQueue.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/ApplicationAIGenerationQueue.cs
@@ -3,14 +3,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Unity.AI.Automation;
+using Unity.AI.Features;
+using Unity.AI.Operations;
 using Unity.AI.RateLimit;
 using Unity.GrantManager.GrantApplications;
 using Unity.GrantManager.GrantApplications.Automation.BackgroundJobs;
 using Medallion.Threading;
 using Microsoft.Extensions.Logging;
+using Volo.Abp;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.BackgroundJobs;
 using Volo.Abp.DependencyInjection;
+using Volo.Abp.Features;
 using Volo.Abp.Users;
 
 namespace Unity.GrantManager.GrantApplications.Automation;
@@ -19,6 +23,8 @@ public class ApplicationAIGenerationQueue(
     IBackgroundJobManager backgroundJobManager,
     IRepository<AIGenerationRequest, Guid> generationRequestRepository,
     IDistributedLockProvider distributedLockProvider,
+    IAIGenerationPrerequisiteValidator aiGenerationPrerequisiteValidator,
+    IFeatureChecker featureChecker,
     IAIRateLimiter aiRateLimiter,
     ICurrentUser currentUser,
     ILogger<ApplicationAIGenerationQueue> logger)
@@ -32,6 +38,7 @@ public class ApplicationAIGenerationQueue(
             tenantId,
             AIGenerationRequestKeyHelper.AttachmentSummaryOperationType,
             applicationId,
+            () => aiGenerationPrerequisiteValidator.EnsureAttachmentSummaryAvailableAsync(applicationId),
             () =>
             {
                 return backgroundJobManager.EnqueueAsync(new GenerateAttachmentSummaryBackgroundJobArgs
@@ -54,6 +61,7 @@ public class ApplicationAIGenerationQueue(
             tenantId,
             AIGenerationRequestKeyHelper.ApplicationAnalysisOperationType,
             applicationId,
+            () => aiGenerationPrerequisiteValidator.EnsureApplicationAnalysisAvailableAsync(applicationId),
             () =>
             {
                 return backgroundJobManager.EnqueueAsync(new GenerateApplicationAnalysisBackgroundJobArgs
@@ -75,6 +83,7 @@ public class ApplicationAIGenerationQueue(
             tenantId,
             AIGenerationRequestKeyHelper.ApplicationScoringOperationType,
             applicationId,
+            () => aiGenerationPrerequisiteValidator.EnsureApplicationScoringAvailableAsync(applicationId),
             () =>
             {
                 return backgroundJobManager.EnqueueAsync(new GenerateApplicationScoringBackgroundJobArgs
@@ -96,6 +105,7 @@ public class ApplicationAIGenerationQueue(
             tenantId,
             AIGenerationRequestKeyHelper.PipelineOperationType,
             applicationId,
+            () => EnsureAnyPipelineStageAvailableAsync(applicationId),
             () =>
             {
                 return backgroundJobManager.EnqueueAsync(new RunApplicationAIPipelineJobArgs
@@ -114,6 +124,7 @@ public class ApplicationAIGenerationQueue(
         Guid? tenantId,
         string operationType,
         Guid? applicationId,
+        Func<Task> validateInput,
         Func<Task> enqueue)
     {
         var requestLock = distributedLockProvider.CreateLock($"ai-generation:{requestKey}");
@@ -134,6 +145,8 @@ public class ApplicationAIGenerationQueue(
             {
                 return;
             }
+
+            await validateInput();
 
             // Single chokepoint for all AI generate flows (manual + auto).
             // The limiter is a no-op for system/background callers without an authenticated user.
@@ -158,6 +171,60 @@ public class ApplicationAIGenerationQueue(
                 throw;
             }
         }
+    }
+
+    private async Task EnsureAnyPipelineStageAvailableAsync(Guid applicationId)
+    {
+        var hasEnabledStage = false;
+        var hasAvailableStage = false;
+        UserFriendlyException? lastPrerequisiteException = null;
+
+        async Task CheckStageAsync(bool isEnabled, Func<Task> ensurePrerequisite)
+        {
+            if (!isEnabled)
+            {
+                return;
+            }
+
+            hasEnabledStage = true;
+
+            try
+            {
+                await ensurePrerequisite();
+                hasAvailableStage = true;
+            }
+            catch (UserFriendlyException ex)
+            {
+                lastPrerequisiteException = ex;
+            }
+        }
+
+        await CheckStageAsync(
+            await featureChecker.IsEnabledAsync(AIFeatures.AttachmentSummaries),
+            () => aiGenerationPrerequisiteValidator.EnsureAttachmentSummaryAvailableAsync(applicationId));
+        await CheckStageAsync(
+            await featureChecker.IsEnabledAsync(AIFeatures.ApplicationAnalysis),
+            () => aiGenerationPrerequisiteValidator.EnsureApplicationAnalysisAvailableAsync(applicationId));
+        await CheckStageAsync(
+            await featureChecker.IsEnabledAsync(AIFeatures.Scoring),
+            () => aiGenerationPrerequisiteValidator.EnsureApplicationScoringAvailableAsync(applicationId));
+
+        if (hasAvailableStage)
+        {
+            return;
+        }
+
+        if (lastPrerequisiteException != null)
+        {
+            throw lastPrerequisiteException;
+        }
+
+        if (!hasEnabledStage)
+        {
+            throw new UserFriendlyException("AI generation is not enabled.");
+        }
+
+        throw new UserFriendlyException("No AI generation stages have the required input to run.");
     }
 
     private async Task MarkFailedBestEffortAsync(AIGenerationRequest request, Exception exception)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/ApplicationAIGenerationQueue.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/ApplicationAIGenerationQueue.cs
@@ -4,12 +4,14 @@ using System.Linq;
 using System.Threading.Tasks;
 using Unity.AI.Automation;
 using Unity.AI.Features;
+using Unity.AI.Localization;
 using Unity.AI.Operations;
 using Unity.AI.RateLimit;
 using Unity.GrantManager.GrantApplications;
 using Unity.GrantManager.GrantApplications.Automation.BackgroundJobs;
 using Medallion.Threading;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Localization;
 using Volo.Abp;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.BackgroundJobs;
@@ -27,7 +29,8 @@ public class ApplicationAIGenerationQueue(
     IFeatureChecker featureChecker,
     IAIRateLimiter aiRateLimiter,
     ICurrentUser currentUser,
-    ILogger<ApplicationAIGenerationQueue> logger)
+    ILogger<ApplicationAIGenerationQueue> logger,
+    IStringLocalizer<AIResource> localizer)
     : IApplicationAIGenerationQueue, ITransientDependency
 {
     public async Task QueueAttachmentSummaryAsync(Guid applicationId, Guid? tenantId, string? promptVersion = null, List<Guid>? attachmentIds = null)
@@ -221,10 +224,8 @@ public class ApplicationAIGenerationQueue(
 
         if (!hasEnabledStage)
         {
-            throw new UserFriendlyException("AI generation is not enabled.");
+            throw new UserFriendlyException(localizer[AILocalizationKeys.GenerateAllDisabled]);
         }
-
-        throw new UserFriendlyException("No AI generation stages have the required input to run.");
     }
 
     private async Task MarkFailedBestEffortAsync(AIGenerationRequest request, Exception exception)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/RunApplicationAIPipelineJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/RunApplicationAIPipelineJob.cs
@@ -3,11 +3,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Unity.AI.Operations;
 using Unity.AI.RateLimit;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Attachments;
 using Unity.GrantManager.GrantApplications;
 using Unity.GrantManager.GrantApplications.Automation.Events;
+using Volo.Abp;
 using Volo.Abp.BackgroundJobs;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Repositories;
@@ -23,6 +25,7 @@ public class RunApplicationAIPipelineJob(
     IAttachmentSummaryAppService attachmentSummaryAppService,
     IApplicationAnalysisAppService applicationAnalysisAppService,
     IApplicationScoringAppService applicationScoringAppService,
+    IAIGenerationPrerequisiteValidator aiGenerationPrerequisiteValidator,
     IFeatureChecker featureChecker,
     ILocalEventBus localEventBus,
     IRepository<AIGenerationRequest, Guid> generationRequestRepository,
@@ -58,7 +61,10 @@ public class RunApplicationAIPipelineJob(
 
                 logger.LogInformation("Executing queued AI content pipeline for application {ApplicationId}.", args.ApplicationId);
 
-                if (attachmentSummariesEnabled)
+                if (attachmentSummariesEnabled && await HasStageInputAsync(
+                    args.ApplicationId,
+                    "attachment summaries",
+                    () => aiGenerationPrerequisiteValidator.EnsureAttachmentSummaryAvailableAsync(args.ApplicationId)))
                 {
                     var attachmentIds = await GetAttachmentIdsAsync(args.ApplicationId);
                     var attachmentResults = await attachmentSummaryAppService.GenerateAttachmentSummariesForPipelineAsync(attachmentIds, args.PromptVersion);
@@ -68,7 +74,10 @@ public class RunApplicationAIPipelineJob(
                 Exception? analysisException = null;
                 Exception? scoringException = null;
 
-                if (applicationAnalysisEnabled)
+                if (applicationAnalysisEnabled && await HasStageInputAsync(
+                    args.ApplicationId,
+                    "application analysis",
+                    () => aiGenerationPrerequisiteValidator.EnsureApplicationAnalysisAvailableAsync(args.ApplicationId)))
                 {
                     try
                     {
@@ -85,7 +94,10 @@ public class RunApplicationAIPipelineJob(
                     }
                 }
 
-                if (scoringEnabled)
+                if (scoringEnabled && await HasStageInputAsync(
+                    args.ApplicationId,
+                    "application scoring",
+                    () => aiGenerationPrerequisiteValidator.EnsureApplicationScoringAvailableAsync(args.ApplicationId)))
                 {
                     try
                     {
@@ -123,6 +135,24 @@ public class RunApplicationAIPipelineJob(
                 await AIGenerationRequestJobHelper.MarkFailedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey, ex.Message);
                 throw;
             }
+        }
+    }
+
+    private async Task<bool> HasStageInputAsync(Guid applicationId, string stageName, Func<Task> ensurePrerequisite)
+    {
+        try
+        {
+            await ensurePrerequisite();
+            return true;
+        }
+        catch (UserFriendlyException ex)
+        {
+            logger.LogInformation(
+                ex,
+                "Skipping AI {StageName} stage for application {ApplicationId} because required input is unavailable.",
+                stageName,
+                applicationId);
+            return false;
         }
     }
 

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/AttachmentSummaryServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/AttachmentSummaryServiceTests.cs
@@ -13,6 +13,7 @@ using Unity.AI.Requests;
 using Unity.AI.Responses;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Intakes;
+using Volo.Abp;
 using Xunit;
 
 namespace Unity.GrantManager.AI.Operations;
@@ -51,11 +52,14 @@ public class AttachmentSummaryServiceTests
         aiService.GenerateAttachmentSummaryAsync(Arg.Do<AttachmentSummaryRequest>(request => capturedRequest = request))
             .Returns(new AttachmentSummaryResponse { Summary = "summary text" });
 
+        var prerequisiteValidator = Substitute.For<IAIGenerationPrerequisiteValidator>();
+
         var service = new AttachmentSummaryService(
             attachmentRepository,
             streamProvider,
             textExtractionService,
             aiService,
+            prerequisiteValidator,
             new AIExecutionModeResolver(new ConfigurationBuilder().Build()),
             NullLogger<AttachmentSummaryService>.Instance);
 
@@ -103,10 +107,34 @@ public class AttachmentSummaryServiceTests
             streamProvider,
             Substitute.For<ITextExtractionService>(),
             Substitute.For<IAIService>(),
+            Substitute.For<IAIGenerationPrerequisiteValidator>(),
             new AIExecutionModeResolver(new ConfigurationBuilder().Build()),
             NullLogger<AttachmentSummaryService>.Instance);
 
         await Should.ThrowAsync<OperationCanceledException>(() =>
             service.GenerateAndSaveAsync(attachmentId, "v1", cancellationTokenSource.Token));
+    }
+
+    [Fact]
+    public async Task GenerateAndSaveAsync_Should_Reject_Empty_Attachment_List()
+    {
+        var attachmentRepository = Substitute.For<IApplicationChefsFileAttachmentRepository>();
+        var streamProvider = Substitute.For<IChefsFileAttachmentStreamProvider>();
+        var textExtractionService = Substitute.For<ITextExtractionService>();
+        var aiService = Substitute.For<IAIService>();
+        var prerequisiteValidator = Substitute.For<IAIGenerationPrerequisiteValidator>();
+
+        var service = new AttachmentSummaryService(
+            attachmentRepository,
+            streamProvider,
+            textExtractionService,
+            aiService,
+            prerequisiteValidator,
+            new AIExecutionModeResolver(new ConfigurationBuilder().Build()),
+            NullLogger<AttachmentSummaryService>.Instance);
+
+        await Should.ThrowAsync<UserFriendlyException>(() => service.GenerateAndSaveAsync([], "v1"));
+
+        await aiService.DidNotReceive().GenerateAttachmentSummaryAsync(Arg.Any<AttachmentSummaryRequest>());
     }
 }

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/AttachmentSummaryServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/AttachmentSummaryServiceTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Shouldly;
@@ -8,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Unity.AI;
 using Unity.AI.Extraction;
+using Unity.AI.Localization;
 using Unity.AI.Operations;
 using Unity.AI.Requests;
 using Unity.AI.Responses;
@@ -61,7 +63,8 @@ public class AttachmentSummaryServiceTests
             aiService,
             prerequisiteValidator,
             new AIExecutionModeResolver(new ConfigurationBuilder().Build()),
-            NullLogger<AttachmentSummaryService>.Instance);
+            NullLogger<AttachmentSummaryService>.Instance,
+            Substitute.For<IStringLocalizer<AIResource>>());
 
         var result = await service.GenerateAndSaveAsync(attachmentId, "v1");
 
@@ -109,7 +112,8 @@ public class AttachmentSummaryServiceTests
             Substitute.For<IAIService>(),
             Substitute.For<IAIGenerationPrerequisiteValidator>(),
             new AIExecutionModeResolver(new ConfigurationBuilder().Build()),
-            NullLogger<AttachmentSummaryService>.Instance);
+            NullLogger<AttachmentSummaryService>.Instance,
+            Substitute.For<IStringLocalizer<AIResource>>());
 
         await Should.ThrowAsync<OperationCanceledException>(() =>
             service.GenerateAndSaveAsync(attachmentId, "v1", cancellationTokenSource.Token));
@@ -131,7 +135,8 @@ public class AttachmentSummaryServiceTests
             aiService,
             prerequisiteValidator,
             new AIExecutionModeResolver(new ConfigurationBuilder().Build()),
-            NullLogger<AttachmentSummaryService>.Instance);
+            NullLogger<AttachmentSummaryService>.Instance,
+            Substitute.For<IStringLocalizer<AIResource>>());
 
         await Should.ThrowAsync<UserFriendlyException>(() => service.GenerateAndSaveAsync([], "v1"));
 

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/AIGenerationQueueTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/AIGenerationQueueTests.cs
@@ -1,4 +1,5 @@
 using Medallion.Threading;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Shouldly;
@@ -8,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Unity.AI.Features;
+using Unity.AI.Localization;
 using Unity.AI.RateLimit;
 using Unity.AI.Operations;
 using Unity.GrantManager.GrantApplications;
@@ -123,6 +125,40 @@ public class AIGenerationQueueTests(ITestOutputHelper outputHelper) : GrantManag
 
         await Should.ThrowAsync<UserFriendlyException>(() => queue.QueueAllAIStagesAsync(applicationId, tenantId));
 
+        await rateLimiter.DidNotReceive().EnsureAsync();
+        await repository.DidNotReceive().InsertAsync(Arg.Any<AIGenerationRequest>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await backgroundJobManager.DidNotReceive().EnqueueAsync(Arg.Any<RunApplicationAIPipelineJobArgs>(), Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
+    }
+
+    [Fact]
+    public async Task QueueAllAIStagesAsync_Should_Not_Insert_Or_Enqueue_When_No_AI_Stages_Are_Enabled()
+    {
+        var applicationId = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        var repository = Substitute.For<IRepository<AIGenerationRequest, Guid>>();
+        repository.GetQueryableAsync().Returns(Task.FromResult<IQueryable<AIGenerationRequest>>(Array.Empty<AIGenerationRequest>().AsQueryable()));
+
+        var backgroundJobManager = Substitute.For<IBackgroundJobManager>();
+        var rateLimiter = Substitute.For<IAIRateLimiter>();
+        rateLimiter.EnsureAsync().Returns(Task.CompletedTask);
+        var prerequisiteValidator = Substitute.For<IAIGenerationPrerequisiteValidator>();
+        var featureChecker = Substitute.For<IFeatureChecker>();
+        featureChecker.IsEnabledAsync(AIFeatures.AttachmentSummaries).Returns(Task.FromResult(false));
+        featureChecker.IsEnabledAsync(AIFeatures.ApplicationAnalysis).Returns(Task.FromResult(false));
+        featureChecker.IsEnabledAsync(AIFeatures.Scoring).Returns(Task.FromResult(false));
+
+        var queue = CreateQueue(
+            backgroundJobManager,
+            repository,
+            rateLimiter,
+            prerequisiteValidator,
+            featureChecker);
+
+        await Should.ThrowAsync<UserFriendlyException>(() => queue.QueueAllAIStagesAsync(applicationId, tenantId));
+
+        await prerequisiteValidator.DidNotReceive().EnsureAttachmentSummaryAvailableAsync(Arg.Any<Guid>());
+        await prerequisiteValidator.DidNotReceive().EnsureApplicationAnalysisAvailableAsync(Arg.Any<Guid>());
+        await prerequisiteValidator.DidNotReceive().EnsureApplicationScoringAvailableAsync(Arg.Any<Guid>());
         await rateLimiter.DidNotReceive().EnsureAsync();
         await repository.DidNotReceive().InsertAsync(Arg.Any<AIGenerationRequest>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await backgroundJobManager.DidNotReceive().EnqueueAsync(Arg.Any<RunApplicationAIPipelineJobArgs>(), Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
@@ -471,7 +507,8 @@ public class AIGenerationQueueTests(ITestOutputHelper outputHelper) : GrantManag
             featureChecker,
             rateLimiter,
             CreateCurrentUser(),
-            Substitute.For<ILogger<ApplicationAIGenerationQueue>>());
+            Substitute.For<ILogger<ApplicationAIGenerationQueue>>(),
+            Substitute.For<IStringLocalizer<AIResource>>());
     }
 
     private static readonly Guid CreateQueueCurrentUserId = Guid.NewGuid();

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/AIGenerationQueueTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/AIGenerationQueueTests.cs
@@ -7,13 +7,17 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Unity.AI.Features;
 using Unity.AI.RateLimit;
+using Unity.AI.Operations;
 using Unity.GrantManager.GrantApplications;
 using Unity.GrantManager.GrantApplications.Automation;
 using Unity.GrantManager.GrantApplications.Automation.BackgroundJobs;
 using Volo.Abp.BackgroundJobs;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.DistributedLocking;
+using Volo.Abp;
+using Volo.Abp.Features;
 using Volo.Abp.Users;
 using Xunit;
 using Xunit.Abstractions;
@@ -61,6 +65,67 @@ public class AIGenerationQueueTests(ITestOutputHelper outputHelper) : GrantManag
             r.OperationType == AIGenerationRequestKeyHelper.PipelineOperationType &&
             r.RequestKey == capturedArgs.RequestKey &&
             r.Status == AIGenerationRequestStatus.Queued), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueueAllAIStagesAsync_Should_Enqueue_When_Any_Enabled_Stage_Has_Required_Input()
+    {
+        var applicationId = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        var repository = Substitute.For<IRepository<AIGenerationRequest, Guid>>();
+        repository.GetQueryableAsync().Returns(Task.FromResult<IQueryable<AIGenerationRequest>>(Array.Empty<AIGenerationRequest>().AsQueryable()));
+        repository.InsertAsync(Arg.Any<AIGenerationRequest>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => Task.FromResult(callInfo.Arg<AIGenerationRequest>()));
+
+        var backgroundJobManager = Substitute.For<IBackgroundJobManager>();
+        var prerequisiteValidator = Substitute.For<IAIGenerationPrerequisiteValidator>();
+        prerequisiteValidator.EnsureAttachmentSummaryAvailableAsync(applicationId)
+            .Returns<Task>(_ => throw new UserFriendlyException("No attachments are available to summarize."));
+        prerequisiteValidator.EnsureApplicationAnalysisAvailableAsync(applicationId).Returns(Task.CompletedTask);
+        prerequisiteValidator.EnsureApplicationScoringAvailableAsync(applicationId)
+            .Returns<Task>(_ => throw new UserFriendlyException("AI scoring requires a configured scoresheet."));
+
+        var queue = CreateQueue(
+            backgroundJobManager,
+            repository,
+            prerequisiteValidator: prerequisiteValidator);
+
+        await queue.QueueAllAIStagesAsync(applicationId, tenantId);
+
+        await repository.Received(1).InsertAsync(Arg.Any<AIGenerationRequest>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await backgroundJobManager.Received(1).EnqueueAsync(Arg.Any<RunApplicationAIPipelineJobArgs>(), Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
+    }
+
+    [Fact]
+    public async Task QueueAllAIStagesAsync_Should_Not_Insert_Or_Enqueue_When_No_Enabled_Stage_Has_Required_Input()
+    {
+        var applicationId = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        var repository = Substitute.For<IRepository<AIGenerationRequest, Guid>>();
+        repository.GetQueryableAsync().Returns(Task.FromResult<IQueryable<AIGenerationRequest>>(Array.Empty<AIGenerationRequest>().AsQueryable()));
+
+        var backgroundJobManager = Substitute.For<IBackgroundJobManager>();
+        var rateLimiter = Substitute.For<IAIRateLimiter>();
+        rateLimiter.EnsureAsync().Returns(Task.CompletedTask);
+        var prerequisiteValidator = Substitute.For<IAIGenerationPrerequisiteValidator>();
+        prerequisiteValidator.EnsureAttachmentSummaryAvailableAsync(applicationId)
+            .Returns<Task>(_ => throw new UserFriendlyException("No attachments are available to summarize."));
+        prerequisiteValidator.EnsureApplicationAnalysisAvailableAsync(applicationId)
+            .Returns<Task>(_ => throw new UserFriendlyException("AI application analysis requires application submission data."));
+        prerequisiteValidator.EnsureApplicationScoringAvailableAsync(applicationId)
+            .Returns<Task>(_ => throw new UserFriendlyException("AI scoring requires a configured scoresheet."));
+
+        var queue = CreateQueue(
+            backgroundJobManager,
+            repository,
+            rateLimiter,
+            prerequisiteValidator);
+
+        await Should.ThrowAsync<UserFriendlyException>(() => queue.QueueAllAIStagesAsync(applicationId, tenantId));
+
+        await rateLimiter.DidNotReceive().EnsureAsync();
+        await repository.DidNotReceive().InsertAsync(Arg.Any<AIGenerationRequest>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await backgroundJobManager.DidNotReceive().EnqueueAsync(Arg.Any<RunApplicationAIPipelineJobArgs>(), Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
     }
 
     [Fact]
@@ -173,6 +238,29 @@ public class AIGenerationQueueTests(ITestOutputHelper outputHelper) : GrantManag
         await rateLimiter.Received(1).EnsureAsync();
         await repository.DidNotReceive().InsertAsync(Arg.Any<AIGenerationRequest>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await backgroundJobManager.DidNotReceive().EnqueueAsync(Arg.Any<GenerateApplicationAnalysisBackgroundJobArgs>(), Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
+    }
+
+    [Fact]
+    public async Task QueueAttachmentSummaryAsync_Should_Not_Insert_Or_Enqueue_When_No_Attachments_Are_Available()
+    {
+        var applicationId = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        var repository = Substitute.For<IRepository<AIGenerationRequest, Guid>>();
+        repository.GetQueryableAsync().Returns(Task.FromResult<IQueryable<AIGenerationRequest>>(Array.Empty<AIGenerationRequest>().AsQueryable()));
+
+        var backgroundJobManager = Substitute.For<IBackgroundJobManager>();
+        var rateLimiter = Substitute.For<IAIRateLimiter>();
+        rateLimiter.EnsureAsync().Returns(Task.CompletedTask);
+        var prerequisiteValidator = Substitute.For<IAIGenerationPrerequisiteValidator>();
+        prerequisiteValidator.EnsureAttachmentSummaryAvailableAsync(applicationId)
+            .Returns<Task>(_ => throw new UserFriendlyException("No attachments are available to summarize."));
+        var queue = CreateQueue(backgroundJobManager, repository, rateLimiter, prerequisiteValidator);
+
+        await Should.ThrowAsync<UserFriendlyException>(() => queue.QueueAttachmentSummaryAsync(applicationId, tenantId));
+
+        await rateLimiter.DidNotReceive().EnsureAsync();
+        await repository.DidNotReceive().InsertAsync(Arg.Any<AIGenerationRequest>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await backgroundJobManager.DidNotReceive().EnqueueAsync(Arg.Any<GenerateAttachmentSummaryBackgroundJobArgs>(), Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
     }
 
     [Fact]
@@ -349,7 +437,9 @@ public class AIGenerationQueueTests(ITestOutputHelper outputHelper) : GrantManag
     private static ApplicationAIGenerationQueue CreateQueue(
         IBackgroundJobManager backgroundJobManager,
         IRepository<AIGenerationRequest, Guid> repository,
-        Unity.AI.RateLimit.IAIRateLimiter? rateLimiter = null)
+        Unity.AI.RateLimit.IAIRateLimiter? rateLimiter = null,
+        IAIGenerationPrerequisiteValidator? prerequisiteValidator = null,
+        IFeatureChecker? featureChecker = null)
     {
         if (rateLimiter == null)
         {
@@ -357,10 +447,28 @@ public class AIGenerationQueueTests(ITestOutputHelper outputHelper) : GrantManag
             rateLimiter.EnsureAsync().Returns(Task.CompletedTask);
         }
 
+        if (prerequisiteValidator == null)
+        {
+            prerequisiteValidator = Substitute.For<IAIGenerationPrerequisiteValidator>();
+            prerequisiteValidator.EnsureAttachmentSummaryAvailableAsync(Arg.Any<Guid>()).Returns(Task.CompletedTask);
+            prerequisiteValidator.EnsureApplicationAnalysisAvailableAsync(Arg.Any<Guid>()).Returns(Task.CompletedTask);
+            prerequisiteValidator.EnsureApplicationScoringAvailableAsync(Arg.Any<Guid>()).Returns(Task.CompletedTask);
+        }
+
+        if (featureChecker == null)
+        {
+            featureChecker = Substitute.For<IFeatureChecker>();
+            featureChecker.IsEnabledAsync(AIFeatures.AttachmentSummaries).Returns(Task.FromResult(true));
+            featureChecker.IsEnabledAsync(AIFeatures.ApplicationAnalysis).Returns(Task.FromResult(true));
+            featureChecker.IsEnabledAsync(AIFeatures.Scoring).Returns(Task.FromResult(true));
+        }
+
         return new ApplicationAIGenerationQueue(
             backgroundJobManager,
             repository,
             new TestDistributedLockProvider(),
+            prerequisiteValidator,
+            featureChecker,
             rateLimiter,
             CreateCurrentUser(),
             Substitute.For<ILogger<ApplicationAIGenerationQueue>>());

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/RunApplicationAIPipelineJobTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/Automation/RunApplicationAIPipelineJobTests.cs
@@ -6,10 +6,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Unity.AI.Operations;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Attachments;
 using Unity.GrantManager.GrantApplications.Automation.BackgroundJobs;
 using Unity.AI.RateLimit;
+using Volo.Abp;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.EventBus.Local;
 using Volo.Abp.Features;
@@ -87,6 +89,49 @@ public class RunApplicationAIPipelineJobTests(ITestOutputHelper outputHelper) : 
             Arg.Is<Automation.Events.ApplicationAIScoringGeneratedEvent>(x => x.ApplicationId == request.ApplicationId));
     }
 
+    [Fact]
+    public async Task ExecuteAsync_Should_Skip_Unavailable_Stage_And_Run_Available_Stage()
+    {
+        var featureChecker = Substitute.For<IFeatureChecker>();
+        featureChecker.IsEnabledAsync("Unity.AI.AttachmentSummaries").Returns(true);
+        featureChecker.IsEnabledAsync("Unity.AI.ApplicationAnalysis").Returns(true);
+        featureChecker.IsEnabledAsync("Unity.AI.Scoring").Returns(false);
+
+        var repository = BuildRequestRepository(out var requests);
+        var request = CreateRequest();
+        requests.Add(request);
+
+        var prerequisiteValidator = Substitute.For<IAIGenerationPrerequisiteValidator>();
+        prerequisiteValidator.EnsureAttachmentSummaryAvailableAsync(request.ApplicationId!.Value)
+            .Returns<Task>(_ => throw new UserFriendlyException("No attachments are available to summarize."));
+        prerequisiteValidator.EnsureApplicationAnalysisAvailableAsync(request.ApplicationId.Value)
+            .Returns(Task.CompletedTask);
+
+        var attachmentSummaryAppService = Substitute.For<IAttachmentSummaryAppService>();
+        var applicationAnalysisAppService = Substitute.For<IApplicationAnalysisAppService>();
+        applicationAnalysisAppService.GenerateApplicationAnalysisForPipelineAsync(Arg.Any<Guid>(), Arg.Any<string?>())
+            .Returns(new ApplicationAnalysisResultDto { Completed = true });
+
+        var job = BuildJob(
+            featureChecker,
+            repository,
+            attachmentSummaryAppService: attachmentSummaryAppService,
+            applicationAnalysisAppService: applicationAnalysisAppService,
+            prerequisiteValidator: prerequisiteValidator);
+
+        await job.ExecuteAsync(new RunApplicationAIPipelineJobArgs
+        {
+            ApplicationId = request.ApplicationId.Value,
+            RequestKey = request.RequestKey,
+            RequestedByUserId = Guid.NewGuid(),
+            TenantId = request.TenantId
+        });
+
+        request.Status.ShouldBe(AIGenerationRequestStatus.Completed);
+        await attachmentSummaryAppService.DidNotReceive().GenerateAttachmentSummariesForPipelineAsync(Arg.Any<List<Guid>>(), Arg.Any<string?>());
+        await applicationAnalysisAppService.Received(1).GenerateApplicationAnalysisForPipelineAsync(request.ApplicationId.Value, Arg.Any<string?>());
+    }
+
     private RunApplicationAIPipelineJob BuildJob(
         IFeatureChecker featureChecker,
         IRepository<AIGenerationRequest, Guid> generationRequestRepository,
@@ -94,13 +139,23 @@ public class RunApplicationAIPipelineJobTests(ITestOutputHelper outputHelper) : 
         IAttachmentSummaryAppService? attachmentSummaryAppService = null,
         IApplicationAnalysisAppService? applicationAnalysisAppService = null,
         IApplicationScoringAppService? applicationScoringAppService = null,
+        IAIGenerationPrerequisiteValidator? prerequisiteValidator = null,
         IAIRateLimiter? rateLimiter = null)
     {
+        if (prerequisiteValidator == null)
+        {
+            prerequisiteValidator = Substitute.For<IAIGenerationPrerequisiteValidator>();
+            prerequisiteValidator.EnsureAttachmentSummaryAvailableAsync(Arg.Any<Guid>()).Returns(Task.CompletedTask);
+            prerequisiteValidator.EnsureApplicationAnalysisAvailableAsync(Arg.Any<Guid>()).Returns(Task.CompletedTask);
+            prerequisiteValidator.EnsureApplicationScoringAvailableAsync(Arg.Any<Guid>()).Returns(Task.CompletedTask);
+        }
+
         return new RunApplicationAIPipelineJob(
             Substitute.For<IApplicationChefsFileAttachmentRepository>(),
             attachmentSummaryAppService ?? Substitute.For<IAttachmentSummaryAppService>(),
             applicationAnalysisAppService ?? Substitute.For<IApplicationAnalysisAppService>(),
             applicationScoringAppService ?? Substitute.For<IApplicationScoringAppService>(),
+            prerequisiteValidator,
             featureChecker,
             localEventBus ?? Substitute.For<ILocalEventBus>(),
             generationRequestRepository,


### PR DESCRIPTION
## Summary
- Adds prerequisite validation before queueing AI generation requests.
- Prevents empty attachment summary, application analysis, and scoring requests from being enqueued.
- Skips unavailable stages during full pipeline execution so available stages can still run.

## Validation
- `dotnet test applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/Unity.GrantManager.Application.Tests.csproj --filter "FullyQualifiedName~RunApplicationAIPipelineJobTests|FullyQualifiedName~AIGenerationQueueTests|FullyQualifiedName~AttachmentSummaryServiceTests"`
