### PR TITLE
AB#33009 azure openai sdk migration

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AttachmentSummaryService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/AttachmentSummaryService.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Localization;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,6 +13,7 @@ using Unity.GrantManager.Applications;
 using Unity.GrantManager.Intakes;
 using Volo.Abp;
 using Volo.Abp.DependencyInjection;
+using Volo.Abp.Uow;
 
 namespace Unity.AI.Operations;
 
@@ -22,18 +24,26 @@ public class AttachmentSummaryService(
     IAIService aiService,
     IAIGenerationPrerequisiteValidator aiGenerationPrerequisiteValidator,
     AIExecutionModeResolver executionModeResolver,
+    IUnitOfWorkManager unitOfWorkManager,
     ILogger<AttachmentSummaryService> logger,
     IStringLocalizer<AIResource> localizer) : IAttachmentSummaryService, ITransientDependency
 {
     private const string SummaryGenerationFailedMessage = "AI summary generation failed.";
+    private const string TextExtractionFailedSummary = "Attachment text could not be extracted for AI summary generation.";
 
     public async Task<string> GenerateAndSaveAsync(Guid attachmentId, string? promptVersion = null, CancellationToken cancellationToken = default)
     {
-        var attachment = await applicationChefsFileAttachmentRepository.GetAsync(attachmentId);
+        var attachment = await LoadAttachmentAsync(attachmentId);
         var fileName = string.IsNullOrWhiteSpace(attachment.FileName) ? "unknown" : attachment.FileName;
 
         await using var attachmentStream = await OpenAttachmentStreamAsync(attachment, fileName, cancellationToken);
         var extractedText = await textExtractionService.ExtractTextAsync(fileName, attachmentStream.Content, attachmentStream.ContentType, cancellationToken);
+        if (ShouldStopOnEmptyExtraction(fileName, extractedText))
+        {
+            LogEmptyExtraction(attachmentId, fileName, attachmentStream);
+            await SaveSummaryAsync(attachmentId, TextExtractionFailedSummary);
+            return TextExtractionFailedSummary;
+        }
 
         var summaryResponse = await aiService.GenerateAttachmentSummaryAsync(new AttachmentSummaryRequest
         {
@@ -43,8 +53,7 @@ public class AttachmentSummaryService(
             PromptVersion = promptVersion,
         }, cancellationToken);
 
-        attachment.AISummary = summaryResponse.Summary;
-        await applicationChefsFileAttachmentRepository.UpdateAsync(attachment);
+        await SaveSummaryAsync(attachmentId, summaryResponse.Summary);
 
         return summaryResponse.Summary;
     }
@@ -113,11 +122,9 @@ public class AttachmentSummaryService(
         IReadOnlyCollection<Guid>? attachmentIds = null,
         CancellationToken cancellationToken = default)
     {
-        await aiGenerationPrerequisiteValidator.EnsureAttachmentSummaryAvailableAsync(applicationId);
+        await WithUnitOfWorkAsync(() => aiGenerationPrerequisiteValidator.EnsureAttachmentSummaryAvailableAsync(applicationId));
 
-        var applicationAttachmentIds = (await applicationChefsFileAttachmentRepository.GetListAsync(a => a.ApplicationId == applicationId))
-            .Select(a => a.Id)
-            .ToList();
+        var applicationAttachmentIds = await LoadApplicationAttachmentIdsAsync(applicationId);
 
         if (attachmentIds is not { Count: > 0 })
         {
@@ -135,8 +142,47 @@ public class AttachmentSummaryService(
         return await GenerateAndSaveAsync(selectedIds, promptVersion, cancellationToken);
     }
 
+    private async Task<AttachmentSummarySource> LoadAttachmentAsync(Guid attachmentId)
+    {
+        using var uow = unitOfWorkManager.Begin(requiresNew: true, isTransactional: false);
+        var attachment = await applicationChefsFileAttachmentRepository.GetAsync(attachmentId);
+        var source = new AttachmentSummarySource(
+            attachment.Id,
+            attachment.FileName,
+            attachment.ChefsSubmissionId,
+            attachment.ChefsFileId);
+        await uow.CompleteAsync();
+        return source;
+    }
+
+    private async Task SaveSummaryAsync(Guid attachmentId, string summary)
+    {
+        using var uow = unitOfWorkManager.Begin(requiresNew: true);
+        var attachment = await applicationChefsFileAttachmentRepository.GetAsync(attachmentId);
+        attachment.AISummary = summary;
+        await applicationChefsFileAttachmentRepository.UpdateAsync(attachment);
+        await uow.CompleteAsync();
+    }
+
+    private async Task<List<Guid>> LoadApplicationAttachmentIdsAsync(Guid applicationId)
+    {
+        using var uow = unitOfWorkManager.Begin(requiresNew: true, isTransactional: false);
+        var ids = (await applicationChefsFileAttachmentRepository.GetListAsync(a => a.ApplicationId == applicationId))
+            .Select(a => a.Id)
+            .ToList();
+        await uow.CompleteAsync();
+        return ids;
+    }
+
+    private async Task WithUnitOfWorkAsync(Func<Task> operation)
+    {
+        using var uow = unitOfWorkManager.Begin(requiresNew: true, isTransactional: false);
+        await operation();
+        await uow.CompleteAsync();
+    }
+
     private async Task<ChefsFileAttachmentStream> OpenAttachmentStreamAsync(
-        ApplicationChefsFileAttachment attachment,
+        AttachmentSummarySource attachment,
         string fileName,
         CancellationToken cancellationToken)
     {
@@ -168,4 +214,52 @@ public class AttachmentSummaryService(
             return ChefsFileAttachmentStream.Empty;
         }
     }
+
+    private static bool ShouldStopOnEmptyExtraction(string fileName, string extractedText)
+    {
+        return string.IsNullOrWhiteSpace(extractedText) && IsSupportedOfficeOrPdf(fileName);
+    }
+
+    private static bool IsSupportedOfficeOrPdf(string fileName)
+    {
+        var extension = Path.GetExtension(fileName)?.ToLowerInvariant();
+        return extension is ".pdf" or ".docx" or ".xlsx" or ".xls" or ".pptx";
+    }
+
+    private void LogEmptyExtraction(
+        Guid attachmentId,
+        string fileName,
+        ChefsFileAttachmentStream attachmentStream)
+    {
+        logger.LogWarning(
+            "No text extracted for supported attachment {AttachmentId} ({FileName}). Skipping AI summary generation. ContentType: {ContentType}; StreamCanSeek: {StreamCanSeek}; StreamLength: {StreamLength}.",
+            attachmentId,
+            fileName,
+            attachmentStream.ContentType,
+            attachmentStream.Content.CanSeek,
+            TryGetStreamLength(attachmentStream.Content));
+    }
+
+    private static long? TryGetStreamLength(Stream stream)
+    {
+        if (!stream.CanSeek)
+        {
+            return null;
+        }
+
+        try
+        {
+            return stream.Length;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private sealed record AttachmentSummarySource(
+        Guid Id,
+        string? FileName,
+        string? ChefsSubmissionId,
+        string? ChefsFileId);
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIChatClientFactory.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIChatClientFactory.cs
@@ -1,0 +1,20 @@
+using Azure.AI.OpenAI;
+using OpenAI.Chat;
+using System.ClientModel;
+using Volo.Abp.DependencyInjection;
+
+namespace Unity.AI.Runtime;
+
+public class OpenAIChatClientFactory(OpenAIConfigurationResolver configurationResolver) : ITransientDependency
+{
+    private readonly OpenAIConfigurationResolver _configurationResolver = configurationResolver;
+
+    public ChatClient Create(string? operationName = null)
+    {
+        return new AzureOpenAIClient(
+            _configurationResolver.ResolveEndpoint(operationName),
+            new ApiKeyCredential(_configurationResolver.ResolveApiKey(operationName)),
+            new AzureOpenAIClientOptions())
+            .GetChatClient(_configurationResolver.ResolveDeploymentName(operationName));
+    }
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIConfigurationResolver.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIConfigurationResolver.cs
@@ -7,9 +7,6 @@ namespace Unity.AI.Runtime;
 
 public class OpenAIConfigurationResolver(IConfiguration configuration) : ITransientDependency
 {
-    private static readonly string[] SupportedReasoningEfforts = ["minimal", "low", "medium", "high"];
-    private static readonly string[] SupportedVerbosityValues = ["low", "medium", "high"];
-
     private readonly IConfiguration _configuration = configuration;
 
     public string ResolveProviderName(string? operationName = null)
@@ -32,13 +29,6 @@ public class OpenAIConfigurationResolver(IConfiguration configuration) : ITransi
         return Required($"Azure:{providerName}:ApiKey");
     }
 
-    public string ResolveMaxTokensParameterNameForOperation(string? operationName = null)
-    {
-        var providerName = ResolveProviderName(operationName);
-        var profileName = ResolveProfileName(operationName);
-        return RequiredProfile(providerName, profileName, "MaxTokensParameter");
-    }
-
     public double? ResolveConfiguredTemperature(string? operationName = null)
     {
         var providerName = ResolveProviderName(operationName);
@@ -51,16 +41,6 @@ public class OpenAIConfigurationResolver(IConfiguration configuration) : ITransi
         }
 
         return null;
-    }
-
-    public string? ResolveConfiguredReasoningEffort(string? operationName = null)
-    {
-        return ResolveOptionalProfileValue(operationName, "ReasoningEffort", SupportedReasoningEfforts);
-    }
-
-    public string? ResolveConfiguredVerbosity(string? operationName = null)
-    {
-        return ResolveOptionalProfileValue(operationName, "Verbosity", SupportedVerbosityValues);
     }
 
     public int ResolveCompletionTokens(string operationName)
@@ -86,13 +66,54 @@ public class OpenAIConfigurationResolver(IConfiguration configuration) : ITransi
             ?? Required("Azure:Operations:Defaults:PromptVersion");
     }
 
-    public string ResolveApiUrl(string? operationName = null)
+    public Uri ResolveEndpoint(string? operationName = null)
     {
         var providerName = ResolveProviderName(operationName);
         var endpoint = Required($"Azure:{providerName}:Endpoint");
+        return new Uri(endpoint);
+    }
+
+    public string ResolveDeploymentName(string? operationName = null)
+    {
+        var providerName = ResolveProviderName(operationName);
         var profileName = ResolveProfileName(operationName);
         var profileApiUrl = RequiredProfile(providerName, profileName, "ApiUrl");
-        return CombineEndpointAndPath(endpoint, profileApiUrl);
+        // Extract deployment name from URL like "/openai/deployments/gpt-5-mini/chat/completions?api-version=..."
+        var parts = profileApiUrl.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var deploymentIndex = Array.IndexOf(parts, "deployments");
+        if (deploymentIndex >= 0 && deploymentIndex + 1 < parts.Length)
+        {
+            var raw = parts[deploymentIndex + 1];
+            // Strip query string if present (e.g., "gpt-5-mini?api-version=...")
+            var deployment = raw.Contains('?') ? raw[..raw.IndexOf('?')] : raw;
+            return deployment;
+        }
+        throw new InvalidOperationException($"Could not extract deployment name from API URL: {profileApiUrl}");
+    }
+
+    public string? ResolveApiVersion(string? operationName = null)
+    {
+        var providerName = ResolveProviderName(operationName);
+        var profileName = ResolveProfileName(operationName);
+        var profileApiUrl = RequiredProfile(providerName, profileName, "ApiUrl");
+        // Extract api-version from query string like "?api-version=2024-10-01-preview"
+        var queryString = profileApiUrl.Contains('?') ? profileApiUrl.Substring(profileApiUrl.IndexOf('?') + 1) : null;
+        if (string.IsNullOrEmpty(queryString))
+        {
+            return null;
+        }
+
+        var parameters = queryString.Split('&');
+        foreach (var param in parameters)
+        {
+            var keyValue = param.Split('=');
+            if (keyValue.Length == 2 && keyValue[0] == "api-version")
+            {
+                return Uri.UnescapeDataString(keyValue[1]);
+            }
+        }
+
+        return null;
     }
 
     private string ResolveProfileName(string? operationName)
@@ -140,34 +161,5 @@ public class OpenAIConfigurationResolver(IConfiguration configuration) : ITransi
     private static string ProfileKey(string providerName, string profileName, string settingName)
     {
         return $"Azure:{providerName}:Profiles:{profileName}:{settingName}";
-    }
-
-    private string? ResolveOptionalProfileValue(string? operationName, string settingName, string[] supportedValues)
-    {
-        var providerName = ResolveProviderName(operationName);
-        var profileName = ResolveProfileName(operationName);
-        var configuredValue = OptionalProfile(providerName, profileName, settingName);
-        if (configuredValue == null)
-        {
-            return null;
-        }
-
-        var trimmedValue = configuredValue.Trim();
-        if (Array.Exists(supportedValues, supportedValue => string.Equals(supportedValue, trimmedValue, StringComparison.Ordinal)))
-        {
-            return trimmedValue;
-        }
-
-        throw new InvalidOperationException(
-            $"AI {settingName} value '{configuredValue}' is not supported. Use one of: {string.Join(", ", supportedValues)}.");
-    }
-
-    private static string CombineEndpointAndPath(string endpoint, string profilePath)
-    {
-        const char UrlPathSeparator = '/';
-
-        return endpoint.Trim().TrimEnd(UrlPathSeparator)
-            + UrlPathSeparator
-            + profilePath.Trim().TrimStart(UrlPathSeparator);
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIConfigurationResolver.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIConfigurationResolver.cs
@@ -43,6 +43,14 @@ public class OpenAIConfigurationResolver(IConfiguration configuration) : ITransi
         return null;
     }
 
+    public bool ResolveMaxOutputTokenCountSupported(string? operationName = null)
+    {
+        var providerName = ResolveProviderName(operationName);
+        var profileName = ResolveProfileName(operationName);
+        var configuredValue = OptionalProfile(providerName, profileName, "MaxOutputTokenCountSupported");
+        return configuredValue == null || bool.Parse(configuredValue);
+    }
+
     public int ResolveCompletionTokens(string operationName)
     {
         var configuredValue = OptionalPositiveInt($"Azure:Operations:{operationName}:MaxCompletionTokens");
@@ -77,43 +85,7 @@ public class OpenAIConfigurationResolver(IConfiguration configuration) : ITransi
     {
         var providerName = ResolveProviderName(operationName);
         var profileName = ResolveProfileName(operationName);
-        var profileApiUrl = RequiredProfile(providerName, profileName, "ApiUrl");
-        // Extract deployment name from URL like "/openai/deployments/gpt-5-mini/chat/completions?api-version=..."
-        var parts = profileApiUrl.Split('/', StringSplitOptions.RemoveEmptyEntries);
-        var deploymentIndex = Array.IndexOf(parts, "deployments");
-        if (deploymentIndex >= 0 && deploymentIndex + 1 < parts.Length)
-        {
-            var raw = parts[deploymentIndex + 1];
-            // Strip query string if present (e.g., "gpt-5-mini?api-version=...")
-            var deployment = raw.Contains('?') ? raw[..raw.IndexOf('?')] : raw;
-            return deployment;
-        }
-        throw new InvalidOperationException($"Could not extract deployment name from API URL: {profileApiUrl}");
-    }
-
-    public string? ResolveApiVersion(string? operationName = null)
-    {
-        var providerName = ResolveProviderName(operationName);
-        var profileName = ResolveProfileName(operationName);
-        var profileApiUrl = RequiredProfile(providerName, profileName, "ApiUrl");
-        // Extract api-version from query string like "?api-version=2024-10-01-preview"
-        var queryString = profileApiUrl.Contains('?') ? profileApiUrl.Substring(profileApiUrl.IndexOf('?') + 1) : null;
-        if (string.IsNullOrEmpty(queryString))
-        {
-            return null;
-        }
-
-        var parameters = queryString.Split('&');
-        foreach (var param in parameters)
-        {
-            var keyValue = param.Split('=');
-            if (keyValue.Length == 2 && keyValue[0] == "api-version")
-            {
-                return Uri.UnescapeDataString(keyValue[1]);
-            }
-        }
-
-        return null;
+        return RequiredProfile(providerName, profileName, "DeploymentName");
     }
 
     private string ResolveProfileName(string? operationName)

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
@@ -27,9 +27,6 @@ namespace Unity.AI.Runtime
         private const string ApplicationScoringPromptType = AIPromptTypes.ApplicationScoring;
         private const int MaxAiAttempts = 3;
 
-        private int AttachmentSummaryCompletionTokens => _openAIConfigurationResolver.ResolveCompletionTokens(AttachmentSummaryPromptType);
-        private int ApplicationAnalysisCompletionTokens => _openAIConfigurationResolver.ResolveCompletionTokens(ApplicationAnalysisPromptType);
-        private int ApplicationScoringCompletionTokens => _openAIConfigurationResolver.ResolveCompletionTokens(ApplicationScoringPromptType);
         // Optional local debugging sink for prompt payload logs to a local file.
         // Not intended for deployed/shared environments.
         private bool IsPromptFileLoggingEnabled => _configuration.GetValue<bool?>("Azure:Logging:EnablePromptFileLog") ?? false;
@@ -92,7 +89,7 @@ namespace Unity.AI.Runtime
                 () => _openAITransportService.GenerateSummaryAsync(
                     applicationAnalysisContent,
                     systemPrompt,
-                    ApplicationAnalysisCompletionTokens,
+                    _openAIConfigurationResolver.ResolveCompletionTokens(ApplicationAnalysisPromptType),
                     operationName: ApplicationAnalysisPromptType,
                     promptVersion: promptVersion,
                     cancellationToken: cancellationToken),
@@ -146,7 +143,7 @@ namespace Unity.AI.Runtime
                     () => _openAITransportService.GenerateSummaryAsync(
                         contentToAnalyze,
                         prompt,
-                        AttachmentSummaryCompletionTokens,
+                        _openAIConfigurationResolver.ResolveCompletionTokens(AttachmentSummaryPromptType),
                         operationName: AttachmentSummaryPromptType,
                         promptVersion: promptVersion,
                         fileName: fileName,
@@ -223,7 +220,7 @@ namespace Unity.AI.Runtime
                 () => _openAITransportService.GenerateSummaryAsync(
                     applicationScoringContent,
                     systemPrompt,
-                    ApplicationScoringCompletionTokens,
+                    _openAIConfigurationResolver.ResolveCompletionTokens(ApplicationScoringPromptType),
                     operationName: ApplicationScoringPromptType,
                     promptVersion: promptVersion,
                     cancellationToken: cancellationToken),

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAITransportService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAITransportService.cs
@@ -1,4 +1,3 @@
-using Azure.AI.OpenAI;
 using Microsoft.Extensions.Logging;
 using OpenAI.Chat;
 using System;
@@ -14,9 +13,11 @@ namespace Unity.AI.Runtime;
 
 public class OpenAITransportService(
     OpenAIConfigurationResolver configurationResolver,
+    OpenAIChatClientFactory chatClientFactory,
     ILogger<OpenAITransportService> logger) : ITransientDependency
 {
     private readonly OpenAIConfigurationResolver _configurationResolver = configurationResolver;
+    private readonly OpenAIChatClientFactory _chatClientFactory = chatClientFactory;
     private readonly ILogger<OpenAITransportService> _logger = logger;
 
     public async Task<AIOperationResult> GenerateSummaryAsync(
@@ -38,29 +39,15 @@ public class OpenAITransportService(
                 return AIOperationResult.PermanentFailure(new AIProviderResult($"Unsupported provider: {providerName}"));
             }
 
-            var apiKey = _configurationResolver.ResolveApiKey(operationName);
             var resolvedSystemPrompt = string.IsNullOrWhiteSpace(systemPrompt)
                 ? "You are a professional grant analyst for the BC Government."
                 : systemPrompt;
 
-            var clientOptions = new AzureOpenAIClientOptions();
-            var resolvedApiVersion = _configurationResolver.ResolveApiVersion(operationName);
-            // Note: Azure SDK uses its default API version. Configured version is parsed for documentation/future use.
-            if (!string.IsNullOrEmpty(resolvedApiVersion))
+            var options = new ChatCompletionOptions();
+            if (_configurationResolver.ResolveMaxOutputTokenCountSupported(operationName))
             {
-                _logger.LogDebug("Profile specifies API version {ApiVersion}; SDK will use its default", resolvedApiVersion);
+                options.MaxOutputTokenCount = maxTokens;
             }
-
-            var client = new AzureOpenAIClient(
-                _configurationResolver.ResolveEndpoint(operationName),
-                new ApiKeyCredential(apiKey),
-                clientOptions)
-                .GetChatClient(_configurationResolver.ResolveDeploymentName(operationName));
-
-            var options = new ChatCompletionOptions
-            {
-                MaxOutputTokenCount = maxTokens
-            };
 
             var profileTemperature = _configurationResolver.ResolveConfiguredTemperature(operationName);
             var resolvedTemperature = temperature ?? profileTemperature;
@@ -69,7 +56,7 @@ public class OpenAITransportService(
                 options.Temperature = (float)resolvedTemperature.Value;
             }
 
-            var result = await client.CompleteChatAsync(
+            var result = await _chatClientFactory.Create(operationName).CompleteChatAsync(
                 [
                     new SystemChatMessage(resolvedSystemPrompt),
                     new UserChatMessage(content ?? string.Empty)
@@ -80,12 +67,17 @@ public class OpenAITransportService(
             var completion = result.Value;
             var rawResponse = result.GetRawResponse();
             var responseContent = rawResponse.Content.ToString();
-            var modelOutput = completion.Content.Count > 0 ? completion.Content[0].Text : null;
+            var modelOutput = ExtractModelOutput(completion, responseContent);
             var providerResponse = BuildProviderResponseFromMetadata(
                 modelOutput ?? string.Empty,
                 responseContent,
                 TryExtractProviderMetadata(responseContent),
                 rawResponse.Status);
+
+            if (string.IsNullOrWhiteSpace(modelOutput))
+            {
+                LogEmptyModelOutput(completion, providerResponse, rawResponse.Status);
+            }
 
             return string.IsNullOrWhiteSpace(modelOutput)
                 ? AIOperationResult.InvalidOutput(providerResponse)
@@ -110,7 +102,11 @@ public class OpenAITransportService(
                 TryExtractProviderMetadata(responseContent),
                 statusCode);
 
-            _logger.LogError(ex, "OpenAI API request failed: {StatusCode} - {Content}", statusCode, responseContent);
+            _logger.LogError(
+                ex,
+                "OpenAI API request failed with status {StatusCode}. Response body length: {ResponseLength}.",
+                statusCode,
+                responseContent.Length);
             return statusCode.HasValue
                 ? MapFailureOutcome((HttpStatusCode)statusCode.Value, providerResponse)
                 : AIOperationResult.TransientFailure(providerResponse);
@@ -149,6 +145,94 @@ public class OpenAITransportService(
             metadata?.CompletionTokens,
             metadata?.TotalTokens,
             metadata?.ReasoningTokens);
+    }
+
+    private void LogEmptyModelOutput(ChatCompletion completion, AIProviderResult response, int statusCode)
+    {
+        _logger.LogWarning(
+            "AI model output was empty. StatusCode: {StatusCode}; FinishReason: {FinishReason}; ContentPartCount: {ContentPartCount}; PromptTokens: {PromptTokens}; CompletionTokens: {CompletionTokens}; TotalTokens: {TotalTokens}; ReasoningTokens: {ReasoningTokens}.",
+            statusCode,
+            response.FinishReason,
+            completion.Content.Count,
+            response.PromptTokens,
+            response.CompletionTokens,
+            response.TotalTokens,
+            response.ReasoningTokens);
+    }
+
+    private static string? ExtractModelOutput(ChatCompletion completion, string? responseContent)
+    {
+        if (completion.Content.Count > 0 && !string.IsNullOrWhiteSpace(completion.Content[0].Text))
+        {
+            return completion.Content[0].Text;
+        }
+
+        return TryExtractMessageContent(responseContent);
+    }
+
+    private static string? TryExtractMessageContent(string? responseContent)
+    {
+        if (string.IsNullOrWhiteSpace(responseContent))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var jsonDoc = JsonDocument.Parse(responseContent);
+            if (!TryGetFirstChoice(jsonDoc.RootElement, out var firstChoice)
+                || !firstChoice.TryGetProperty("message", out var message)
+                || !message.TryGetProperty("content", out var content))
+            {
+                return null;
+            }
+
+            if (content.ValueKind == JsonValueKind.String)
+            {
+                return content.GetString();
+            }
+
+            if (content.ValueKind == JsonValueKind.Array)
+            {
+                return ExtractTextContentParts(content);
+            }
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        return null;
+    }
+
+    private static bool TryGetFirstChoice(JsonElement root, out JsonElement firstChoice)
+    {
+        firstChoice = default;
+        if (!root.TryGetProperty("choices", out var choices)
+            || choices.ValueKind != JsonValueKind.Array
+            || choices.GetArrayLength() == 0)
+        {
+            return false;
+        }
+
+        firstChoice = choices[0];
+        return true;
+    }
+
+    private static string? ExtractTextContentParts(JsonElement content)
+    {
+        var parts = new List<string>();
+        foreach (var part in content.EnumerateArray())
+        {
+            if (part.ValueKind == JsonValueKind.Object
+                && part.TryGetProperty("text", out var text)
+                && text.ValueKind == JsonValueKind.String)
+            {
+                parts.Add(text.GetString() ?? string.Empty);
+            }
+        }
+
+        return parts.Count > 0 ? string.Concat(parts) : null;
     }
 
     private static AIProviderResponseMetadata? TryExtractProviderMetadata(string? responseContent)

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAITransportService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAITransportService.cs
@@ -1,9 +1,10 @@
+using Azure.AI.OpenAI;
 using Microsoft.Extensions.Logging;
+using OpenAI.Chat;
 using System;
+using System.ClientModel;
 using System.Collections.Generic;
 using System.Net;
-using System.Net.Http;
-using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,11 +13,9 @@ using Volo.Abp.DependencyInjection;
 namespace Unity.AI.Runtime;
 
 public class OpenAITransportService(
-    HttpClient httpClient,
     OpenAIConfigurationResolver configurationResolver,
     ILogger<OpenAITransportService> logger) : ITransientDependency
 {
-    private readonly HttpClient _httpClient = httpClient;
     private readonly OpenAIConfigurationResolver _configurationResolver = configurationResolver;
     private readonly ILogger<OpenAITransportService> _logger = logger;
 
@@ -30,105 +29,67 @@ public class OpenAITransportService(
         string? fileName = null,
         CancellationToken cancellationToken = default)
     {
-        var providerName = _configurationResolver.ResolveProviderName(operationName);
-        if (!string.Equals(providerName, "OpenAI", StringComparison.Ordinal))
-        {
-            _logger.LogWarning("Provider {ProviderName} is not supported by OpenAI transport.", providerName);
-            return AIOperationResult.PermanentFailure(new AIProviderResult($"Unsupported provider: {providerName}"));
-        }
-
-        var apiKey = _configurationResolver.ResolveApiKey(operationName);
         try
         {
+            var providerName = _configurationResolver.ResolveProviderName(operationName);
+            if (!string.Equals(providerName, "OpenAI", StringComparison.Ordinal))
+            {
+                _logger.LogWarning("Provider {ProviderName} is not supported by OpenAI transport.", providerName);
+                return AIOperationResult.PermanentFailure(new AIProviderResult($"Unsupported provider: {providerName}"));
+            }
+
+            var apiKey = _configurationResolver.ResolveApiKey(operationName);
             var resolvedSystemPrompt = string.IsNullOrWhiteSpace(systemPrompt)
                 ? "You are a professional grant analyst for the BC Government."
                 : systemPrompt;
 
-            var requestPayload = new Dictionary<string, object?>
+            var clientOptions = new AzureOpenAIClientOptions();
+            var resolvedApiVersion = _configurationResolver.ResolveApiVersion(operationName);
+            // Note: Azure SDK uses its default API version. Configured version is parsed for documentation/future use.
+            if (!string.IsNullOrEmpty(resolvedApiVersion))
             {
-                ["messages"] = new[]
-                {
-                    new { role = "system", content = resolvedSystemPrompt },
-                    new { role = "user", content = content ?? string.Empty }
-                },
-                [_configurationResolver.ResolveMaxTokensParameterNameForOperation(operationName)] = maxTokens
+                _logger.LogDebug("Profile specifies API version {ApiVersion}; SDK will use its default", resolvedApiVersion);
+            }
+
+            var client = new AzureOpenAIClient(
+                _configurationResolver.ResolveEndpoint(operationName),
+                new ApiKeyCredential(apiKey),
+                clientOptions)
+                .GetChatClient(_configurationResolver.ResolveDeploymentName(operationName));
+
+            var options = new ChatCompletionOptions
+            {
+                MaxOutputTokenCount = maxTokens
             };
 
             var profileTemperature = _configurationResolver.ResolveConfiguredTemperature(operationName);
-            var resolvedTemperature = profileTemperature.HasValue ? temperature ?? profileTemperature : null;
+            var resolvedTemperature = temperature ?? profileTemperature;
             if (resolvedTemperature.HasValue)
             {
-                requestPayload["temperature"] = resolvedTemperature.Value;
+                options.Temperature = (float)resolvedTemperature.Value;
             }
 
-            var reasoningEffort = _configurationResolver.ResolveConfiguredReasoningEffort(operationName);
-            if (!string.IsNullOrWhiteSpace(reasoningEffort))
-            {
-                requestPayload["reasoning_effort"] = reasoningEffort;
-            }
+            var result = await client.CompleteChatAsync(
+                [
+                    new SystemChatMessage(resolvedSystemPrompt),
+                    new UserChatMessage(content ?? string.Empty)
+                ],
+                options,
+                cancellationToken);
 
-            var verbosity = _configurationResolver.ResolveConfiguredVerbosity(operationName);
-            if (!string.IsNullOrWhiteSpace(verbosity))
-            {
-                requestPayload["verbosity"] = verbosity;
-            }
-
-            var json = JsonSerializer.Serialize(requestPayload);
-            var httpContent = new StringContent(json, Encoding.UTF8, "application/json");
-
-            using var request = new HttpRequestMessage(HttpMethod.Post, _configurationResolver.ResolveApiUrl(operationName))
-            {
-                Content = httpContent
-            };
-            request.Headers.TryAddWithoutValidation("Authorization", apiKey);
-
-            using var response = await _httpClient.SendAsync(request, cancellationToken);
-            var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
-            var metadata = TryExtractProviderMetadata(responseContent);
+            var completion = result.Value;
+            var rawResponse = result.GetRawResponse();
+            var responseContent = rawResponse.Content.ToString();
+            var modelOutput = completion.Content.Count > 0 ? completion.Content[0].Text : null;
             var providerResponse = BuildProviderResponseFromMetadata(
-                string.Empty,
+                modelOutput ?? string.Empty,
                 responseContent,
-                metadata,
-                (int)response.StatusCode);
+                TryExtractProviderMetadata(responseContent),
+                rawResponse.Status);
 
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogError(
-                    "OpenAI API request failed with status {StatusCode}. Response body length: {ResponseLength}.",
-                    response.StatusCode,
-                    responseContent.Length);
-                return MapFailureOutcome(response.StatusCode, providerResponse);
-            }
-
-            if (string.IsNullOrWhiteSpace(responseContent))
-            {
-                return AIOperationResult.InvalidOutput(providerResponse);
-            }
-
-            try
-            {
-                using var jsonDoc = JsonDocument.Parse(responseContent);
-                var choices = jsonDoc.RootElement.GetProperty("choices");
-                if (choices.GetArrayLength() > 0)
-                {
-                    var message = choices[0].GetProperty("message");
-                    var modelOutput = message.GetProperty("content").GetString();
-                    return string.IsNullOrWhiteSpace(modelOutput)
-                        ? AIOperationResult.InvalidOutput(providerResponse)
-                        : AIOperationResult.Success(BuildProviderResponseFromMetadata(
-                            modelOutput,
-                            responseContent,
-                            metadata,
-                            (int)response.StatusCode));
-                }
-
-                return AIOperationResult.InvalidOutput(providerResponse);
-            }
-            catch (Exception ex) when (ex is JsonException || ex is KeyNotFoundException || ex is InvalidOperationException)
-            {
-                _logger.LogWarning(ex, "AI response payload had an invalid output shape");
-                return AIOperationResult.InvalidOutput(providerResponse);
-            }
+            return string.IsNullOrWhiteSpace(modelOutput)
+                ? AIOperationResult.InvalidOutput(providerResponse)
+                : AIOperationResult.Success(providerResponse);
         }
         catch (OperationCanceledException)
         {
@@ -138,6 +99,21 @@ public class OpenAITransportService(
         {
             _logger.LogError(ex, "AI request configuration is invalid.");
             return AIOperationResult.PermanentFailure(new AIProviderResult(ex.Message));
+        }
+        catch (ClientResultException ex)
+        {
+            int? statusCode = ex.Status > 0 ? ex.Status : null;
+            var responseContent = ex.GetRawResponse()?.Content?.ToString() ?? ex.Message;
+            var providerResponse = BuildProviderResponseFromMetadata(
+                string.Empty,
+                responseContent,
+                TryExtractProviderMetadata(responseContent),
+                statusCode);
+
+            _logger.LogError(ex, "OpenAI API request failed: {StatusCode} - {Content}", statusCode, responseContent);
+            return statusCode.HasValue
+                ? MapFailureOutcome((HttpStatusCode)statusCode.Value, providerResponse)
+                : AIOperationResult.TransientFailure(providerResponse);
         }
         catch (Exception ex)
         {

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Unity.AI.Application.csproj
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Unity.AI.Application.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NPOI" Version="2.7.5" />
     <PackageReference Include="PdfPig" Version="0.1.13" />

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Intakes/IChefsAttachmentDownloadService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/Intakes/IChefsAttachmentDownloadService.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Threading.Tasks;
+using Unity.GrantManager.Attachments;
+
+namespace Unity.GrantManager.Intakes;
+
+public interface IChefsAttachmentDownloadService
+{
+    Task<BlobDto> DownloadAsync(Guid? formSubmissionId, Guid? chefsFileAttachmentId, string name);
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/ChefsAttachmentDownloadService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/ChefsAttachmentDownloadService.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Net.Http;
+using System.Linq;
+using System.Threading.Tasks;
+using Unity.GrantManager.Applications;
+using Unity.GrantManager.Attachments;
+using Unity.GrantManager.Integrations;
+using Unity.Modules.Shared.Http;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.Linq;
+using Volo.Abp.Security.Encryption;
+
+namespace Unity.GrantManager.Intakes;
+
+public class ChefsAttachmentDownloadService(
+    IApplicationFormSubmissionRepository applicationFormSubmissionRepository,
+    IRepository<ApplicationForm, Guid> applicationFormRepository,
+    IAsyncQueryableExecuter asyncExecuter,
+    IEndpointManagementAppService endpointManagementAppService,
+    IResilientHttpRequest resilientRestClient,
+    IStringEncryptionService stringEncryptionService) : IChefsAttachmentDownloadService, ITransientDependency
+{
+    public async Task<BlobDto> DownloadAsync(Guid? formSubmissionId, Guid? chefsFileAttachmentId, string name)
+    {
+        if (formSubmissionId == null)
+        {
+            throw new ApiException(400, "Missing required parameter 'formId' when calling GetSubmission");
+        }
+
+        if (chefsFileAttachmentId == null)
+        {
+            throw new ApiException(400, "Missing required parameter 'chefsFileAttachmentId' when calling GetFileAttachment");
+        }
+
+        ApplicationForm? applicationForm = await GetApplicationFormBySubmissionId(formSubmissionId)
+            ?? throw new ApiException(400, "Missing Form configuration");
+
+        if (applicationForm.ChefsApplicationFormGuid == null)
+        {
+            throw new ApiException(400, "Missing CHEFS form Id");
+        }
+
+        if (applicationForm.ApiKey == null)
+        {
+            throw new ApiException(400, "Missing CHEFS Api Key");
+        }
+
+        string chefsApi = await endpointManagementAppService.GetChefsApiBaseUrlAsync();
+        string url = $"{chefsApi}/files/{chefsFileAttachmentId}";
+        var decryptedApiKey = stringEncryptionService.Decrypt(applicationForm.ApiKey!);
+
+        var response = await resilientRestClient.HttpAsync(
+            HttpMethod.Get,
+            url,
+            null,
+            null,
+            basicAuth: (applicationForm.ChefsApplicationFormGuid!, decryptedApiKey ?? string.Empty)
+        );
+
+        if (((int)response.StatusCode) != 200)
+        {
+            var errorContent = response.Content != null ? await response.Content.ReadAsStringAsync() : string.Empty;
+            throw new ApiException((int)response.StatusCode, "Error calling GetChefsFileAttachment: " + errorContent, response.ReasonPhrase ?? $"{response.StatusCode}");
+        }
+
+        var contentBytes = response.Content != null ? await response.Content.ReadAsByteArrayAsync() : [];
+        var contentType = response.Content?.Headers?.ContentType?.MediaType ?? "application/octet-stream";
+        if (!string.IsNullOrEmpty(name) && name.Contains('%'))
+        {
+            name = Uri.UnescapeDataString(name);
+        }
+
+        return new BlobDto { Name = name, Content = contentBytes, ContentType = contentType };
+    }
+
+    private async Task<ApplicationForm?> GetApplicationFormBySubmissionId(Guid? formSubmissionId)
+    {
+        ApplicationForm? applicationFormData = new();
+
+        if (formSubmissionId != null)
+        {
+            var query = from applicationSubmission in await applicationFormSubmissionRepository.GetQueryableAsync()
+                        join applicationForm in await applicationFormRepository.GetQueryableAsync() on applicationSubmission.ApplicationFormId equals applicationForm.Id
+                        where applicationSubmission.ChefsSubmissionGuid == formSubmissionId.ToString()
+                        select applicationForm;
+            applicationFormData = await asyncExecuter.FirstOrDefaultAsync(query);
+        }
+        return applicationFormData;
+    }
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/ChefsFileAttachmentStreamProvider.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/ChefsFileAttachmentStreamProvider.cs
@@ -1,102 +1,41 @@
+using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
-using System.Net.Http;
 using System.Threading.Tasks;
-using Unity.GrantManager.Applications;
-using Unity.GrantManager.Integrations;
-using Unity.Modules.Shared.Http;
 using Volo.Abp.DependencyInjection;
-using Volo.Abp.Domain.Repositories;
-using Volo.Abp.Security.Encryption;
 
 namespace Unity.GrantManager.Intakes;
 
 public class ChefsFileAttachmentStreamProvider(
-    IApplicationFormSubmissionRepository applicationFormSubmissionRepository,
-    IRepository<ApplicationForm, Guid> applicationFormRepository,
-    IEndpointManagementAppService endpointManagementAppService,
-    IResilientHttpRequest resilientRestClient,
-    IStringEncryptionService stringEncryptionService)
+    IChefsAttachmentDownloadService chefsAttachmentDownloadService,
+    ILogger<ChefsFileAttachmentStreamProvider> logger)
     : IChefsFileAttachmentStreamProvider, ITransientDependency
 {
     public async Task<ChefsFileAttachmentStream> OpenAsync(Guid formSubmissionId, Guid chefsFileAttachmentId, string name)
     {
-        var applicationForm = await GetApplicationFormBySubmissionId(formSubmissionId)
-            ?? throw new ApiException(400, "Missing Form configuration");
-
-        if (applicationForm.ChefsApplicationFormGuid == null)
-        {
-            throw new ApiException(400, "Missing CHEFS form Id");
-        }
-
-        if (applicationForm.ApiKey == null)
-        {
-            throw new ApiException(400, "Missing CHEFS Api Key");
-        }
-
-        var chefsApi = await endpointManagementAppService.GetChefsApiBaseUrlAsync();
-        var url = $"{chefsApi}/files/{chefsFileAttachmentId}";
-        var decryptedApiKey = stringEncryptionService.Decrypt(applicationForm.ApiKey);
-
-        using var response = await resilientRestClient.HttpAsync(
-            HttpMethod.Get,
-            url,
-            null,
-            null,
-            basicAuth: (applicationForm.ChefsApplicationFormGuid, decryptedApiKey ?? string.Empty),
-            completionOption: HttpCompletionOption.ResponseHeadersRead
-        );
-
-        if (((int)response.StatusCode) != 200)
-        {
-            var errorContent = response.Content != null ? await response.Content.ReadAsStringAsync() : string.Empty;
-            throw new ApiException((int)response.StatusCode, "Error calling GetChefsFileAttachment: " + errorContent, response.ReasonPhrase ?? $"{response.StatusCode}");
-        }
-
-        var contentType = response.Content?.Headers?.ContentType?.MediaType ?? "application/octet-stream";
-        var extension = !string.IsNullOrEmpty(name) ? Path.GetExtension(Uri.UnescapeDataString(name)) : string.Empty;
-        var tempPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}{extension}");
-
         try
         {
-            await using (var writeStream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan))
-            await using (var contentStream = await response.Content!.ReadAsStreamAsync())
-            {
-                await contentStream.CopyToAsync(writeStream);
-            }
+            var file = await chefsAttachmentDownloadService.DownloadAsync(formSubmissionId, chefsFileAttachmentId, name);
+            var content = file.Content ?? [];
+            var stream = new MemoryStream(content, writable: false);
 
-            var readStream = new FileStream(tempPath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan | FileOptions.DeleteOnClose);
-            return new ChefsFileAttachmentStream(readStream, contentType);
+            logger.LogInformation(
+                "Opened CHEFS attachment {ChefsFileAttachmentId} for submission {FormSubmissionId}. ContentType: {ContentType}; DownloadedLength: {DownloadedLength}.",
+                chefsFileAttachmentId,
+                formSubmissionId,
+                file.ContentType,
+                content.Length);
+
+            return new ChefsFileAttachmentStream(stream, file.ContentType);
         }
-        catch
+        catch (Exception ex)
         {
-            TryDeleteTempFile(tempPath);
+            logger.LogWarning(
+                ex,
+                "Failed to open CHEFS attachment {ChefsFileAttachmentId} for submission {FormSubmissionId}.",
+                chefsFileAttachmentId,
+                formSubmissionId);
             throw;
-        }
-    }
-
-    private async Task<ApplicationForm?> GetApplicationFormBySubmissionId(Guid formSubmissionId)
-    {
-        var submission = await applicationFormSubmissionRepository.FirstOrDefaultAsync(
-            x => x.ChefsSubmissionGuid == formSubmissionId.ToString());
-
-        return submission == null
-            ? null
-            : await applicationFormRepository.FirstOrDefaultAsync(x => x.Id == submission.ApplicationFormId);
-    }
-
-    private static void TryDeleteTempFile(string tempPath)
-    {
-        try
-        {
-            if (File.Exists(tempPath))
-            {
-                File.Delete(tempPath);
-            }
-        }
-        catch
-        {
-            // Best-effort cleanup; never throw from cleanup path.
         }
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/SubmissionAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/SubmissionAppService.cs
@@ -27,8 +27,9 @@ public class SubmissionAppService(
         IEndpointManagementAppService endpointManagementAppService,
         IResilientHttpRequest resilientRestClient,
         IStringEncryptionService stringEncryptionService,
-        IApplicationRepository applicationRepository,
-        ITenantRepository tenantRepository
+    IChefsAttachmentDownloadService chefsAttachmentDownloadService,
+    IApplicationRepository applicationRepository,
+    ITenantRepository tenantRepository
         ) : GrantManagerAppService, ISubmissionAppService
 {
 
@@ -61,54 +62,7 @@ public class SubmissionAppService(
     [AllowAnonymous]
     public async Task<BlobDto> GetChefsFileAttachment(Guid? formSubmissionId, Guid? chefsFileAttachmentId, string name)
     {
-        if (formSubmissionId == null)
-        {
-            throw new ApiException(400, "Missing required parameter 'formId' when calling GetSubmission");
-        }
-
-        if (chefsFileAttachmentId == null)
-        {
-            throw new ApiException(400, "Missing required parameter 'chefsFileAttachmentId' when calling GetFileAttachment");
-        }
-
-        ApplicationForm? applicationForm = await GetApplicationFormBySubmissionId(formSubmissionId) ?? throw new ApiException(400, "Missing Form configuration");
-        if (applicationForm.ChefsApplicationFormGuid == null)
-        {
-            throw new ApiException(400, "Missing CHEFS form Id");
-        }
-
-        if (applicationForm.ApiKey == null)
-        {
-            throw new ApiException(400, "Missing CHEFS Api Key");
-        }
-
-        string chefsApi = await endpointManagementAppService.GetChefsApiBaseUrlAsync();
-        string url = $"{chefsApi}/files/{chefsFileAttachmentId}";
-        var decryptedApiKey = stringEncryptionService.Decrypt(applicationForm.ApiKey!);
-
-        var response = await resilientRestClient.HttpAsync(
-            HttpMethod.Get,
-            url,
-            null,
-            null,
-            basicAuth: (applicationForm.ChefsApplicationFormGuid!, decryptedApiKey ?? string.Empty)
-        );
-
-        if (((int)response.StatusCode) != 200)
-        {
-            var errorContent = response.Content != null ? await response.Content.ReadAsStringAsync() : string.Empty;
-            throw new ApiException((int)response.StatusCode, "Error calling GetChefsFileAttachment: " + errorContent, response.ReasonPhrase ?? $"{response.StatusCode}");
-        }
-
-        var contentBytes = response.Content != null ? await response.Content.ReadAsByteArrayAsync() : [];
-        var contentType = response.Content?.Headers?.ContentType?.MediaType ?? "application/octet-stream";
-        // Check and decode the file name if it is URL encoded
-        if (!string.IsNullOrEmpty(name) && name.Contains('%'))
-        {
-            name = Uri.UnescapeDataString(name);
-        }
-
-        return new BlobDto { Name = name, Content = contentBytes, ContentType = contentType };
+        return await chefsAttachmentDownloadService.DownloadAsync(formSubmissionId, chefsFileAttachmentId, name);
     }
 
     public async Task<ApplicationForm?> GetApplicationFormBySubmissionId(Guid? formSubmissionId)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/appsettings.json
@@ -175,15 +175,16 @@
       "Endpoint": "",
       "Profiles": {
         "Gpt4oMini": {
-          "ApiUrl": "/openai/deployments/gpt-4o-mini/chat/completions?api-version=2024-02-01",
-          "MaxTokensParameter": "max_tokens",
+          "DeploymentName": "gpt-4o-mini",
           "Temperature": 0.3
         },
         "Gpt5Mini": {
-          "ApiUrl": "/openai/deployments/gpt-5-mini/chat/completions?api-version=2024-10-01-preview",
-          "MaxTokensParameter": "max_completion_tokens",
-          "ReasoningEffort": "minimal",
-          "Verbosity": "low"
+          "DeploymentName": "gpt-5-mini",
+          "MaxOutputTokenCountSupported": false
+        },
+        "Gpt5Nano": {
+          "DeploymentName": "gpt-5-nano",
+          "MaxOutputTokenCountSupported": false
         }
       }
     },

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/AttachmentSummaryServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/AttachmentSummaryServiceTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using NPOI.XWPF.UserModel;
 using Shouldly;
 using System;
 using System.IO;
@@ -16,6 +17,7 @@ using Unity.AI.Responses;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Intakes;
 using Volo.Abp;
+using Volo.Abp.Uow;
 using Xunit;
 
 namespace Unity.GrantManager.AI.Operations;
@@ -55,6 +57,7 @@ public class AttachmentSummaryServiceTests
             .Returns(new AttachmentSummaryResponse { Summary = "summary text" });
 
         var prerequisiteValidator = Substitute.For<IAIGenerationPrerequisiteValidator>();
+        var unitOfWorkManager = CreateUnitOfWorkManager();
 
         var service = new AttachmentSummaryService(
             attachmentRepository,
@@ -63,6 +66,7 @@ public class AttachmentSummaryServiceTests
             aiService,
             prerequisiteValidator,
             new AIExecutionModeResolver(new ConfigurationBuilder().Build()),
+            unitOfWorkManager,
             NullLogger<AttachmentSummaryService>.Instance,
             Substitute.For<IStringLocalizer<AIResource>>());
 
@@ -104,6 +108,7 @@ public class AttachmentSummaryServiceTests
         var streamProvider = Substitute.For<IChefsFileAttachmentStreamProvider>();
         streamProvider.OpenAsync(submissionId, fileId, "test.txt")
             .Returns(new ChefsFileAttachmentStream(stream, "text/plain"));
+        var unitOfWorkManager = CreateUnitOfWorkManager();
 
         var service = new AttachmentSummaryService(
             attachmentRepository,
@@ -112,6 +117,7 @@ public class AttachmentSummaryServiceTests
             Substitute.For<IAIService>(),
             Substitute.For<IAIGenerationPrerequisiteValidator>(),
             new AIExecutionModeResolver(new ConfigurationBuilder().Build()),
+            unitOfWorkManager,
             NullLogger<AttachmentSummaryService>.Instance,
             Substitute.For<IStringLocalizer<AIResource>>());
 
@@ -127,6 +133,7 @@ public class AttachmentSummaryServiceTests
         var textExtractionService = Substitute.For<ITextExtractionService>();
         var aiService = Substitute.For<IAIService>();
         var prerequisiteValidator = Substitute.For<IAIGenerationPrerequisiteValidator>();
+        var unitOfWorkManager = CreateUnitOfWorkManager();
 
         var service = new AttachmentSummaryService(
             attachmentRepository,
@@ -135,11 +142,128 @@ public class AttachmentSummaryServiceTests
             aiService,
             prerequisiteValidator,
             new AIExecutionModeResolver(new ConfigurationBuilder().Build()),
+            unitOfWorkManager,
             NullLogger<AttachmentSummaryService>.Instance,
             Substitute.For<IStringLocalizer<AIResource>>());
 
         await Should.ThrowAsync<UserFriendlyException>(() => service.GenerateAndSaveAsync([], "v1"));
 
         await aiService.DidNotReceive().GenerateAttachmentSummaryAsync(Arg.Any<AttachmentSummaryRequest>());
+    }
+
+    [Fact]
+    public async Task GenerateAndSaveAsync_Should_Not_Call_AI_When_Supported_File_Extraction_Is_Empty()
+    {
+        var attachmentId = Guid.NewGuid();
+        var submissionId = Guid.NewGuid();
+        var fileId = Guid.NewGuid();
+        var stream = new MemoryStream([1, 2, 3]);
+
+        var attachment = new ApplicationChefsFileAttachment
+        {
+            ApplicationId = Guid.NewGuid(),
+            FileName = "test.docx",
+            ChefsSubmissionId = submissionId.ToString(),
+            ChefsFileId = fileId.ToString()
+        };
+
+        var attachmentRepository = Substitute.For<IApplicationChefsFileAttachmentRepository>();
+        attachmentRepository.GetAsync(attachmentId).Returns(attachment);
+
+        var streamProvider = Substitute.For<IChefsFileAttachmentStreamProvider>();
+        streamProvider.OpenAsync(submissionId, fileId, "test.docx")
+            .Returns(new ChefsFileAttachmentStream(stream, "application/vnd.openxmlformats-officedocument.wordprocessingml.document"));
+
+        var textExtractionService = Substitute.For<ITextExtractionService>();
+        textExtractionService.ExtractTextAsync("test.docx", stream, "application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+            .Returns(string.Empty);
+
+        var aiService = Substitute.For<IAIService>();
+        var service = new AttachmentSummaryService(
+            attachmentRepository,
+            streamProvider,
+            textExtractionService,
+            aiService,
+            Substitute.For<IAIGenerationPrerequisiteValidator>(),
+            new AIExecutionModeResolver(new ConfigurationBuilder().Build()),
+            CreateUnitOfWorkManager(),
+            NullLogger<AttachmentSummaryService>.Instance,
+            Substitute.For<IStringLocalizer<AIResource>>());
+
+        var result = await service.GenerateAndSaveAsync(attachmentId, "v1");
+
+        result.ShouldBe("Attachment text could not be extracted for AI summary generation.");
+        attachment.AISummary.ShouldBe(result);
+        await aiService.DidNotReceive().GenerateAttachmentSummaryAsync(Arg.Any<AttachmentSummaryRequest>());
+        await attachmentRepository.Received(1).UpdateAsync(attachment);
+    }
+
+    [Fact]
+    public async Task GenerateAndSaveAsync_Should_Pass_Extracted_Docx_Text_To_AI()
+    {
+        var attachmentId = Guid.NewGuid();
+        var submissionId = Guid.NewGuid();
+        var fileId = Guid.NewGuid();
+        var stream = CreateDocxStream("Riverside mock attachment content");
+        AttachmentSummaryRequest? capturedRequest = null;
+
+        var attachment = new ApplicationChefsFileAttachment
+        {
+            ApplicationId = Guid.NewGuid(),
+            FileName = "riverside-profile.docx",
+            ChefsSubmissionId = submissionId.ToString(),
+            ChefsFileId = fileId.ToString()
+        };
+
+        var attachmentRepository = Substitute.For<IApplicationChefsFileAttachmentRepository>();
+        attachmentRepository.GetAsync(attachmentId).Returns(attachment);
+
+        var streamProvider = Substitute.For<IChefsFileAttachmentStreamProvider>();
+        streamProvider.OpenAsync(submissionId, fileId, "riverside-profile.docx")
+            .Returns(new ChefsFileAttachmentStream(stream, "application/vnd.openxmlformats-officedocument.wordprocessingml.document"));
+
+        var aiService = Substitute.For<IAIService>();
+        aiService.GenerateAttachmentSummaryAsync(Arg.Do<AttachmentSummaryRequest>(request => capturedRequest = request))
+            .Returns(new AttachmentSummaryResponse { Summary = "summary text" });
+
+        var service = new AttachmentSummaryService(
+            attachmentRepository,
+            streamProvider,
+            new TextExtractionService(NullLogger<TextExtractionService>.Instance),
+            aiService,
+            Substitute.For<IAIGenerationPrerequisiteValidator>(),
+            new AIExecutionModeResolver(new ConfigurationBuilder().Build()),
+            CreateUnitOfWorkManager(),
+            NullLogger<AttachmentSummaryService>.Instance,
+            Substitute.For<IStringLocalizer<AIResource>>());
+
+        var result = await service.GenerateAndSaveAsync(attachmentId, "v1");
+
+        result.ShouldBe("summary text");
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest.ExtractedText.ShouldNotBeNull();
+        capturedRequest.ExtractedText.ShouldContain("Riverside mock attachment content");
+        await aiService.Received(1).GenerateAttachmentSummaryAsync(Arg.Any<AttachmentSummaryRequest>());
+    }
+
+    private static MemoryStream CreateDocxStream(string paragraphText)
+    {
+        var writeStream = new MemoryStream();
+        using (var document = new XWPFDocument())
+        {
+            document.CreateParagraph().CreateRun().SetText(paragraphText);
+            document.Write(writeStream);
+        }
+
+        return new MemoryStream(writeStream.ToArray());
+    }
+
+    private static IUnitOfWorkManager CreateUnitOfWorkManager()
+    {
+        var unitOfWork = Substitute.For<IUnitOfWork>();
+        var unitOfWorkManager = Substitute.For<IUnitOfWorkManager>();
+        unitOfWorkManager.Begin(Arg.Any<AbpUnitOfWorkOptions>(), Arg.Any<bool>())
+            .Returns(unitOfWork);
+        return unitOfWorkManager;
     }
 }

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAIConfigurationResolverTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAIConfigurationResolverTests.cs
@@ -81,6 +81,75 @@ public class OpenAIConfigurationResolverTests
     }
 
     [Fact]
+    public void ResolveEndpoint_Should_Return_Configured_Provider_Endpoint()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Azure:Operations:Defaults:Provider"] = "OpenAI",
+                ["Azure:OpenAI:Endpoint"] = "https://example.test"
+            })
+            .Build();
+
+        var resolver = new OpenAIConfigurationResolver(configuration);
+
+        resolver.ResolveEndpoint().ShouldBe(new Uri("https://example.test"));
+    }
+
+    [Fact]
+    public void ResolveDeploymentName_Should_Return_Profile_DeploymentName()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Azure:Operations:Defaults:Provider"] = "OpenAI",
+                ["Azure:Operations:Defaults:Profile"] = "Gpt5Mini",
+                ["Azure:OpenAI:Profiles:Gpt5Mini:DeploymentName"] = "gpt-5-mini"
+            })
+            .Build();
+
+        var resolver = new OpenAIConfigurationResolver(configuration);
+
+        resolver.ResolveDeploymentName().ShouldBe("gpt-5-mini");
+    }
+
+    [Fact]
+    public void ResolveDeploymentName_Should_Use_Operation_Profile_Override()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Azure:Operations:Defaults:Provider"] = "OpenAI",
+                ["Azure:Operations:Defaults:Profile"] = "Gpt5Mini",
+                ["Azure:Operations:ApplicationAnalysis:Profile"] = "Gpt4oMini",
+                ["Azure:OpenAI:Profiles:Gpt5Mini:DeploymentName"] = "gpt-5-mini",
+                ["Azure:OpenAI:Profiles:Gpt4oMini:DeploymentName"] = "gpt-4o-mini"
+            })
+            .Build();
+
+        var resolver = new OpenAIConfigurationResolver(configuration);
+
+        resolver.ResolveDeploymentName("ApplicationAnalysis").ShouldBe("gpt-4o-mini");
+    }
+
+    [Fact]
+    public void ResolveDeploymentName_Should_Throw_When_Profile_DeploymentName_Is_Missing()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Azure:Operations:Defaults:Provider"] = "OpenAI",
+                ["Azure:Operations:Defaults:Profile"] = "Gpt5Mini"
+            })
+            .Build();
+
+        var resolver = new OpenAIConfigurationResolver(configuration);
+
+        var ex = Should.Throw<InvalidOperationException>(() => resolver.ResolveDeploymentName());
+        ex.Message.ShouldContain("Azure:OpenAI:Profiles:Gpt5Mini:DeploymentName");
+    }
+
+    [Fact]
     public void ResolveConfiguredTemperature_Should_Return_Profile_Temperature()
     {
         var configuration = new ConfigurationBuilder()
@@ -122,15 +191,31 @@ public class OpenAIConfigurationResolverTests
         resolver.ResolveConfiguredTemperature().ShouldBeNull();
     }
 
-    private static IConfiguration BuildProfileConfiguration(string settingName, string settingValue)
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    public void ResolveMaxOutputTokenCountSupported_Should_Use_Profile_Setting_Or_Default_True(
+        string? configuredValue,
+        bool expected)
     {
-        return new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Azure:Operations:Defaults:Provider"] = "OpenAI",
-                ["Azure:Operations:Defaults:Profile"] = "Gpt5Mini",
-                [$"Azure:OpenAI:Profiles:Gpt5Mini:{settingName}"] = settingValue
-            })
+        var values = new Dictionary<string, string?>
+        {
+            ["Azure:Operations:Defaults:Provider"] = "OpenAI",
+            ["Azure:Operations:Defaults:Profile"] = "Gpt5Mini"
+        };
+
+        if (configuredValue != null)
+        {
+            values["Azure:OpenAI:Profiles:Gpt5Mini:MaxOutputTokenCountSupported"] = configuredValue;
+        }
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
             .Build();
+
+        var resolver = new OpenAIConfigurationResolver(configuration);
+
+        resolver.ResolveMaxOutputTokenCountSupported().ShouldBe(expected);
     }
 }

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAIConfigurationResolverTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAIConfigurationResolverTests.cs
@@ -10,25 +10,6 @@ namespace Unity.GrantManager.AI.Runtime;
 public class OpenAIConfigurationResolverTests
 {
     [Fact]
-    public void ResolveApiUrl_Should_CombineEndpointWithLeadingSlashProfilePath()
-    {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Azure:Operations:Defaults:Provider"] = "OpenAI",
-                ["Azure:Operations:Defaults:Profile"] = "Gpt4oMini",
-                ["Azure:OpenAI:Endpoint"] = "https://d837ad-test-recap-webapp.azurewebsites.net",
-                ["Azure:OpenAI:Profiles:Gpt4oMini:ApiUrl"] = "/openai/deployments/gpt-4o-mini/chat/completions?api-version=2024-02-01"
-            })
-            .Build();
-
-        var resolver = new OpenAIConfigurationResolver(configuration);
-
-        resolver.ResolveApiUrl().ShouldBe(
-            "https://d837ad-test-recap-webapp.azurewebsites.net/openai/deployments/gpt-4o-mini/chat/completions?api-version=2024-02-01");
-    }
-
-    [Fact]
     public void ResolveProviderName_Should_Throw_When_DefaultProvider_Is_Missing()
     {
         var configuration = new ConfigurationBuilder()
@@ -39,41 +20,6 @@ public class OpenAIConfigurationResolverTests
 
         var ex = Should.Throw<InvalidOperationException>(() => resolver.ResolveProviderName());
         ex.Message.ShouldContain("Azure:Operations:Defaults:Provider");
-    }
-
-    [Fact]
-    public void ResolveApiUrl_Should_Throw_When_Endpoint_Is_Missing()
-    {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Azure:Operations:Defaults:Provider"] = "OpenAI",
-                ["Azure:Operations:Defaults:Profile"] = "Gpt4oMini",
-                ["Azure:OpenAI:Profiles:Gpt4oMini:ApiUrl"] = "/openai/deployments/gpt-4o-mini/chat/completions?api-version=2024-02-01"
-            })
-            .Build();
-
-        var resolver = new OpenAIConfigurationResolver(configuration);
-
-        var ex = Should.Throw<InvalidOperationException>(() => resolver.ResolveApiUrl());
-        ex.Message.ShouldContain("Azure:OpenAI:Endpoint");
-    }
-
-    [Fact]
-    public void ResolveMaxTokensParameterNameForOperation_Should_Return_Configured_Profile_Parameter()
-    {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Azure:Operations:Defaults:Provider"] = "OpenAI",
-                ["Azure:Operations:Defaults:Profile"] = "Gpt4oMini",
-                ["Azure:OpenAI:Profiles:Gpt4oMini:MaxTokensParameter"] = "max_tokens"
-            })
-            .Build();
-
-        var resolver = new OpenAIConfigurationResolver(configuration);
-
-        resolver.ResolveMaxTokensParameterNameForOperation().ShouldBe("max_tokens");
     }
 
     [Fact]
@@ -174,44 +120,6 @@ public class OpenAIConfigurationResolverTests
         var resolver = new OpenAIConfigurationResolver(configuration);
 
         resolver.ResolveConfiguredTemperature().ShouldBeNull();
-    }
-
-    [Fact]
-    public void ResolveConfiguredReasoningEffort_Should_Return_ProfileValue()
-    {
-        var configuration = BuildProfileConfiguration("ReasoningEffort", "minimal");
-        var resolver = new OpenAIConfigurationResolver(configuration);
-
-        resolver.ResolveConfiguredReasoningEffort().ShouldBe("minimal");
-    }
-
-    [Fact]
-    public void ResolveConfiguredVerbosity_Should_Return_ProfileValue()
-    {
-        var configuration = BuildProfileConfiguration("Verbosity", "low");
-        var resolver = new OpenAIConfigurationResolver(configuration);
-
-        resolver.ResolveConfiguredVerbosity().ShouldBe("low");
-    }
-
-    [Fact]
-    public void ResolveConfiguredReasoningEffort_Should_ReturnNull_WhenProfileSettingMissing()
-    {
-        var configuration = BuildProfileConfiguration("Temperature", "0.3");
-        var resolver = new OpenAIConfigurationResolver(configuration);
-
-        resolver.ResolveConfiguredReasoningEffort().ShouldBeNull();
-    }
-
-    [Fact]
-    public void ResolveConfiguredVerbosity_Should_RejectUnsupportedValue()
-    {
-        var configuration = BuildProfileConfiguration("Verbosity", "verbose");
-        var resolver = new OpenAIConfigurationResolver(configuration);
-
-        var exception = Should.Throw<System.InvalidOperationException>(() => resolver.ResolveConfiguredVerbosity());
-        exception.Message.ShouldContain("Verbosity");
-        exception.Message.ShouldContain("low, medium, high");
     }
 
     private static IConfiguration BuildProfileConfiguration(string settingName, string settingValue)

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAITransportServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAITransportServiceTests.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Shouldly;
 using System.Collections.Generic;
-using System.Text.Json;
 using System.Threading.Tasks;
 using Unity.AI.Runtime;
 using Xunit;
@@ -21,6 +20,7 @@ public class OpenAITransportServiceTests
 
         var service = new OpenAITransportService(
             resolver,
+            new OpenAIChatClientFactory(resolver),
             NullLogger<OpenAITransportService>.Instance);
 
         var result = await service.GenerateSummaryAsync("content", "system", 100);
@@ -37,8 +37,7 @@ public class OpenAITransportServiceTests
             ["Azure:Operations:Defaults:Profile"] = "Gpt5Mini",
             ["Azure:OpenAI:ApiKey"] = "test-key",
             ["Azure:OpenAI:Endpoint"] = "https://example.test",
-            ["Azure:OpenAI:Profiles:Gpt5Mini:ApiUrl"] = "/openai/deployments/gpt-5-mini/chat/completions",
-            ["Azure:OpenAI:Profiles:Gpt5Mini:MaxTokensParameter"] = "max_completion_tokens"
+            ["Azure:OpenAI:Profiles:Gpt5Mini:DeploymentName"] = "gpt-5-mini"
         };
 
         if (overrides != null)

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAITransportServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/OpenAITransportServiceTests.cs
@@ -2,11 +2,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Shouldly;
 using System.Collections.Generic;
-using System.Net;
-using System.Net.Http;
-using System.Text;
 using System.Text.Json;
-using System.Threading;
 using System.Threading.Tasks;
 using Unity.AI.Runtime;
 using Xunit;
@@ -16,59 +12,21 @@ namespace Unity.GrantManager.AI.Runtime;
 public class OpenAITransportServiceTests
 {
     [Fact]
-    public async Task GenerateSummaryAsync_Should_Include_ProfileReasoningEffortAndVerbosity()
+    public async Task GenerateSummaryAsync_Should_ReturnPermanentFailure_When_ProviderNotSupported()
     {
-        var handler = new CaptureRequestHandler();
         var resolver = CreateResolver(new Dictionary<string, string?>
         {
-            ["Azure:OpenAI:Profiles:Gpt5Mini:ReasoningEffort"] = "minimal",
-            ["Azure:OpenAI:Profiles:Gpt5Mini:Verbosity"] = "low"
+            ["Azure:Operations:Defaults:Provider"] = "UnsupportedProvider"
         });
 
         var service = new OpenAITransportService(
-            new HttpClient(handler),
             resolver,
-            NullLogger<OpenAITransportService>.Instance);
-
-        await service.GenerateSummaryAsync("content", "system", 100);
-
-        using var payload = JsonDocument.Parse(handler.RequestContent);
-        payload.RootElement.GetProperty("reasoning_effort").GetString().ShouldBe("minimal");
-        payload.RootElement.GetProperty("verbosity").GetString().ShouldBe("low");
-        payload.RootElement.TryGetProperty("temperature", out _).ShouldBeFalse();
-    }
-
-    [Fact]
-    public async Task GenerateSummaryAsync_Should_Omit_RequestTemperature_When_ProfileDoesNotSupportTemperature()
-    {
-        var handler = new CaptureRequestHandler();
-        var service = new OpenAITransportService(
-            new HttpClient(handler),
-            CreateResolver(),
-            NullLogger<OpenAITransportService>.Instance);
-
-        await service.GenerateSummaryAsync("content", "system", 100, temperature: 0.2);
-
-        using var payload = JsonDocument.Parse(handler.RequestContent);
-        payload.RootElement.TryGetProperty("temperature", out _).ShouldBeFalse();
-    }
-
-    [Fact]
-    public async Task GenerateSummaryAsync_Should_ReturnPermanentFailure_When_ProfileOptionIsInvalid()
-    {
-        var handler = new CaptureRequestHandler();
-        var service = new OpenAITransportService(
-            new HttpClient(handler),
-            CreateResolver(new Dictionary<string, string?>
-            {
-                ["Azure:OpenAI:Profiles:Gpt5Mini:Verbosity"] = "verbose"
-            }),
             NullLogger<OpenAITransportService>.Instance);
 
         var result = await service.GenerateSummaryAsync("content", "system", 100);
 
         result.Outcome.ShouldBe(AIOperationOutcome.PermanentFailure);
-        handler.SendCount.ShouldBe(0);
+        result.Response?.Content.ShouldContain("Unsupported provider");
     }
 
     private static OpenAIConfigurationResolver CreateResolver(Dictionary<string, string?>? overrides = null)
@@ -94,38 +52,5 @@ public class OpenAITransportServiceTests
         return new OpenAIConfigurationResolver(new ConfigurationBuilder()
             .AddInMemoryCollection(values)
             .Build());
-    }
-
-    private sealed class CaptureRequestHandler : HttpMessageHandler
-    {
-        public string RequestContent { get; private set; } = string.Empty;
-
-        public int SendCount { get; private set; }
-
-        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            SendCount++;
-            RequestContent = request.Content == null
-                ? string.Empty
-                : await request.Content.ReadAsStringAsync(cancellationToken);
-
-            const string response = """
-                {
-                  "choices": [
-                    {
-                      "message": {
-                        "content": "generated"
-                      },
-                      "finish_reason": "stop"
-                    }
-                  ]
-                }
-                """;
-
-            return new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(response, Encoding.UTF8, "application/json")
-            };
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Migrates the Unity.AI runtime to the Azure OpenAI SDK with explicit deployment-based configuration.
- Removes the old URL-based profile settings and GPT-5 token-parameter assumptions in favor of SDK-native client setup.
- Keeps attachment summaries working under the new client path by routing CHEFS downloads through a shared downloader used by both submission downloads and AI extraction.

## Validation
- dotnet build applications/Unity.GrantManager/src/Unity.GrantManager.Application/Unity.GrantManager.Application.csproj --no-restore