### PR TITLE
AB#33267 structure empty AI attachment context

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Prompts/Versions/v1/application-analysis.system.txt
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Prompts/Versions/v1/application-analysis.system.txt
@@ -3,7 +3,7 @@ You are a careful grant review assistant for human reviewers. Do not fill gaps, 
 
 TASK
 Using SCHEMA, DATA, ATTACHMENTS, RUBRIC, SCORE, OUTPUT, and RULES:
-1. Review the application and attachments for the strongest reviewer-relevant evidence.
+1. Review the application and any provided attachments for the strongest reviewer-relevant evidence.
 2. Determine which conclusions are directly supported by that evidence.
 3. Exclude weak, repetitive, or loosely supported conclusions.
 4. Return only the strongest evidence-backed reviewer conclusions.

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Prompts/Versions/v1/application-scoring.system.txt
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Prompts/Versions/v1/application-scoring.system.txt
@@ -5,7 +5,7 @@ TASK
 Using DATA, ATTACHMENTS, SECTION, RESPONSE, OUTPUT, and RULES:
 1. Review each question in SECTION one at a time.
 2. Identify the exact condition the question asks about.
-3. Consider only the most relevant evidence in DATA and ATTACHMENTS for that condition.
+3. Consider only the most relevant evidence in DATA and any provided ATTACHMENTS for that condition.
 4. Choose the most conservative valid answer supported by that evidence.
 5. If evidence is incomplete or indirect, explain the uncertainty in the rationale.
 6. Repeat for every question in SECTION.

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Prompts/Versions/v1/common.rules.txt
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Prompts/Versions/v1/common.rules.txt
@@ -1,4 +1,5 @@
 - Any narrative text response must be at least 12 words.
+- If ATTACHMENTS is empty, use DATA only and do not mention missing attachments unless their absence is material to the specific conclusion or question.
 - Return values exactly as specified in OUTPUT.
 - Do not return keys outside OUTPUT.
 - Return valid JSON only.

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
@@ -198,7 +198,7 @@ namespace Unity.AI.Runtime
             {
                 var attachments = attachmentSummaries.Count > 0
                     ? string.Join("\n- ", attachmentSummaries.Select((summary, index) => $"Attachment {index + 1}: {summary}"))
-                    : "No attachments provided.";
+                    : "[]";
 
                 var section = OpenAIPromptRenderer.BuildAliasedApplicationScoringSection(request.SectionName, sectionJson, out var questionIdAliasMap);
                 var response = OpenAIPromptRenderer.BuildApplicationScoringResponseTemplate(section);

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/DataSeed/AIPromptDataSeeder.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/DataSeed/AIPromptDataSeeder.cs
@@ -278,7 +278,7 @@ public class AIPromptDataSeeder(
 
         TASK
         Using SCHEMA, DATA, ATTACHMENTS, RUBRIC, SCORE, OUTPUT, and RULES:
-        1. Review the application and attachments for the strongest reviewer-relevant evidence.
+        1. Review the application and any provided attachments for the strongest reviewer-relevant evidence.
         2. Determine which conclusions are directly supported by that evidence.
         3. Exclude weak, repetitive, or loosely supported conclusions.
         4. Return only the strongest evidence-backed reviewer conclusions.
@@ -520,7 +520,7 @@ public class AIPromptDataSeeder(
         Using DATA, ATTACHMENTS, SECTION, RESPONSE, OUTPUT, and RULES:
         1. Review each question in SECTION one at a time.
         2. Identify the exact condition the question asks about.
-        3. Consider only the most relevant evidence in DATA and ATTACHMENTS for that condition.
+        3. Consider only the most relevant evidence in DATA and any provided ATTACHMENTS for that condition.
         4. Choose the most conservative valid answer supported by that evidence.
         5. If evidence is incomplete or indirect, explain the uncertainty in the rationale.
         6. Repeat for every question in SECTION.
@@ -583,6 +583,7 @@ public class AIPromptDataSeeder(
     // ── v1/common.rules.txt ──────────────────────────────────────────────────
     private const string CommonRules = """
         - Any narrative text response must be at least 12 words.
+        - If ATTACHMENTS is empty, use DATA only and do not mention missing attachments unless their absence is material to the specific conclusion or question.
         - Return values exactly as specified in OUTPUT.
         - Do not return keys outside OUTPUT.
         - Return valid JSON only.

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAIPromptRendererTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAIPromptRendererTests.cs
@@ -26,4 +26,20 @@ public class OpenAIPromptRendererTests
     {
         Should.Throw<InvalidOperationException>(() => OpenAIPromptRenderer.ResolvePromptVersion(version));
     }
+
+    [Fact]
+    public void BuildApplicationScoringUserPrompt_Should_Render_Structured_Empty_Attachments()
+    {
+        var prompt = OpenAIPromptRenderer.BuildApplicationScoringUserPrompt(
+            "v1",
+            "{}",
+            "[]",
+            "{\"name\":\"Test\",\"questions\":[]}",
+            "{}");
+
+        prompt.ShouldContain("ATTACHMENTS");
+        prompt.ShouldContain("[]");
+        prompt.ShouldContain("If ATTACHMENTS is empty, use DATA only");
+        prompt.ShouldNotContain("No attachments provided.");
+    }
 }


### PR DESCRIPTION
## Summary
- Renders empty AI attachment context as structured `[]`.
- Updates prompt rules and seeded prompt text to handle empty attachments without filler language.
- Adds prompt renderer coverage for structured empty attachment context.

## Validation
- `dotnet test applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/Unity.GrantManager.Application.Tests.csproj --filter "FullyQualifiedName~OpenAIPromptRendererTests"`
