### PR TITLE
AB#33319 clean up AI generation status DTO

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
@@ -317,12 +317,22 @@ namespace Unity.AI.Runtime
 
         private async Task LogPromptInputAsync(string promptType, string promptVersion, string? systemPrompt, string userPrompt, CancellationToken cancellationToken = default)
         {
+            if (!CanWritePromptFileLog())
+            {
+                return;
+            }
+
             var formattedInput = FormatPromptInputForLog(systemPrompt, userPrompt);
             await WritePromptLogFileAsync(promptType, promptVersion, "INPUT", formattedInput, cancellationToken);
         }
 
         private async Task LogPromptOutputAsync(string promptType, string promptVersion, string output, CancellationToken cancellationToken = default)
         {
+            if (!CanWritePromptFileLog())
+            {
+                return;
+            }
+
             var formattedOutput = FormatPromptOutputForLog(output);
             await WritePromptLogFileAsync(promptType, promptVersion, "OUTPUT", formattedOutput, cancellationToken);
         }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAITransportService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAITransportService.cs
@@ -93,7 +93,10 @@ public class OpenAITransportService(
 
             if (!response.IsSuccessStatusCode)
             {
-                _logger.LogError("OpenAI API request failed: {StatusCode} - {Content}", response.StatusCode, responseContent);
+                _logger.LogError(
+                    "OpenAI API request failed with status {StatusCode}. Response body length: {ResponseLength}.",
+                    response.StatusCode,
+                    responseContent.Length);
                 return MapFailureOutcome(response.StatusCode, providerResponse);
             }
 

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/RateLimit/AIRateLimiter.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/RateLimit/AIRateLimiter.cs
@@ -86,15 +86,11 @@ public class AIRateLimiter(
             return new AIRateLimitStateDto { RetryAfterSeconds = 0, IsGenerating = false };
         }
 
-        var userLock = distributedLockProvider.CreateLock(CooldownLockPrefix + userId);
-        using (await userLock.AcquireAsync())
+        return new AIRateLimitStateDto
         {
-            return new AIRateLimitStateDto
-            {
-                RetryAfterSeconds = await GetRemainingSecondsAsync(userId),
-                IsGenerating = await HasActiveGenerationAsync()
-            };
-        }
+            RetryAfterSeconds = await GetRemainingSecondsAsync(userId),
+            IsGenerating = await HasActiveGenerationAsync()
+        };
     }
 
     private async Task<bool> HasActiveGenerationAsync()

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/AIGenerationRequestDto.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/AIGenerationRequestDto.cs
@@ -13,6 +13,4 @@ public class AIGenerationRequestDto : EntityDto<Guid>
     public DateTime? CompletedAt { get; set; }
     public string? FailureReason { get; set; }
     public bool IsActive { get; set; }
-    public bool IsGenerating { get; set; }
-    public int RetryAfterSeconds { get; set; }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/AIGenerationStatusDto.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/AIGenerationStatusDto.cs
@@ -1,0 +1,8 @@
+namespace Unity.GrantManager.GrantApplications;
+
+public class AIGenerationStatusDto
+{
+    public AIGenerationRequestDto? GenerationRequest { get; set; }
+    public bool IsGenerating { get; set; }
+    public int RetryAfterSeconds { get; set; }
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/IGrantApplicationAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/IGrantApplicationAppService.cs
@@ -18,12 +18,12 @@ public interface IGrantApplicationAppService
     Task<IList<GrantApplicationDto>> GetApplicationDetailsListAsync(List<Guid> applicationIds);
     Task<GrantApplicationDto> GetAsync(Guid id);
     Task<GrantApplicationDto> TriggerAction(Guid applicationId, GrantApplicationAction triggerAction);
-    Task<AIGenerationRequestDto> QueueAIGenerationAsync(Guid applicationId, string? promptVersion = null);
-    Task<AIGenerationRequestDto> QueueApplicationAnalysisAsync(Guid applicationId, string? promptVersion = null);
-    Task<AIGenerationRequestDto> QueueAttachmentSummaryAsync(QueueAttachmentSummaryRequestDto input, string? promptVersion = null);
-    Task<AIGenerationRequestDto> QueueApplicationScoringAsync(Guid applicationId, string? promptVersion = null);
-    Task<AIGenerationRequestDto?> GetAIGenerationStatusAsync(Guid applicationId, string operationType, string? promptVersion = null);
-    Task<AIGenerationRequestDto> QueueAllAIStagesAsync(Guid applicationId, string? promptVersion = null);
+    Task<AIGenerationStatusDto> QueueAIGenerationAsync(Guid applicationId, string? promptVersion = null);
+    Task<AIGenerationStatusDto> QueueApplicationAnalysisAsync(Guid applicationId, string? promptVersion = null);
+    Task<AIGenerationStatusDto> QueueAttachmentSummaryAsync(QueueAttachmentSummaryRequestDto input, string? promptVersion = null);
+    Task<AIGenerationStatusDto> QueueApplicationScoringAsync(Guid applicationId, string? promptVersion = null);
+    Task<AIGenerationStatusDto> GetAIGenerationStatusAsync(Guid applicationId, string operationType, string? promptVersion = null);
+    Task<AIGenerationStatusDto> QueueAllAIStagesAsync(Guid applicationId, string? promptVersion = null);
     Task<Guid?> GetAccountCodingIdFromFormIdAsync(Guid formId);
     Task<string> DismissAIAnalysisItemAsync(Guid applicationId, string itemId);
     Task<string> RestoreAIAnalysisItemAsync(Guid applicationId, string itemId);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/GrantApplicationAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/GrantApplicationAppService.cs
@@ -1165,14 +1165,14 @@ public class GrantApplicationAppService(
         return ObjectMapper.Map<Application, GrantApplicationDto>(application);
     }
 
-    public async Task<AIGenerationRequestDto> QueueAIGenerationAsync(Guid applicationId, string? promptVersion = null)
+    public async Task<AIGenerationStatusDto> QueueAIGenerationAsync(Guid applicationId, string? promptVersion = null)
     {
         await EnsureAIAnalysisEnabledAsync();
         return await QueueApplicationAnalysisAsync(applicationId, promptVersion);
     }
 
     [Authorize(AIPermissions.Analysis.GenerateApplicationAnalysis)]
-    public async Task<AIGenerationRequestDto> QueueApplicationAnalysisAsync(Guid applicationId, string? promptVersion = null)
+    public async Task<AIGenerationStatusDto> QueueApplicationAnalysisAsync(Guid applicationId, string? promptVersion = null)
     {
         await EnsureAIAnalysisEnabledAsync();
         await aiGenerationQueue.QueueApplicationAnalysisAsync(applicationId, CurrentTenant.Id, promptVersion);
@@ -1182,12 +1182,12 @@ public class GrantApplicationAppService(
             AIGenerationRequestKeyHelper.ApplicationAnalysisOperationType,
             CurrentTenant.Id);
 
-        return await ApplyRateLimitStateAsync(
+        return await CreateGenerationStatusAsync(
             request ?? throw new UserFriendlyException("Unable to queue AI analysis request."));
     }
 
     [Authorize(AIPermissions.Analysis.GenerateAttachmentSummaries)]
-    public async Task<AIGenerationRequestDto> QueueAttachmentSummaryAsync(QueueAttachmentSummaryRequestDto input, string? promptVersion = null)
+    public async Task<AIGenerationStatusDto> QueueAttachmentSummaryAsync(QueueAttachmentSummaryRequestDto input, string? promptVersion = null)
     {
         await EnsureAttachmentSummariesEnabledAsync();
         var attachmentIds = await ResolveAttachmentSummaryIdsAsync(input);
@@ -1198,12 +1198,12 @@ public class GrantApplicationAppService(
             AIGenerationRequestKeyHelper.AttachmentSummaryOperationType,
             CurrentTenant.Id);
 
-        return await ApplyRateLimitStateAsync(
+        return await CreateGenerationStatusAsync(
             request ?? throw new UserFriendlyException("Unable to queue AI attachment summary request."));
     }
 
     [Authorize(AIPermissions.Analysis.GenerateScoring)]
-    public async Task<AIGenerationRequestDto> QueueApplicationScoringAsync(Guid applicationId, string? promptVersion = null)
+    public async Task<AIGenerationStatusDto> QueueApplicationScoringAsync(Guid applicationId, string? promptVersion = null)
     {
         await EnsureScoringEnabledAsync();
         await aiGenerationQueue.QueueApplicationScoringAsync(applicationId, CurrentTenant.Id, promptVersion);
@@ -1213,21 +1213,21 @@ public class GrantApplicationAppService(
             AIGenerationRequestKeyHelper.ApplicationScoringOperationType,
             CurrentTenant.Id);
 
-        return await ApplyRateLimitStateAsync(
+        return await CreateGenerationStatusAsync(
             request ?? throw new UserFriendlyException("Unable to queue AI scoring request."));
     }
 
-    public async Task<AIGenerationRequestDto?> GetAIGenerationStatusAsync(Guid applicationId, string operationType, string? promptVersion = null)
+    public async Task<AIGenerationStatusDto> GetAIGenerationStatusAsync(Guid applicationId, string operationType, string? promptVersion = null)
     {
         await EnsureAIGenerationStatusAccessAsync(operationType);
-        return await ApplyRateLimitStateOrDefaultAsync(
+        return await CreateGenerationStatusAsync(
             await aiGenerationStatusAppService.GetLatestAsync(applicationId, operationType, CurrentTenant.Id));
     }
 
     [Authorize(AIPermissions.Analysis.GenerateApplicationAnalysis)]
     [Authorize(AIPermissions.Analysis.GenerateAttachmentSummaries)]
     [Authorize(AIPermissions.Analysis.GenerateScoring)]
-    public async Task<AIGenerationRequestDto> QueueAllAIStagesAsync(Guid applicationId, string? promptVersion = null)
+    public async Task<AIGenerationStatusDto> QueueAllAIStagesAsync(Guid applicationId, string? promptVersion = null)
     {
         await EnsureAttachmentSummariesEnabledAsync();
         await EnsureAIAnalysisEnabledAsync();
@@ -1239,26 +1239,19 @@ public class GrantApplicationAppService(
             AIGenerationRequestKeyHelper.PipelineOperationType,
             CurrentTenant.Id);
 
-        return await ApplyRateLimitStateAsync(
+        return await CreateGenerationStatusAsync(
             request ?? throw new UserFriendlyException("Unable to queue AI generation request."));
     }
 
-    private async Task<AIGenerationRequestDto?> ApplyRateLimitStateOrDefaultAsync(AIGenerationRequestDto? request)
-    {
-        if (request is null)
-        {
-            return null;
-        }
-
-        return await ApplyRateLimitStateAsync(request);
-    }
-
-    private async Task<AIGenerationRequestDto> ApplyRateLimitStateAsync(AIGenerationRequestDto request)
+    private async Task<AIGenerationStatusDto> CreateGenerationStatusAsync(AIGenerationRequestDto? request)
     {
         var state = await aiRateLimiter.GetStateAsync();
-        request.IsGenerating = state.IsGenerating;
-        request.RetryAfterSeconds = state.RetryAfterSeconds;
-        return request;
+        return new AIGenerationStatusDto
+        {
+            GenerationRequest = request,
+            IsGenerating = state.IsGenerating,
+            RetryAfterSeconds = state.RetryAfterSeconds
+        };
     }
 
     private async Task EnsureAIGenerationStatusAccessAsync(string operationType)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantManagerApplicationMapperlyProfile.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantManagerApplicationMapperlyProfile.cs
@@ -536,17 +536,7 @@ public partial class ApplicationActionResultItemToDtoMapper : MapperBase<Applica
 [Mapper] public partial class CommunityToDtoMapper : MapperBase<Community, CommunityDto> { public override partial CommunityDto Map(Community source); public override partial void Map(Community source, CommunityDto destination); }
 [Mapper] public partial class RegionalDistrictToDtoMapper : MapperBase<RegionalDistrict, RegionalDistrictDto> { public override partial RegionalDistrictDto Map(RegionalDistrict source); public override partial void Map(RegionalDistrict source, RegionalDistrictDto destination); }
 [Mapper] public partial class ApplicationTagsToDtoMapper : MapperBase<ApplicationTags, ApplicationTagsDto> { public override partial ApplicationTagsDto Map(ApplicationTags source); public override partial void Map(ApplicationTags source, ApplicationTagsDto destination); }
-[Mapper]
-public partial class AIGenerationRequestToDtoMapper : MapperBase<AIGenerationRequest, AIGenerationRequestDto>
-{
-    [MapperIgnoreTarget(nameof(AIGenerationRequestDto.IsGenerating))]
-    [MapperIgnoreTarget(nameof(AIGenerationRequestDto.RetryAfterSeconds))]
-    public override partial AIGenerationRequestDto Map(AIGenerationRequest source);
-
-    [MapperIgnoreTarget(nameof(AIGenerationRequestDto.IsGenerating))]
-    [MapperIgnoreTarget(nameof(AIGenerationRequestDto.RetryAfterSeconds))]
-    public override partial void Map(AIGenerationRequest source, AIGenerationRequestDto destination);
-}
+[Mapper] public partial class AIGenerationRequestToDtoMapper : MapperBase<AIGenerationRequest, AIGenerationRequestDto> { public override partial AIGenerationRequestDto Map(AIGenerationRequest source); public override partial void Map(AIGenerationRequest source, AIGenerationRequestDto destination); }
 [Mapper(AllowNullPropertyAssignment = true)]
 public partial class ApplicantToGrantApplicationApplicantDtoMapper : MapperBase<Applicant, GrantApplicationApplicantDto>
 {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-analysis.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-analysis.js
@@ -451,12 +451,13 @@ globalThis.queueApplicationAnalysis = function(triggerButton = null) {
 
     unity.grantManager.grantApplications.grantApplication
         .queueApplicationAnalysis(applicationId)
-        .done(function(request) {
+        .done(function(generationStatus) {
+            const request = generationStatus?.generationRequest;
             const status = globalThis.AIGenerationButtonState?.resolveStatus(request?.status) ?? '';
 
             if (status === 'Completed') {
                 globalThis.AIGenerationButtonState?.restoreForCooldownCheck($button, existingHtml);
-                globalThis.AIGenerationButtonState?.applyStatusState(request);
+                globalThis.AIGenerationButtonState?.applyStatusState(generationStatus);
                 loadAIAnalysis();
                 return;
             }
@@ -540,7 +541,8 @@ $(function() {
 
         unity.grantManager.grantApplications.grantApplication
             .getAIGenerationStatus(applicationId, 'application-analysis')
-            .done(function(request) {
+            .done(function(generationStatus) {
+                const request = generationStatus?.generationRequest;
                 if (request?.isActive !== true) {
                     return;
                 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-generation-button-state.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/ai-generation-button-state.js
@@ -13,11 +13,12 @@
             .prop('disabled', true);
     }
 
-    function applyRateLimitState(request, options = {}) {
+    function applyRateLimitState(generationStatus, options = {}) {
+        const request = generationStatus?.generationRequest;
         global.applyAIRateLimitState?.(
             {
-                isGenerating: request?.isGenerating === true || request?.isActive === true,
-                retryAfterSeconds: Number(request?.retryAfterSeconds) || 0
+                isGenerating: generationStatus?.isGenerating === true || request?.isActive === true,
+                retryAfterSeconds: Number(generationStatus?.retryAfterSeconds) || 0
             },
             { pollWhenGenerating: options.pollWhenGenerating === true }
         );
@@ -47,8 +48,8 @@
         restoreForCooldownCheck($button, html) {
             restoreButtonForCooldownCheck($button, html);
         },
-        applyStatusState(request) {
-            applyRateLimitState(request, { pollWhenGenerating: true });
+        applyStatusState(generationStatus) {
+            applyRateLimitState(generationStatus, { pollWhenGenerating: true });
         },
         monitor(options) {
             const intervalMs = options.intervalMs || 15000;
@@ -77,14 +78,15 @@
 
             const poll = () => {
                 options.getStatus()
-                    .done((request) => {
+                    .done((generationStatus) => {
                         failures = 0;
+                        const request = generationStatus?.generationRequest;
                         const status = this.resolveStatus(request?.status);
 
                         if (status === 'Failed') {
                             stop();
                             restoreButton(options.$button, options.originalHtml);
-                            applyRateLimitState(request, { pollWhenGenerating: true });
+                            applyRateLimitState(generationStatus, { pollWhenGenerating: true });
                             options.onFailed?.(request);
                             return;
                         }
@@ -100,12 +102,12 @@
                         if (request.isActive === false || status === 'Completed') {
                             stop();
                             restoreButtonForCooldownCheck(options.$button, options.originalHtml);
-                            applyRateLimitState(request, { pollWhenGenerating: true });
+                            applyRateLimitState(generationStatus, { pollWhenGenerating: true });
                             options.onComplete?.(request);
                             return;
                         }
 
-                        applyRateLimitState(request);
+                        applyRateLimitState(generationStatus);
                         scheduleNextPoll();
                     })
                     .fail((error) => {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentScoresWidget/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentScoresWidget/Default.js
@@ -694,12 +694,13 @@ function queueApplicationScoring(triggerButton = null) {
 
     unity.grantManager.grantApplications.grantApplication
         .queueApplicationScoring(applicationId)
-        .done(function (request) {
+        .done(function (generationStatus) {
+            const request = generationStatus?.generationRequest;
             const status = globalThis.AIGenerationButtonState?.resolveStatus(request?.status) ?? '';
 
             if (status === 'Completed') {
                 globalThis.AIGenerationButtonState?.restoreForCooldownCheck($button, existingHtml);
-                globalThis.AIGenerationButtonState?.applyStatusState(request);
+                globalThis.AIGenerationButtonState?.applyStatusState(generationStatus);
                 PubSub.publish('refresh_assessment_scores', null);
                 return;
             }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/ChefsAttachments.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ChefsAttachments/ChefsAttachments.js
@@ -210,7 +210,8 @@ $(function () {
                     applicationId: getApplicationId(),
                     attachmentIds: summaryAttachmentIds
                 })
-                .done(function (request) {
+                .done(function (generationStatus) {
+                    const request = generationStatus?.generationRequest;
                     const status = globalThis.AIGenerationButtonState?.resolveStatus(request?.status) ?? '';
 
                     if (status === 'Completed') {
@@ -218,7 +219,7 @@ $(function () {
                         chefsDataTable.ajax.reload();
                         abp.notify.success('AI summaries generated successfully.');
                         globalThis.AIGenerationButtonState?.restoreForCooldownCheck($activeButton, existingHTML);
-                        globalThis.AIGenerationButtonState?.applyStatusState(request);
+                        globalThis.AIGenerationButtonState?.applyStatusState(generationStatus);
                         return;
                     }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ReviewList/ReviewList.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ReviewList/ReviewList.js
@@ -472,12 +472,13 @@ function generateAiButtonAction(e, dt, button, config) {
     }
 
     unity.grantManager.grantApplications.grantApplication.queueApplicationScoring(pageApplicationId)
-        .done(function (request) {
+        .done(function (generationStatus) {
+            const request = generationStatus?.generationRequest;
             const status = globalThis.AIGenerationButtonState?.resolveStatus(request?.status) ?? '';
 
             if (status === 'Completed') {
                 restoreReviewListAiButtonForCooldownCheck($button);
-                globalThis.AIGenerationButtonState?.applyStatusState(request);
+                globalThis.AIGenerationButtonState?.applyStatusState(generationStatus);
                 refreshReviewListAfterAiScoring();
                 return;
             }
@@ -518,7 +519,8 @@ function resumeActiveReviewListAiButton(reviewListTable) {
     const $button = $(button.node());
     unity.grantManager.grantApplications.grantApplication
         .getAIGenerationStatus(pageApplicationId, 'application-scoring')
-        .done(function(request) {
+        .done(function(generationStatus) {
+            const request = generationStatus?.generationRequest;
             if (request?.isActive !== true) {
                 return;
             }

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/RateLimit/AIRateLimiterTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/RateLimit/AIRateLimiterTests.cs
@@ -58,6 +58,17 @@ public class AIRateLimiterTests
     }
 
     [Fact]
+    public async Task GetStateAsync_Does_Not_Acquire_Cooldown_Lock()
+    {
+        var lockProvider = new CountingDistributedLockProvider();
+        var limiter = new AIRateLimiter(_cache, _currentUser, _configuration, lockProvider, []);
+
+        await limiter.GetStateAsync();
+
+        lockProvider.CreatedLockCount.ShouldBe(0);
+    }
+
+    [Fact]
     public async Task EnsureAsync_AllowsThrough_When_NoCooldown()
     {
         await NewLimiter().EnsureAsync();
@@ -165,6 +176,17 @@ public class AIRateLimiterTests
     private sealed class TestDistributedLockProvider : IDistributedLockProvider
     {
         public IDistributedLock CreateLock(string name) => new TestDistributedLock(name);
+    }
+
+    private sealed class CountingDistributedLockProvider : IDistributedLockProvider
+    {
+        public int CreatedLockCount { get; private set; }
+
+        public IDistributedLock CreateLock(string name)
+        {
+            CreatedLockCount++;
+            return new TestDistributedLock(name);
+        }
     }
 
     private sealed class TestDistributedLock(string name) : IDistributedLock

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAIPromptRendererTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAIPromptRendererTests.cs
@@ -34,12 +34,13 @@ public class OpenAIPromptRendererTests
             "v1",
             "{}",
             "[]",
-            "{\"name\":\"Test\",\"questions\":[]}",
+            "{\"name\":\"Test\",\"questions\":[{\"id\":\"q1\",\"type\":\"YesNo\"}]}",
             "{}");
 
-        prompt.ShouldContain("ATTACHMENTS");
-        prompt.ShouldContain("[]");
-        prompt.ShouldContain("If ATTACHMENTS is empty, use DATA only");
-        prompt.ShouldNotContain("No attachments provided.");
+        var normalized = prompt.Replace("\r\n", "\n");
+
+        normalized.ShouldContain("ATTACHMENTS\n[]\n\nSECTION");
+        normalized.ShouldContain("If ATTACHMENTS is empty, use DATA only");
+        normalized.ShouldNotContain("No attachments provided.");
     }
 }

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/GrantApplicationAIGenerationStatusTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/GrantApplications/GrantApplicationAIGenerationStatusTests.cs
@@ -1,0 +1,79 @@
+using NSubstitute;
+using Shouldly;
+using System;
+using System.Threading.Tasks;
+using Unity.AI.Automation;
+using Unity.AI.RateLimit;
+using Unity.GrantManager.Applicants;
+using Unity.GrantManager.ApplicationForms;
+using Unity.GrantManager.Applications;
+using Unity.GrantManager.Flex;
+using Unity.GrantManager.GlobalTag;
+using Unity.GrantManager.Identity;
+using Unity.GrantManager.Payments;
+using Unity.Payments.PaymentRequests;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Features;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Unity.GrantManager.GrantApplications;
+
+public class GrantApplicationAIGenerationStatusTests(ITestOutputHelper outputHelper) : GrantManagerApplicationTestBase(outputHelper)
+{
+    [Fact]
+    public async Task GetAIGenerationStatusAsync_Should_Return_RateLimit_State_When_No_Generation_Request_Exists()
+    {
+        var applicationId = Guid.NewGuid();
+        var aiGenerationStatusAppService = Substitute.For<IAIGenerationStatusAppService>();
+        aiGenerationStatusAppService
+            .GetLatestAsync(applicationId, AIGenerationRequestKeyHelper.ApplicationAnalysisOperationType, null)
+            .Returns((AIGenerationRequestDto?)null);
+
+        var aiRateLimiter = Substitute.For<IAIRateLimiter>();
+        aiRateLimiter.GetStateAsync().Returns(new AIRateLimitStateDto
+        {
+            IsGenerating = true,
+            RetryAfterSeconds = 17
+        });
+
+        var appService = CreateAppService(aiGenerationStatusAppService, aiRateLimiter);
+
+        var result = await appService.GetAIGenerationStatusAsync(
+            applicationId,
+            AIGenerationRequestKeyHelper.ApplicationAnalysisOperationType);
+
+        result.ShouldNotBeNull();
+        result.GenerationRequest.ShouldBeNull();
+        result.IsGenerating.ShouldBeTrue();
+        result.RetryAfterSeconds.ShouldBe(17);
+        await aiGenerationStatusAppService.Received(1)
+            .GetLatestAsync(applicationId, AIGenerationRequestKeyHelper.ApplicationAnalysisOperationType, null);
+        await aiRateLimiter.Received(1).GetStateAsync();
+    }
+
+    private GrantApplicationAppService CreateAppService(
+        IAIGenerationStatusAppService aiGenerationStatusAppService,
+        IAIRateLimiter aiRateLimiter)
+    {
+        var appService = new GrantApplicationAppService(
+            Substitute.For<IApplicationManager>(),
+            Substitute.For<IApplicationRepository>(),
+            Substitute.For<IApplicationChefsFileAttachmentRepository>(),
+            Substitute.For<IApplicationStatusRepository>(),
+            Substitute.For<IApplicationFormSubmissionRepository>(),
+            Substitute.For<IApplicantRepository>(),
+            Substitute.For<IApplicationFormRepository>(),
+            Substitute.For<IApplicantAgentRepository>(),
+            Substitute.For<IApplicantAddressRepository>(),
+            Substitute.For<IApplicantSupplierAppService>(),
+            Substitute.For<IPaymentRequestAppService>(),
+            Substitute.For<IApplicationAIGenerationQueue>(),
+            aiGenerationStatusAppService,
+            aiRateLimiter,
+            Substitute.For<IFeatureChecker>());
+
+        appService.LazyServiceProvider = GetRequiredService<IAbpLazyServiceProvider>();
+        return appService;
+    }
+}


### PR DESCRIPTION
## Summary
- Keeps AI generation request DTOs focused on persisted request state.
- Moves shared generating/cooldown state into an AI generation status DTO.
- Updates AI generation polling UI to read the nested generation request.

## Validation
- `node --check` on touched AI generation JavaScript files.
- `git diff --check`.
