### PR TITLE
AB#33263 extract AI prompt input builders

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationAnalysisService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationAnalysisService.cs
@@ -1,12 +1,8 @@
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Unity.AI.Models;
 using Unity.AI.Prompts;
 using Unity.AI.Requests;
 using Unity.AI.Runtime;
@@ -24,12 +20,6 @@ namespace Unity.AI.Operations
         IAIGenerationPrerequisiteValidator aiGenerationPrerequisiteValidator,
         ILogger<ApplicationAnalysisService> logger) : IApplicationAnalysisService, ITransientDependency
     {
-        private const string ComponentsKey = "components";
-        private static readonly HashSet<string> ExcludedSchemaKeys = new(StringComparer.OrdinalIgnoreCase)
-        {
-            "applicantAgent"
-        };
-
         public async Task<string> RegenerateAndSaveAsync(Guid applicationId, string? promptVersion = null, CancellationToken cancellationToken = default)
         {
             await aiGenerationPrerequisiteValidator.EnsureApplicationAnalysisAvailableAsync(applicationId);
@@ -39,20 +29,11 @@ namespace Unity.AI.Operations
             var attachments = await applicationChefsFileAttachmentRepository.GetListAsync(a => a.ApplicationId == applicationId);
             var formSchema = await GetFormSchemaAsync(formSubmission?.ApplicationFormVersionId);
 
-            var attachmentSummaries = attachments
-                .Where(a => !string.IsNullOrWhiteSpace(a.AISummary))
-                .Select(a => new AIAttachmentItem
-                {
-                    Name = string.IsNullOrWhiteSpace(a.FileName) ? "attachment" : a.FileName.Trim(),
-                    Summary = a.AISummary!.Trim()
-                })
-                .ToList();
-
-            object formFieldConfiguration = new { message = "Form configuration not available." };
-            if (formSubmission?.ApplicationFormVersionId != null)
-            {
-                formFieldConfiguration = await ExtractFormFieldConfigurationAsync(formSubmission.ApplicationFormVersionId.Value);
-            }
+            var attachmentSummaries = PromptDataPayloadBuilder.BuildAttachmentSummaries(attachments);
+            var formFieldConfiguration = await PromptDataPayloadBuilder.BuildFormFieldConfigurationAsync(
+                applicationFormVersionRepository,
+                formSubmission?.ApplicationFormVersionId,
+                logger);
 
             var analysis = await aiService.GenerateApplicationAnalysisAsync(new ApplicationAnalysisRequest
             {
@@ -87,115 +68,5 @@ namespace Unity.AI.Operations
             }
         }
 
-        private async Task<object> ExtractFormFieldConfigurationAsync(Guid formVersionId)
-        {
-            try
-            {
-                var formVersion = await applicationFormVersionRepository.GetAsync(formVersionId);
-                if (formVersion == null || string.IsNullOrEmpty(formVersion.FormSchema))
-                {
-                    return new { message = "Form configuration not available." };
-                }
-
-                var schema = JObject.Parse(formVersion.FormSchema);
-                var components = schema[ComponentsKey] as JArray;
-                if (components == null || components.Count == 0)
-                {
-                    return new { message = "No form fields configured." };
-                }
-
-                var requiredFields = new List<string>();
-                var optionalFields = new List<string>();
-                ExtractFieldRequirements(components, requiredFields, optionalFields, string.Empty);
-
-                return new
-                {
-                    required_fields = requiredFields,
-                    optional_fields = optionalFields
-                };
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error extracting form field configuration for form version {FormVersionId}", formVersionId);
-                return new { message = "Form configuration could not be extracted." };
-            }
-        }
-
-        private static void ExtractFieldRequirements(JArray components, List<string> requiredFields, List<string> optionalFields, string currentPath)
-        {
-            foreach (var component in components.OfType<JObject>())
-            {
-                var key = component["key"]?.ToString();
-                var label = component["label"]?.ToString();
-                var type = component["type"]?.ToString();
-                var skipTypes = new HashSet<string> { "button", "simplebuttonadvanced", "html", "htmlelement", "content", "simpleseparator" };
-
-                if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(type) || skipTypes.Contains(type) || ExcludedSchemaKeys.Contains(key))
-                {
-                    ProcessNestedFieldRequirements(component, type, requiredFields, optionalFields, currentPath);
-                    continue;
-                }
-
-                var displayName = !string.IsNullOrEmpty(label) ? $"{label} ({key})" : key;
-                var fullPath = string.IsNullOrEmpty(currentPath) ? displayName : $"{currentPath} > {displayName}";
-                var validate = component["validate"] as JObject;
-                var isRequired = validate?["required"]?.Value<bool>() ?? false;
-
-                if (component["input"]?.Value<bool>() == true)
-                {
-                    if (isRequired) requiredFields.Add(fullPath);
-                    else optionalFields.Add(fullPath);
-                }
-
-                ProcessNestedFieldRequirements(component, type, requiredFields, optionalFields, fullPath);
-            }
-        }
-
-        private static void ProcessNestedFieldRequirements(JObject component, string? type, List<string> requiredFields, List<string> optionalFields, string currentPath)
-        {
-            switch (type)
-            {
-                case "panel":
-                case "simplepanel":
-                case "fieldset":
-                case "well":
-                case "container":
-                case "datagrid":
-                case "table":
-                    if (component[ComponentsKey] is JArray nestedComponents)
-                    {
-                        ExtractFieldRequirements(nestedComponents, requiredFields, optionalFields, currentPath);
-                    }
-                    break;
-                case "columns":
-                case "simplecols2":
-                case "simplecols3":
-                case "simplecols4":
-                    if (component["columns"] is JArray columns)
-                    {
-                        foreach (var column in columns.OfType<JObject>())
-                        {
-                            if (column[ComponentsKey] is JArray columnComponents)
-                            {
-                                ExtractFieldRequirements(columnComponents, requiredFields, optionalFields, currentPath);
-                            }
-                        }
-                    }
-                    break;
-                case "tabs":
-                case "simpletabs":
-                    if (component[ComponentsKey] is JArray tabs)
-                    {
-                        foreach (var tab in tabs.OfType<JObject>())
-                        {
-                            if (tab[ComponentsKey] is JArray tabComponents)
-                            {
-                                ExtractFieldRequirements(tabComponents, requiredFields, optionalFields, currentPath);
-                            }
-                        }
-                    }
-                    break;
-            }
-        }
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
@@ -46,14 +46,7 @@ namespace Unity.AI.Operations
             }
 
             var attachments = await applicationChefsFileAttachmentRepository.GetListAsync(a => a.ApplicationId == applicationId);
-            var attachmentSummaries = attachments
-                .Where(a => !string.IsNullOrEmpty(a.AISummary))
-                .Select(a => new AIAttachmentItem
-                {
-                    Name = string.IsNullOrWhiteSpace(a.FileName) ? "attachment" : a.FileName.Trim(),
-                    Summary = a.AISummary!.Trim()
-                })
-                .ToList();
+            var attachmentSummaries = PromptDataPayloadBuilder.BuildAttachmentSummaries(attachments);
 
             var formSubmission = await applicationFormSubmissionRepository.GetByApplicationAsync(applicationId);
             var formSchema = await GetFormSchemaAsync(formSubmission?.ApplicationFormVersionId);

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
@@ -46,7 +46,9 @@ namespace Unity.AI.Operations
             }
 
             var attachments = await applicationChefsFileAttachmentRepository.GetListAsync(a => a.ApplicationId == applicationId);
-            var attachmentSummaries = PromptDataPayloadBuilder.BuildAttachmentSummaries(attachments);
+            var attachmentSummaries = PromptDataPayloadBuilder.BuildAttachmentSummaries(
+                attachments,
+                excludeWhitespaceOnlySummaries: false);
 
             var formSubmission = await applicationFormSubmissionRepository.GetByApplicationAsync(applicationId);
             var formSchema = await GetFormSchemaAsync(formSubmission?.ApplicationFormVersionId);

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Prompts/PromptDataPayloadBuilder.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Prompts/PromptDataPayloadBuilder.cs
@@ -35,15 +35,15 @@ namespace Unity.AI.Prompts
             "simpleseparator"
         };
 
-        private static readonly HashSet<string> NonFieldRequirementComponentTypes =
-        [
+        private static readonly HashSet<string> NonFieldRequirementComponentTypes = new(StringComparer.OrdinalIgnoreCase)
+        {
             "button",
             "simplebuttonadvanced",
             "html",
             "htmlelement",
             "content",
             "simpleseparator"
-        ];
+        };
 
         private const string ComponentsKey = "components";
 
@@ -104,7 +104,7 @@ namespace Unity.AI.Prompts
             try
             {
                 var formVersion = await applicationFormVersionRepository.GetAsync(formVersionId.Value);
-                if (formVersion == null || string.IsNullOrEmpty(formVersion.FormSchema))
+                if (formVersion == null || string.IsNullOrWhiteSpace(formVersion.FormSchema))
                 {
                     return new { message = "Form configuration not available." };
                 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Prompts/PromptDataPayloadBuilder.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Prompts/PromptDataPayloadBuilder.cs
@@ -35,6 +35,16 @@ namespace Unity.AI.Prompts
             "simpleseparator"
         };
 
+        private static readonly HashSet<string> NonFieldRequirementComponentTypes =
+        [
+            "button",
+            "simplebuttonadvanced",
+            "html",
+            "htmlelement",
+            "content",
+            "simpleseparator"
+        ];
+
         private const string ComponentsKey = "components";
 
         private static readonly HashSet<string> ExcludedSchemaKeys = new(StringComparer.OrdinalIgnoreCase)
@@ -65,10 +75,14 @@ namespace Unity.AI.Prompts
             return JsonSerializer.SerializeToElement(fallbackPayload);
         }
 
-        public static List<AIAttachmentItem> BuildAttachmentSummaries(IEnumerable<ApplicationChefsFileAttachment> attachments)
+        public static List<AIAttachmentItem> BuildAttachmentSummaries(
+            IEnumerable<ApplicationChefsFileAttachment> attachments,
+            bool excludeWhitespaceOnlySummaries = true)
         {
             return attachments
-                .Where(a => !string.IsNullOrWhiteSpace(a.AISummary))
+                .Where(a => excludeWhitespaceOnlySummaries
+                    ? !string.IsNullOrWhiteSpace(a.AISummary)
+                    : !string.IsNullOrEmpty(a.AISummary))
                 .Select(a => new AIAttachmentItem
                 {
                     Name = string.IsNullOrWhiteSpace(a.FileName) ? "attachment" : a.FileName.Trim(),
@@ -289,7 +303,7 @@ namespace Unity.AI.Prompts
                 var label = component["label"]?.ToString();
                 var type = component["type"]?.ToString();
 
-                if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(type) || NonDataComponentTypes.Contains(type) || ExcludedSchemaKeys.Contains(key))
+                if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(type) || NonFieldRequirementComponentTypes.Contains(type) || ExcludedSchemaKeys.Contains(key))
                 {
                     ProcessNestedFieldRequirements(component, type, requiredFields, optionalFields, currentPath);
                     continue;

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Prompts/PromptDataPayloadBuilder.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Prompts/PromptDataPayloadBuilder.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
+using Unity.AI.Models;
 using Unity.GrantManager.Applications;
 
 namespace Unity.AI.Prompts
@@ -33,6 +35,13 @@ namespace Unity.AI.Prompts
             "simpleseparator"
         };
 
+        private const string ComponentsKey = "components";
+
+        private static readonly HashSet<string> ExcludedSchemaKeys = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "applicantAgent"
+        };
+
         public static JsonElement BuildPromptDataPayload(
             Application application,
             ApplicationFormSubmission? formSubmission,
@@ -54,6 +63,60 @@ namespace Unity.AI.Prompts
             }
 
             return JsonSerializer.SerializeToElement(fallbackPayload);
+        }
+
+        public static List<AIAttachmentItem> BuildAttachmentSummaries(IEnumerable<ApplicationChefsFileAttachment> attachments)
+        {
+            return attachments
+                .Where(a => !string.IsNullOrWhiteSpace(a.AISummary))
+                .Select(a => new AIAttachmentItem
+                {
+                    Name = string.IsNullOrWhiteSpace(a.FileName) ? "attachment" : a.FileName.Trim(),
+                    Summary = a.AISummary!.Trim()
+                })
+                .ToList();
+        }
+
+        public static async Task<object> BuildFormFieldConfigurationAsync(
+            IApplicationFormVersionRepository applicationFormVersionRepository,
+            Guid? formVersionId,
+            ILogger logger)
+        {
+            if (formVersionId == null)
+            {
+                return new { message = "Form configuration not available." };
+            }
+
+            try
+            {
+                var formVersion = await applicationFormVersionRepository.GetAsync(formVersionId.Value);
+                if (formVersion == null || string.IsNullOrEmpty(formVersion.FormSchema))
+                {
+                    return new { message = "Form configuration not available." };
+                }
+
+                var schema = JObject.Parse(formVersion.FormSchema);
+                var components = schema[ComponentsKey] as JArray;
+                if (components == null || components.Count == 0)
+                {
+                    return new { message = "No form fields configured." };
+                }
+
+                var requiredFields = new List<string>();
+                var optionalFields = new List<string>();
+                ExtractFieldRequirements(components, requiredFields, optionalFields, string.Empty);
+
+                return new
+                {
+                    required_fields = requiredFields,
+                    optional_fields = optionalFields
+                };
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error extracting form field configuration for form version {FormVersionId}", formVersionId);
+                return new { message = "Form configuration could not be extracted." };
+            }
         }
 
         private static object BuildFallbackPromptDataPayload(Application application)
@@ -164,7 +227,7 @@ namespace Unity.AI.Prompts
             try
             {
                 var schema = JObject.Parse(formSchema);
-                if (schema["components"] is not JArray components)
+                if (schema[ComponentsKey] is not JArray components)
                 {
                     return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 }
@@ -215,6 +278,82 @@ namespace Unity.AI.Prompts
                         ExtractSchemaKeys(columnComponents, keys);
                     }
                 }
+            }
+        }
+
+        private static void ExtractFieldRequirements(JArray components, List<string> requiredFields, List<string> optionalFields, string currentPath)
+        {
+            foreach (var component in components.OfType<JObject>())
+            {
+                var key = component["key"]?.ToString();
+                var label = component["label"]?.ToString();
+                var type = component["type"]?.ToString();
+
+                if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(type) || NonDataComponentTypes.Contains(type) || ExcludedSchemaKeys.Contains(key))
+                {
+                    ProcessNestedFieldRequirements(component, type, requiredFields, optionalFields, currentPath);
+                    continue;
+                }
+
+                var displayName = !string.IsNullOrEmpty(label) ? $"{label} ({key})" : key;
+                var fullPath = string.IsNullOrEmpty(currentPath) ? displayName : $"{currentPath} > {displayName}";
+                var validate = component["validate"] as JObject;
+                var isRequired = validate?["required"]?.Value<bool>() ?? false;
+
+                if (component["input"]?.Value<bool>() == true)
+                {
+                    if (isRequired) requiredFields.Add(fullPath);
+                    else optionalFields.Add(fullPath);
+                }
+
+                ProcessNestedFieldRequirements(component, type, requiredFields, optionalFields, fullPath);
+            }
+        }
+
+        private static void ProcessNestedFieldRequirements(JObject component, string? type, List<string> requiredFields, List<string> optionalFields, string currentPath)
+        {
+            switch (type)
+            {
+                case "panel":
+                case "simplepanel":
+                case "fieldset":
+                case "well":
+                case "container":
+                case "datagrid":
+                case "table":
+                    if (component[ComponentsKey] is JArray nestedComponents)
+                    {
+                        ExtractFieldRequirements(nestedComponents, requiredFields, optionalFields, currentPath);
+                    }
+                    break;
+                case "columns":
+                case "simplecols2":
+                case "simplecols3":
+                case "simplecols4":
+                    if (component["columns"] is JArray columns)
+                    {
+                        foreach (var column in columns.OfType<JObject>())
+                        {
+                            if (column[ComponentsKey] is JArray columnComponents)
+                            {
+                                ExtractFieldRequirements(columnComponents, requiredFields, optionalFields, currentPath);
+                            }
+                        }
+                    }
+                    break;
+                case "tabs":
+                case "simpletabs":
+                    if (component[ComponentsKey] is JArray tabs)
+                    {
+                        foreach (var tab in tabs.OfType<JObject>())
+                        {
+                            if (tab[ComponentsKey] is JArray tabComponents)
+                            {
+                                ExtractFieldRequirements(tabComponents, requiredFields, optionalFields, currentPath);
+                            }
+                        }
+                    }
+                    break;
             }
         }
     }

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/ApplicationAnalysisServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/ApplicationAnalysisServiceTests.cs
@@ -96,6 +96,7 @@ public class ApplicationAnalysisServiceTests : GrantManagerApplicationTestBase
         var aiService = Substitute.For<IAIService>();
         aiService.GenerateApplicationAnalysisAsync(Arg.Do<ApplicationAnalysisRequest>(request => capturedRequest = request))
             .Returns(new ApplicationAnalysisResponse { Decision = "ok" });
+        var prerequisiteValidator = Substitute.For<IAIGenerationPrerequisiteValidator>();
 
         var service = new ApplicationAnalysisService(
             applicationRepository,
@@ -103,6 +104,7 @@ public class ApplicationAnalysisServiceTests : GrantManagerApplicationTestBase
             formVersionRepository,
             attachmentRepository,
             aiService,
+            prerequisiteValidator,
             NullLogger<ApplicationAnalysisService>.Instance);
 
         var result = await service.RegenerateAndSaveAsync(applicationId, "v1");
@@ -157,6 +159,7 @@ public class ApplicationAnalysisServiceTests : GrantManagerApplicationTestBase
         var aiService = Substitute.For<IAIService>();
         aiService.GenerateApplicationAnalysisAsync(Arg.Do<ApplicationAnalysisRequest>(request => capturedRequest = request))
             .Returns(new ApplicationAnalysisResponse());
+        var prerequisiteValidator = Substitute.For<IAIGenerationPrerequisiteValidator>();
 
         var service = new ApplicationAnalysisService(
             applicationRepository,
@@ -164,6 +167,7 @@ public class ApplicationAnalysisServiceTests : GrantManagerApplicationTestBase
             formVersionRepository,
             attachmentRepository,
             aiService,
+            prerequisiteValidator,
             NullLogger<ApplicationAnalysisService>.Instance);
 
         await service.RegenerateAndSaveAsync(applicationId);

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/ApplicationAnalysisServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/ApplicationAnalysisServiceTests.cs
@@ -1,0 +1,185 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Unity.AI;
+using Unity.AI.Operations;
+using Unity.AI.Requests;
+using Unity.AI.Responses;
+using Unity.GrantManager.Applications;
+using Volo.Abp.Domain.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Unity.GrantManager.AI.Operations;
+
+public class ApplicationAnalysisServiceTests : GrantManagerApplicationTestBase
+{
+    public ApplicationAnalysisServiceTests(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+    }
+
+    [Fact]
+    public async Task RegenerateAndSaveAsync_Builds_Filtered_Prompt_Payload_From_Form_Submission()
+    {
+        var applicationId = Guid.NewGuid();
+        var formVersionId = Guid.NewGuid();
+        ApplicationAnalysisRequest? capturedRequest = null;
+        var application = WithId(new Application
+        {
+            ApplicationFormId = Guid.NewGuid(),
+            ProjectName = "Fallback project",
+            ReferenceNo = "REF-001",
+            RequestedAmount = 100,
+            TotalProjectBudget = 200,
+            SubmissionDate = new DateTime(2026, 1, 2)
+        }, applicationId);
+        var submission = new ApplicationFormSubmission
+        {
+            ApplicationId = applicationId,
+            ApplicationFormVersionId = formVersionId,
+            Submission = """
+            {
+              "data": {
+                "projectName": "Submitted project",
+                "requestedAmount": 12345,
+                "metadata": { "timezone": "utc" },
+                "files": [{ "name": "large.pdf" }],
+                "ignoredField": "not in schema"
+              }
+            }
+            """
+        };
+        var formVersion = new ApplicationFormVersion
+        {
+            FormSchema = """
+            {
+              "components": [
+                { "key": "projectName", "label": "Project Name", "type": "textfield", "input": true, "validate": { "required": true } },
+                { "key": "requestedAmount", "label": "Requested Amount", "type": "number", "input": true },
+                { "key": "applicantAgent", "label": "Applicant Agent", "type": "textfield", "input": true },
+                { "key": "ignoredField", "label": "Ignored Field", "type": "html", "input": false }
+              ]
+            }
+            """
+        };
+
+        var applicationRepository = Substitute.For<IApplicationRepository>();
+        applicationRepository.GetAsync(applicationId).Returns(application);
+
+        var submissionRepository = Substitute.For<IApplicationFormSubmissionRepository>();
+        submissionRepository.GetByApplicationAsync(applicationId).Returns(submission);
+
+        var formVersionRepository = Substitute.For<IApplicationFormVersionRepository>();
+        formVersionRepository.GetAsync(formVersionId).Returns(formVersion);
+
+        var attachmentRepository = Substitute.For<IApplicationChefsFileAttachmentRepository>();
+        attachmentRepository
+            .GetListAsync(Arg.Any<Expression<Func<ApplicationChefsFileAttachment, bool>>>())
+            .Returns([
+                new ApplicationChefsFileAttachment
+                {
+                    FileName = " summary.pdf ",
+                    AISummary = " Summary text "
+                },
+                new ApplicationChefsFileAttachment
+                {
+                    FileName = "empty.txt",
+                    AISummary = " "
+                }
+            ]);
+
+        var aiService = Substitute.For<IAIService>();
+        aiService.GenerateApplicationAnalysisAsync(Arg.Do<ApplicationAnalysisRequest>(request => capturedRequest = request))
+            .Returns(new ApplicationAnalysisResponse { Decision = "ok" });
+
+        var service = new ApplicationAnalysisService(
+            applicationRepository,
+            submissionRepository,
+            formVersionRepository,
+            attachmentRepository,
+            aiService,
+            NullLogger<ApplicationAnalysisService>.Instance);
+
+        var result = await service.RegenerateAndSaveAsync(applicationId, "v1");
+
+        result.ShouldContain("\"Decision\": \"ok\"");
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest.PromptVersion.ShouldBe("v1");
+        capturedRequest.Attachments.Count.ShouldBe(1);
+        capturedRequest.Attachments[0].Name.ShouldBe("summary.pdf");
+        capturedRequest.Attachments[0].Summary.ShouldBe("Summary text");
+
+        capturedRequest.Data.GetProperty("projectName").GetString().ShouldBe("Submitted project");
+        capturedRequest.Data.GetProperty("requestedAmount").GetInt32().ShouldBe(12345);
+        capturedRequest.Data.TryGetProperty("metadata", out _).ShouldBeFalse();
+        capturedRequest.Data.TryGetProperty("files", out _).ShouldBeFalse();
+        capturedRequest.Data.TryGetProperty("ignoredField", out _).ShouldBeFalse();
+
+        var schemaJson = JsonSerializer.Serialize(capturedRequest.Schema);
+        schemaJson.ShouldContain("Project Name (projectName)");
+        schemaJson.ShouldContain("Requested Amount (requestedAmount)");
+        schemaJson.ShouldNotContain("Applicant Agent (applicantAgent)");
+        await applicationRepository.Received(1).UpdateAsync(application);
+    }
+
+    [Fact]
+    public async Task RegenerateAndSaveAsync_Falls_Back_To_Application_Data_When_Submission_Is_Missing()
+    {
+        var applicationId = Guid.NewGuid();
+        var application = WithId(new Application
+        {
+            ProjectName = "Fallback project",
+            ReferenceNo = "REF-002",
+            RequestedAmount = 1500,
+            TotalProjectBudget = 3000,
+            ProjectSummary = "Fallback summary",
+            SubmissionDate = new DateTime(2026, 2, 3)
+        }, applicationId);
+        ApplicationAnalysisRequest? capturedRequest = null;
+
+        var applicationRepository = Substitute.For<IApplicationRepository>();
+        applicationRepository.GetAsync(applicationId).Returns(application);
+
+        var submissionRepository = Substitute.For<IApplicationFormSubmissionRepository>();
+        submissionRepository.GetByApplicationAsync(applicationId).Returns((ApplicationFormSubmission?)null);
+
+        var formVersionRepository = Substitute.For<IApplicationFormVersionRepository>();
+        var attachmentRepository = Substitute.For<IApplicationChefsFileAttachmentRepository>();
+        attachmentRepository
+            .GetListAsync(Arg.Any<Expression<Func<ApplicationChefsFileAttachment, bool>>>())
+            .Returns([]);
+
+        var aiService = Substitute.For<IAIService>();
+        aiService.GenerateApplicationAnalysisAsync(Arg.Do<ApplicationAnalysisRequest>(request => capturedRequest = request))
+            .Returns(new ApplicationAnalysisResponse());
+
+        var service = new ApplicationAnalysisService(
+            applicationRepository,
+            submissionRepository,
+            formVersionRepository,
+            attachmentRepository,
+            aiService,
+            NullLogger<ApplicationAnalysisService>.Instance);
+
+        await service.RegenerateAndSaveAsync(applicationId);
+
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest.Data.GetProperty("project_name").GetString().ShouldBe("Fallback project");
+        capturedRequest.Data.GetProperty("reference_number").GetString().ShouldBe("REF-002");
+        capturedRequest.Data.GetProperty("requested_amount").GetDecimal().ShouldBe(1500);
+        capturedRequest.Attachments.ShouldBeEmpty();
+    }
+
+    private static T WithId<T>(T entity, Guid id) where T : Entity<Guid>
+    {
+        typeof(Entity<Guid>)
+            .GetProperty(nameof(Entity<Guid>.Id))!
+            .SetValue(entity, id);
+        return entity;
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts shared AI prompt input shaping into `PromptDataPayloadBuilder` and wires `ApplicationAnalysisService` and `ApplicationScoringService` to use it.
- Keeps analysis/scoring orchestration and execution-mode behavior intact while isolating payload construction.
- Adds targeted `ApplicationAnalysisService` tests that verify filtered submission payload shaping, attachment summary shaping, and fallback-to-application-data behavior.
- Preserves existing scoring attachment filtering behavior and field-requirement skip-type semantics after rebase/review fixes.

## Validation
- `dotnet test applications\Unity.GrantManager\test\Unity.GrantManager.Application.Tests\Unity.GrantManager.Application.Tests.csproj --filter "FullyQualifiedName~ApplicationAnalysisServiceTests" --no-restore`