### PR TITLE
AB#33319 unify active AI generation status

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/AIGenerationRequestDto.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/AIGenerationRequestDto.cs
@@ -13,4 +13,6 @@ public class AIGenerationRequestDto : EntityDto<Guid>
     public DateTime? CompletedAt { get; set; }
     public string? FailureReason { get; set; }
     public bool IsActive { get; set; }
+    public bool IsGenerating { get; set; }
+    public int RetryAfterSeconds { get; set; }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/GrantApplicationAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/GrantApplicationAppService.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using Unity.Flex.WorksheetInstances;
 using Unity.Flex.Worksheets;
 using Unity.AI.Models;
+using Unity.AI.RateLimit;
 using Unity.AI.Responses;
 using Unity.GrantManager.Applicants;
 using Unity.GrantManager.ApplicationForms;
@@ -58,6 +59,7 @@ public class GrantApplicationAppService(
     IPaymentRequestAppService paymentRequestService,
     IApplicationAIGenerationQueue aiGenerationQueue,
     IAIGenerationStatusAppService aiGenerationStatusAppService,
+    IAIRateLimiter aiRateLimiter,
     IFeatureChecker featureChecker)
     : GrantManagerAppService, IGrantApplicationAppService
 #pragma warning restore S107 // Methods should not have too many parameters
@@ -1180,7 +1182,8 @@ public class GrantApplicationAppService(
             AIGenerationRequestKeyHelper.ApplicationAnalysisOperationType,
             CurrentTenant.Id);
 
-        return request ?? throw new UserFriendlyException("Unable to queue AI analysis request.");
+        return await ApplyRateLimitStateAsync(
+            request ?? throw new UserFriendlyException("Unable to queue AI analysis request."));
     }
 
     [Authorize(AIPermissions.Analysis.GenerateAttachmentSummaries)]
@@ -1195,7 +1198,8 @@ public class GrantApplicationAppService(
             AIGenerationRequestKeyHelper.AttachmentSummaryOperationType,
             CurrentTenant.Id);
 
-        return request ?? throw new UserFriendlyException("Unable to queue AI attachment summary request.");
+        return await ApplyRateLimitStateAsync(
+            request ?? throw new UserFriendlyException("Unable to queue AI attachment summary request."));
     }
 
     [Authorize(AIPermissions.Analysis.GenerateScoring)]
@@ -1209,13 +1213,15 @@ public class GrantApplicationAppService(
             AIGenerationRequestKeyHelper.ApplicationScoringOperationType,
             CurrentTenant.Id);
 
-        return request ?? throw new UserFriendlyException("Unable to queue AI scoring request.");
+        return await ApplyRateLimitStateAsync(
+            request ?? throw new UserFriendlyException("Unable to queue AI scoring request."));
     }
 
     public async Task<AIGenerationRequestDto?> GetAIGenerationStatusAsync(Guid applicationId, string operationType, string? promptVersion = null)
     {
         await EnsureAIGenerationStatusAccessAsync(operationType);
-        return await aiGenerationStatusAppService.GetLatestAsync(applicationId, operationType, CurrentTenant.Id);
+        return await ApplyRateLimitStateOrDefaultAsync(
+            await aiGenerationStatusAppService.GetLatestAsync(applicationId, operationType, CurrentTenant.Id));
     }
 
     [Authorize(AIPermissions.Analysis.GenerateApplicationAnalysis)]
@@ -1233,7 +1239,26 @@ public class GrantApplicationAppService(
             AIGenerationRequestKeyHelper.PipelineOperationType,
             CurrentTenant.Id);
 
-        return request ?? throw new UserFriendlyException("Unable to queue AI generation request.");
+        return await ApplyRateLimitStateAsync(
+            request ?? throw new UserFriendlyException("Unable to queue AI generation request."));
+    }
+
+    private async Task<AIGenerationRequestDto?> ApplyRateLimitStateOrDefaultAsync(AIGenerationRequestDto? request)
+    {
+        if (request is null)
+        {
+            return null;
+        }
+
+        return await ApplyRateLimitStateAsync(request);
+    }
+
+    private async Task<AIGenerationRequestDto> ApplyRateLimitStateAsync(AIGenerationRequestDto request)
+    {
+        var state = await aiRateLimiter.GetStateAsync();
+        request.IsGenerating = state.IsGenerating;
+        request.RetryAfterSeconds = state.RetryAfterSeconds;
+        return request;
     }
 
     private async Task EnsureAIGenerationStatusAccessAsync(string operationType)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantManagerApplicationMapperlyProfile.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantManagerApplicationMapperlyProfile.cs
@@ -536,7 +536,17 @@ public partial class ApplicationActionResultItemToDtoMapper : MapperBase<Applica
 [Mapper] public partial class CommunityToDtoMapper : MapperBase<Community, CommunityDto> { public override partial CommunityDto Map(Community source); public override partial void Map(Community source, CommunityDto destination); }
 [Mapper] public partial class RegionalDistrictToDtoMapper : MapperBase<RegionalDistrict, RegionalDistrictDto> { public override partial RegionalDistrictDto Map(RegionalDistrict source); public override partial void Map(RegionalDistrict source, RegionalDistrictDto destination); }
 [Mapper] public partial class ApplicationTagsToDtoMapper : MapperBase<ApplicationTags, ApplicationTagsDto> { public override partial ApplicationTagsDto Map(ApplicationTags source); public override partial void Map(ApplicationTags source, ApplicationTagsDto destination); }
-[Mapper] public partial class AIGenerationRequestToDtoMapper : MapperBase<AIGenerationRequest, AIGenerationRequestDto> { public override partial AIGenerationRequestDto Map(AIGenerationRequest source); public override partial void Map(AIGenerationRequest source, AIGenerationRequestDto destination); }
+[Mapper]
+public partial class AIGenerationRequestToDtoMapper : MapperBase<AIGenerationRequest, AIGenerationRequestDto>
+{
+    [MapperIgnoreTarget(nameof(AIGenerationRequestDto.IsGenerating))]
+    [MapperIgnoreTarget(nameof(AIGenerationRequestDto.RetryAfterSeconds))]
+    public override partial AIGenerationRequestDto Map(AIGenerationRequest source);
+
+    [MapperIgnoreTarget(nameof(AIGenerationRequestDto.IsGenerating))]
+    [MapperIgnoreTarget(nameof(AIGenerationRequestDto.RetryAfterSeconds))]
+    public override partial void Map(AIGenerationRequest source, AIGenerationRequestDto destination);
+}
 [Mapper(AllowNullPropertyAssignment = true)]
 public partial class ApplicantToGrantApplicationApplicantDtoMapper : MapperBase<Applicant, GrantApplicationApplicantDto>
 {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-analysis.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-analysis.js
@@ -456,8 +456,8 @@ globalThis.queueApplicationAnalysis = function(triggerButton = null) {
 
             if (status === 'Completed') {
                 globalThis.AIGenerationButtonState?.restoreForCooldownCheck($button, existingHtml);
+                globalThis.AIGenerationButtonState?.applyStatusState(request);
                 loadAIAnalysis();
-                globalThis.syncAIRateLimitButtons?.();
                 return;
             }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-generation-button-state.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-generation-button-state.js
@@ -13,6 +13,16 @@
             .prop('disabled', true);
     }
 
+    function applyRateLimitState(request, options = {}) {
+        global.applyAIRateLimitState?.(
+            {
+                isGenerating: request?.isGenerating === true || request?.isActive === true,
+                retryAfterSeconds: Number(request?.retryAfterSeconds) || 0
+            },
+            { pollWhenGenerating: options.pollWhenGenerating === true }
+        );
+    }
+
     global.AIGenerationButtonState = {
         resolveStatus(status) {
             switch (Number(status)) {
@@ -29,7 +39,7 @@
             }
         },
         setGenerating($button) {
-            global.setAIGenerationButtonsGenerating?.();
+            global.setAIGenerationButtonsGenerating?.({ poll: false });
         },
         restore($button) {
             $button.removeClass('disabled');
@@ -37,17 +47,32 @@
         restoreForCooldownCheck($button, html) {
             restoreButtonForCooldownCheck($button, html);
         },
+        applyStatusState(request) {
+            applyRateLimitState(request, { pollWhenGenerating: true });
+        },
         monitor(options) {
             const intervalMs = options.intervalMs || 15000;
+            const activeIntervalMs = options.activeIntervalMs || 2000;
+            const activePollCount = options.activePollCount || 10;
             const maxFailures = options.maxFailures || 3;
             let timeoutId = null;
             let failures = 0;
+            let pollCount = 0;
 
             const stop = () => {
                 if (timeoutId) {
                     clearTimeout(timeoutId);
                     timeoutId = null;
                 }
+            };
+
+            const scheduleNextPoll = () => {
+                pollCount += 1;
+                const nextIntervalMs = pollCount <= activePollCount
+                    ? activeIntervalMs
+                    : intervalMs;
+
+                timeoutId = setTimeout(poll, nextIntervalMs);
             };
 
             const poll = () => {
@@ -59,19 +84,29 @@
                         if (status === 'Failed') {
                             stop();
                             restoreButton(options.$button, options.originalHtml);
+                            applyRateLimitState(request, { pollWhenGenerating: true });
                             options.onFailed?.(request);
                             return;
                         }
 
-                        if (!request || request.isActive === false || status === 'Completed') {
+                        if (!request) {
                             stop();
-                            restoreButtonForCooldownCheck(options.$button, options.originalHtml);
-                            options.onComplete?.(request);
-                            global.syncAIRateLimitButtons?.();
+                            restoreButton(options.$button, options.originalHtml);
+                            global.refreshAIRateLimitState?.();
+                            options.onMissing?.();
                             return;
                         }
 
-                        timeoutId = setTimeout(poll, intervalMs);
+                        if (request.isActive === false || status === 'Completed') {
+                            stop();
+                            restoreButtonForCooldownCheck(options.$button, options.originalHtml);
+                            applyRateLimitState(request, { pollWhenGenerating: true });
+                            options.onComplete?.(request);
+                            return;
+                        }
+
+                        applyRateLimitState(request);
+                        scheduleNextPoll();
                     })
                     .fail((error) => {
                         failures += 1;
@@ -82,7 +117,7 @@
                             return;
                         }
 
-                        timeoutId = setTimeout(poll, intervalMs);
+                        scheduleNextPoll();
                     });
             };
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-rate-limit.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-rate-limit.js
@@ -121,12 +121,14 @@
         }
     }
 
-    function applyGenerating() {
+    function applyGenerating(options = {}) {
         currentState = { mode: 'generating' };
         renderState();
 
         clearStatePollTimer();
-        statePollTimer = setTimeout(() => fetchState(true), 2000);
+        if (options.poll !== false) {
+            statePollTimer = setTimeout(() => fetchState(true), 2000);
+        }
     }
 
     function renderGenerating() {
@@ -223,16 +225,20 @@
                 return;
             }
             const data = await res.json();
-            if (data.isGenerating === true) {
-                applyGenerating();
-                return;
-            }
-
-            applyCooldown(Number(data.retryAfterSeconds) || 0);
+            applyRateLimitState(data);
         } catch (_) {
             // Best-effort; the server is the source of truth.
             handleStateFetchFailure();
         }
+    }
+
+    function applyRateLimitState(data, options = {}) {
+        if (data?.isGenerating === true) {
+            applyGenerating({ poll: options.pollWhenGenerating !== false });
+            return;
+        }
+
+        applyCooldown(Number(data?.retryAfterSeconds) || 0);
     }
 
     globalThis.syncAIRateLimitButtons = () => {
@@ -240,12 +246,13 @@
         fetchState(true);
     };
     globalThis.setAIGenerationButtonsGenerating = applyGenerating;
+    globalThis.applyAIRateLimitState = applyRateLimitState;
     globalThis.refreshAIRateLimitState = globalThis.syncAIRateLimitButtons;
 
     document.addEventListener('click', (e) => {
         const btn = e.target.closest(BUTTON_SELECTOR);
         if (!btn) return;
-        applyGenerating();
+        applyGenerating({ poll: false });
     });
 
     document.addEventListener('DOMContentLoaded', () => {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentScoresWidget/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentScoresWidget/Default.js
@@ -699,8 +699,8 @@ function queueApplicationScoring(triggerButton = null) {
 
             if (status === 'Completed') {
                 globalThis.AIGenerationButtonState?.restoreForCooldownCheck($button, existingHtml);
+                globalThis.AIGenerationButtonState?.applyStatusState(request);
                 PubSub.publish('refresh_assessment_scores', null);
-                globalThis.syncAIRateLimitButtons?.();
                 return;
             }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/ChefsAttachments.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/ChefsAttachments.js
@@ -212,9 +212,8 @@ $(function () {
                         resetAttachmentSelection();
                         chefsDataTable.ajax.reload();
                         abp.notify.success('AI summaries generated successfully.');
-                        globalThis.AIGenerationButtonState?.restore($activeButton);
-                        $activeButton.html(existingHTML).prop('disabled', false);
-                        globalThis.syncAIRateLimitButtons?.();
+                        globalThis.AIGenerationButtonState?.restoreForCooldownCheck($activeButton, existingHTML);
+                        globalThis.AIGenerationButtonState?.applyStatusState(request);
                         return;
                     }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ReviewList/ReviewList.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ReviewList/ReviewList.js
@@ -477,8 +477,8 @@ function generateAiButtonAction(e, dt, button, config) {
 
             if (status === 'Completed') {
                 restoreReviewListAiButtonForCooldownCheck($button);
+                globalThis.AIGenerationButtonState?.applyStatusState(request);
                 refreshReviewListAfterAiScoring();
-                globalThis.syncAIRateLimitButtons?.();
                 return;
             }
 


### PR DESCRIPTION
## Summary
- Enriches AI generation status responses with shared button/rate-limit state.
- Uses operation-specific polling as the active source of truth for analysis, scoring, and attachment summary generation.
- Keeps global rate-limit sync for page load, widget refresh, resume, and failure fallback paths.

## Validation
- `node --check` on touched AI generation JavaScript files.
- `git diff --check`.
