### PR TITLE
AB#33313 only log successful AI operation outputs

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
@@ -99,13 +99,13 @@ namespace Unity.AI.Runtime
                 AIProviderPayloadValidator.IsValidApplicationAnalysisJson,
                 "application analysis",
                 cancellationToken);
-            await LogPromptOutputAsync(ApplicationAnalysisPromptType, promptVersion, result.CaptureOutput, cancellationToken);
 
             if (result.Outcome != AIOperationOutcome.Success)
             {
                 return new ApplicationAnalysisResponse();
             }
 
+            await LogPromptOutputAsync(ApplicationAnalysisPromptType, promptVersion, result.CaptureOutput, cancellationToken);
             return OpenAIResponseParser.ParseApplicationAnalysisResponse(result.Content);
         }
 
@@ -154,7 +154,6 @@ namespace Unity.AI.Runtime
                     AIProviderPayloadValidator.IsValidAttachmentSummaryText,
                     "attachment summary",
                     cancellationToken);
-                await LogPromptOutputAsync(AttachmentSummaryPromptType, promptVersion, result.CaptureOutput, cancellationToken);
 
                 if (result.Outcome != AIOperationOutcome.Success)
                 {
@@ -164,6 +163,7 @@ namespace Unity.AI.Runtime
                     };
                 }
 
+                await LogPromptOutputAsync(AttachmentSummaryPromptType, promptVersion, result.CaptureOutput, cancellationToken);
                 return new AttachmentSummaryResponse
                 {
                     Summary = ExtractSummaryFromJson(result.Content)
@@ -230,13 +230,13 @@ namespace Unity.AI.Runtime
                     content => AIProviderPayloadValidator.IsValidApplicationScoringJson(content, section),
                     $"application scoring section {request.SectionName}",
                     cancellationToken);
-                await LogPromptOutputAsync(ApplicationScoringPromptType, promptVersion, result.CaptureOutput, cancellationToken);
 
                 if (result.Outcome != AIOperationOutcome.Success)
                 {
                     return new ApplicationScoringResponse();
                 }
 
+                await LogPromptOutputAsync(ApplicationScoringPromptType, promptVersion, result.CaptureOutput, cancellationToken);
                 return OpenAIResponseParser.ParseApplicationScoringResponse(result.Content, questionIdAliasMap);
             }
             catch (OperationCanceledException)


### PR DESCRIPTION
## Summary
- Moves AI prompt output file logging so it only runs after the AI operation succeeds.
- Prevents provider error responses from being written in full through the prompt file logging path.
- Keeps normal error logging metadata-only: status code and response length.

## Context
AB#33313 removed the normal application `LogInformation` entry that dumped full model output payloads. A follow-up AC check found that failed AI operations could still pass `RawResponse` through `CaptureOutput` into `LogPromptOutputAsync` before the success check when local prompt file logging was enabled.

## Validation
- Confirmed branch diff is scoped to `OpenAIRuntimeService.cs`.