### PR TITLE
AB#33388 standardize AI response validation and failure handling

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIOperationResult.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIOperationResult.cs
@@ -8,9 +8,21 @@ namespace Unity.AI.Runtime
         InvalidOutput
     }
 
+    public enum AIFailureCategory
+    {
+        None,
+        ProviderUnavailable,
+        TransientProviderFailure,
+        PermanentProviderFailure,
+        InvalidOutput,
+        PartialBatchOutput,
+        PersistenceFailure
+    }
+
     public sealed record AIOperationResult(
         AIOperationOutcome Outcome,
-        AIProviderResult Response)
+        AIProviderResult Response,
+        AIFailureCategory FailureCategory = AIFailureCategory.None)
     {
         public string Content => Response.Content;
 
@@ -20,14 +32,30 @@ namespace Unity.AI.Runtime
             new(AIOperationOutcome.Success, response ?? AIProviderResult.Empty);
 
         public static AIOperationResult TransientFailure(AIProviderResult? response = null) =>
-            new(AIOperationOutcome.TransientFailure, response ?? AIProviderResult.Empty);
+            new(AIOperationOutcome.TransientFailure, response ?? AIProviderResult.Empty, AIFailureCategory.TransientProviderFailure);
 
         public static AIOperationResult PermanentFailure(AIProviderResult? response = null) =>
-            new(AIOperationOutcome.PermanentFailure, response ?? AIProviderResult.Empty);
+            new(AIOperationOutcome.PermanentFailure, response ?? AIProviderResult.Empty, AIFailureCategory.PermanentProviderFailure);
+
+        public static AIOperationResult ProviderUnavailable(AIProviderResult? response = null) =>
+            new(AIOperationOutcome.PermanentFailure, response ?? AIProviderResult.Empty, AIFailureCategory.ProviderUnavailable);
 
         public static AIOperationResult InvalidOutput(AIProviderResult? response = null) =>
-            new(AIOperationOutcome.InvalidOutput, response ?? AIProviderResult.Empty);
+            new(AIOperationOutcome.InvalidOutput, response ?? AIProviderResult.Empty, AIFailureCategory.InvalidOutput);
 
-        public AIOperationResult WithOutcome(AIOperationOutcome outcome) => new(outcome, Response);
+        public AIOperationResult WithOutcome(AIOperationOutcome outcome, AIFailureCategory? failureCategory = null) =>
+            new(outcome, Response, failureCategory ?? ResolveFailureCategory(outcome));
+
+        private static AIFailureCategory ResolveFailureCategory(AIOperationOutcome outcome)
+        {
+            return outcome switch
+            {
+                AIOperationOutcome.Success => AIFailureCategory.None,
+                AIOperationOutcome.TransientFailure => AIFailureCategory.TransientProviderFailure,
+                AIOperationOutcome.PermanentFailure => AIFailureCategory.PermanentProviderFailure,
+                AIOperationOutcome.InvalidOutput => AIFailureCategory.InvalidOutput,
+                _ => AIFailureCategory.None
+            };
+        }
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIOperationResult.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIOperationResult.cs
@@ -14,9 +14,7 @@ namespace Unity.AI.Runtime
         ProviderUnavailable,
         TransientProviderFailure,
         PermanentProviderFailure,
-        InvalidOutput,
-        PartialBatchOutput,
-        PersistenceFailure
+        InvalidOutput
     }
 
     public sealed record AIOperationResult(

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIProviderPayloadValidator.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIProviderPayloadValidator.cs
@@ -5,94 +5,92 @@ using Unity.AI.Models;
 
 namespace Unity.AI.Runtime
 {
-    internal static class AIProviderPayloadValidator
+    public static class AIProviderPayloadValidator
     {
-        public static bool IsValidAttachmentSummaryText(string response)
+        public static AIResponseValidationResult ValidateAttachmentSummaryText(string response)
         {
-            return !string.IsNullOrWhiteSpace(response);
+            return !string.IsNullOrWhiteSpace(response)
+                ? AIResponseValidationResult.Success()
+                : AIResponseValidationResult.Invalid("Attachment summary response was empty.");
         }
 
-        public static bool IsValidApplicationAnalysisJson(string response)
+        public static AIResponseValidationResult ValidateApplicationAnalysisJson(string response)
         {
             if (!TryParseRootObject(response, out var root))
             {
-                return false;
+                return AIResponseValidationResult.Invalid("Application analysis response was not valid JSON.");
             }
 
-            return HasStringProperty(root, AIJsonKeys.Decision) &&
-                   HasArrayProperty(root, AIJsonKeys.Errors) &&
-                   HasArrayProperty(root, AIJsonKeys.Warnings) &&
-                   HasArrayProperty(root, AIJsonKeys.Summaries) &&
-                   HasArrayProperty(root, AIJsonKeys.Recommendations);
+            if (!root.TryGetProperty(AIJsonKeys.Decision, out var decision) || decision.ValueKind != JsonValueKind.String)
+            {
+                return AIResponseValidationResult.Invalid($"Application analysis response is missing required field: {AIJsonKeys.Decision}.");
+            }
+
+            if (!root.TryGetProperty(AIJsonKeys.Errors, out var errors) || errors.ValueKind != JsonValueKind.Array)
+            {
+                return AIResponseValidationResult.Invalid($"Application analysis response is missing required field: {AIJsonKeys.Errors}.");
+            }
+
+            if (!root.TryGetProperty(AIJsonKeys.Warnings, out var warnings) || warnings.ValueKind != JsonValueKind.Array)
+            {
+                return AIResponseValidationResult.Invalid($"Application analysis response is missing required field: {AIJsonKeys.Warnings}.");
+            }
+
+            if (!root.TryGetProperty(AIJsonKeys.Summaries, out var summaries) || summaries.ValueKind != JsonValueKind.Array)
+            {
+                return AIResponseValidationResult.Invalid($"Application analysis response is missing required field: {AIJsonKeys.Summaries}.");
+            }
+
+            if (!root.TryGetProperty(AIJsonKeys.Recommendations, out var recommendations) || recommendations.ValueKind != JsonValueKind.Array)
+            {
+                return AIResponseValidationResult.Invalid($"Application analysis response is missing required field: {AIJsonKeys.Recommendations}.");
+            }
+
+            return AIResponseValidationResult.Success();
         }
 
-        public static bool IsValidApplicationScoringJson(string response, string sectionJson)
+        public static AIResponseValidationResult ValidateApplicationScoringJson(string response, string sectionJson)
         {
             if (!TryParseRootObject(response, out var root))
             {
-                return false;
+                return AIResponseValidationResult.Invalid("Application scoring response was not valid JSON.");
             }
 
             var expectedQuestionIds = ExtractQuestionIds(sectionJson);
             if (expectedQuestionIds.Count == 0)
             {
-                return false;
+                return AIResponseValidationResult.Invalid("Application scoring section schema did not contain any question ids.");
             }
 
             foreach (var questionId in expectedQuestionIds)
             {
-                if (!TryGetRequiredObject(root, questionId, out var answerObject))
+                if (!root.TryGetProperty(questionId, out var answerObject) || answerObject.ValueKind != JsonValueKind.Object)
                 {
-                    return false;
+                    return AIResponseValidationResult.Invalid(
+                        $"Application scoring response is missing required answer object for question id '{questionId}'.");
                 }
 
-                if (!HasPrimitiveProperty(answerObject, AIJsonKeys.Answer))
+                if (!answerObject.TryGetProperty(AIJsonKeys.Answer, out var answerValue)
+                    || answerValue.ValueKind == JsonValueKind.Null
+                    || answerValue.ValueKind == JsonValueKind.Object
+                    || answerValue.ValueKind == JsonValueKind.Array)
                 {
-                    return false;
+                    return AIResponseValidationResult.Invalid(
+                        $"Application scoring response is missing a valid answer for question id '{questionId}'.");
                 }
 
-                if (!IsValidConfidenceProperty(answerObject, AIJsonKeys.Confidence))
+                if (!answerObject.TryGetProperty(AIJsonKeys.Confidence, out var confidenceValue)
+                    || confidenceValue.ValueKind != JsonValueKind.Number
+                    || !confidenceValue.TryGetInt32(out var confidence)
+                    || confidence < 0
+                    || confidence > 100)
                 {
-                    return false;
+                    return AIResponseValidationResult.Invalid(
+                        $"Application scoring response is missing a valid confidence score for question id '{questionId}'.");
                 }
             }
 
-            return true;
-        }
-
-        private static bool HasStringProperty(JsonElement element, string name)
-        {
-            return element.TryGetProperty(name, out var property) &&
-                   property.ValueKind == JsonValueKind.String;
-        }
-
-        private static bool HasArrayProperty(JsonElement element, string name)
-        {
-            return element.TryGetProperty(name, out var property) &&
-                   property.ValueKind == JsonValueKind.Array;
-        }
-
-        private static bool TryGetRequiredObject(JsonElement element, string name, out JsonElement value)
-        {
-            return element.TryGetProperty(name, out value) &&
-                   value.ValueKind == JsonValueKind.Object;
-        }
-
-        private static bool HasPrimitiveProperty(JsonElement element, string name)
-        {
-            return element.TryGetProperty(name, out var property) &&
-                   property.ValueKind != JsonValueKind.Null &&
-                   property.ValueKind != JsonValueKind.Object &&
-                   property.ValueKind != JsonValueKind.Array;
-        }
-
-        private static bool IsValidConfidenceProperty(JsonElement element, string name)
-        {
-            return element.TryGetProperty(name, out var property) &&
-                   property.ValueKind == JsonValueKind.Number &&
-                   property.TryGetInt32(out var confidence) &&
-                   confidence >= 0 &&
-                   confidence <= 100;
+            return AIResponseValidationResult.Success();
         }
 
         private static HashSet<string> ExtractQuestionIds(string sectionJson)
@@ -169,5 +167,6 @@ namespace Unity.AI.Runtime
                 return false;
             }
         }
+
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIProviderPayloadValidator.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIProviderPayloadValidator.cs
@@ -23,27 +23,27 @@ namespace Unity.AI.Runtime
 
             if (!root.TryGetProperty(AIJsonKeys.Decision, out var decision) || decision.ValueKind != JsonValueKind.String)
             {
-                return AIResponseValidationResult.Invalid($"Application analysis response is missing required field: {AIJsonKeys.Decision}.");
+                return AIResponseValidationResult.Invalid($"Application analysis response is missing or invalid required field '{AIJsonKeys.Decision}' (expected string).");
             }
 
             if (!root.TryGetProperty(AIJsonKeys.Errors, out var errors) || errors.ValueKind != JsonValueKind.Array)
             {
-                return AIResponseValidationResult.Invalid($"Application analysis response is missing required field: {AIJsonKeys.Errors}.");
+                return AIResponseValidationResult.Invalid($"Application analysis response is missing or invalid required field '{AIJsonKeys.Errors}' (expected array).");
             }
 
             if (!root.TryGetProperty(AIJsonKeys.Warnings, out var warnings) || warnings.ValueKind != JsonValueKind.Array)
             {
-                return AIResponseValidationResult.Invalid($"Application analysis response is missing required field: {AIJsonKeys.Warnings}.");
+                return AIResponseValidationResult.Invalid($"Application analysis response is missing or invalid required field '{AIJsonKeys.Warnings}' (expected array).");
             }
 
             if (!root.TryGetProperty(AIJsonKeys.Summaries, out var summaries) || summaries.ValueKind != JsonValueKind.Array)
             {
-                return AIResponseValidationResult.Invalid($"Application analysis response is missing required field: {AIJsonKeys.Summaries}.");
+                return AIResponseValidationResult.Invalid($"Application analysis response is missing or invalid required field '{AIJsonKeys.Summaries}' (expected array).");
             }
 
             if (!root.TryGetProperty(AIJsonKeys.Recommendations, out var recommendations) || recommendations.ValueKind != JsonValueKind.Array)
             {
-                return AIResponseValidationResult.Invalid($"Application analysis response is missing required field: {AIJsonKeys.Recommendations}.");
+                return AIResponseValidationResult.Invalid($"Application analysis response is missing or invalid required field '{AIJsonKeys.Recommendations}' (expected array).");
             }
 
             return AIResponseValidationResult.Success();
@@ -59,7 +59,7 @@ namespace Unity.AI.Runtime
             var expectedQuestionIds = ExtractQuestionIds(sectionJson);
             if (expectedQuestionIds.Count == 0)
             {
-                return AIResponseValidationResult.Invalid("Application scoring section schema did not contain any question ids.");
+                return AIResponseValidationResult.Invalid("Application scoring section schema could not be parsed or did not contain any question ids.");
             }
 
             foreach (var questionId in expectedQuestionIds)

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIResponseValidationResult.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIResponseValidationResult.cs
@@ -1,0 +1,16 @@
+namespace Unity.AI.Runtime
+{
+    public sealed record AIResponseValidationResult(
+        bool IsValid,
+        AIFailureCategory FailureCategory = AIFailureCategory.None,
+        string? Reason = null)
+    {
+        public static AIResponseValidationResult Success() =>
+            new(true);
+
+        public static AIResponseValidationResult Invalid(
+            string reason,
+            AIFailureCategory failureCategory = AIFailureCategory.InvalidOutput) =>
+            new(false, failureCategory, reason);
+    }
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
@@ -269,7 +269,7 @@ namespace Unity.AI.Runtime
 
                 if (lastResult.Outcome == AIOperationOutcome.Success)
                 {
-                    lastResult = lastResult.WithOutcome(AIOperationOutcome.InvalidOutput);
+                    lastResult = lastResult.WithOutcome(AIOperationOutcome.InvalidOutput, AIFailureCategory.InvalidOutput);
                 }
 
                 if (lastResult.Outcome == AIOperationOutcome.PermanentFailure)
@@ -282,26 +282,31 @@ namespace Unity.AI.Runtime
                     if (lastResult.Outcome == AIOperationOutcome.TransientFailure)
                     {
                         _logger.LogWarning(
-                            "AI {OperationName} attempt {Attempt}/{MaxAttempts} failed transiently; retrying",
+                            "AI {OperationName} attempt {Attempt}/{MaxAttempts} failed transiently ({FailureCategory}); retrying",
                             operationName,
                             attempt,
-                            MaxAiAttempts);
+                            MaxAiAttempts,
+                            lastResult.FailureCategory);
                     }
                     else if (lastResult.Outcome == AIOperationOutcome.InvalidOutput)
                     {
                         _logger.LogWarning(
-                            "AI {OperationName} attempt {Attempt}/{MaxAttempts} returned invalid response shape; retrying",
+                            "AI {OperationName} attempt {Attempt}/{MaxAttempts} returned invalid response shape ({FailureCategory}); retrying",
                             operationName,
                             attempt,
-                            MaxAiAttempts);
+                            MaxAiAttempts,
+                            lastResult.FailureCategory);
                     }
                 }
             }
 
             _logger.LogWarning(
-                "AI {OperationName} exhausted retries with outcome {Outcome}; returning last result",
+                "AI {OperationName} exhausted retries with outcome {Outcome} and failure category {FailureCategory}; HTTP status {HttpStatusCode}; model {Model}; returning last result",
                 operationName,
-                lastResult.Outcome);
+                lastResult.Outcome,
+                lastResult.FailureCategory,
+                lastResult.Response.HttpStatusCode,
+                lastResult.Response.Model);
             return lastResult;
         }
 

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
@@ -25,8 +25,6 @@ namespace Unity.AI.Runtime
         private const string ApplicationScoringPromptType = AIPromptTypes.ApplicationScoring;
         private const int MaxAiAttempts = 3;
 
-
-
         public OpenAIRuntimeService(
             ILogger<OpenAIRuntimeService> logger,
             OpenAITransportService openAITransportService,
@@ -87,7 +85,7 @@ namespace Unity.AI.Runtime
                         settings,
                         settings.CompletionTokens,
                         cancellationToken: cancellationToken),
-                    AIProviderPayloadValidator.IsValidApplicationAnalysisJson,
+                    AIProviderPayloadValidator.ValidateApplicationAnalysisJson,
                     "application analysis",
                     cancellationToken);
 
@@ -151,7 +149,7 @@ namespace Unity.AI.Runtime
                         settings,
                         settings.CompletionTokens,
                         cancellationToken: cancellationToken),
-                    AIProviderPayloadValidator.IsValidAttachmentSummaryText,
+                    AIProviderPayloadValidator.ValidateAttachmentSummaryText,
                     "attachment summary",
                     cancellationToken);
                 await _promptFileLogger.LogPromptOutputAsync(AttachmentSummaryPromptType, promptVersion, result.CaptureOutput, cancellationToken);
@@ -220,13 +218,13 @@ namespace Unity.AI.Runtime
 
                 await _promptFileLogger.LogPromptInputAsync(ApplicationScoringPromptType, promptVersion, systemPrompt, applicationScoringContent, cancellationToken);
                 var result = await GenerateWithRetryAsync(
-                () => _openAITransportService.GenerateSummaryAsync(
-                    applicationScoringContent,
-                    systemPrompt,
-                    settings,
-                    settings.CompletionTokens,
-                    cancellationToken: cancellationToken),
-                    content => AIProviderPayloadValidator.IsValidApplicationScoringJson(content, section),
+                    () => _openAITransportService.GenerateSummaryAsync(
+                        applicationScoringContent,
+                        systemPrompt,
+                        settings,
+                        settings.CompletionTokens,
+                        cancellationToken: cancellationToken),
+                    content => AIProviderPayloadValidator.ValidateApplicationScoringJson(content, section),
                     $"application scoring section {request.SectionName}",
                     cancellationToken);
                 await _promptFileLogger.LogPromptOutputAsync(ApplicationScoringPromptType, promptVersion, result.CaptureOutput, cancellationToken);
@@ -251,7 +249,7 @@ namespace Unity.AI.Runtime
 
         private async Task<AIOperationResult> GenerateWithRetryAsync(
             Func<Task<AIOperationResult>> operation,
-            Func<string, bool> validator,
+            Func<string, AIResponseValidationResult> validator,
             string operationName,
             CancellationToken cancellationToken = default)
         {
@@ -262,14 +260,23 @@ namespace Unity.AI.Runtime
                 cancellationToken.ThrowIfCancellationRequested();
                 lastResult = await operation();
 
-                if (lastResult.Outcome == AIOperationOutcome.Success && validator(lastResult.Content))
-                {
-                    return lastResult;
-                }
-
                 if (lastResult.Outcome == AIOperationOutcome.Success)
                 {
-                    lastResult = lastResult.WithOutcome(AIOperationOutcome.InvalidOutput, AIFailureCategory.InvalidOutput);
+                    var validationResult = validator(lastResult.Content);
+                    if (validationResult.IsValid)
+                    {
+                        return lastResult;
+                    }
+
+                    lastResult = lastResult.WithOutcome(AIOperationOutcome.InvalidOutput, validationResult.FailureCategory);
+
+                    _logger.LogWarning(
+                        "AI {OperationName} attempt {Attempt}/{MaxAttempts} returned invalid response shape ({FailureCategory}): {Reason}; will retry if attempts remain",
+                        operationName,
+                        attempt,
+                        MaxAiAttempts,
+                        validationResult.FailureCategory,
+                        validationResult.Reason ?? "No validation reason provided");
                 }
 
                 if (lastResult.Outcome == AIOperationOutcome.PermanentFailure)
@@ -291,7 +298,7 @@ namespace Unity.AI.Runtime
                     else if (lastResult.Outcome == AIOperationOutcome.InvalidOutput)
                     {
                         _logger.LogWarning(
-                            "AI {OperationName} attempt {Attempt}/{MaxAttempts} returned invalid response shape ({FailureCategory}); retrying",
+                            "AI {OperationName} attempt {Attempt}/{MaxAttempts} returned invalid output ({FailureCategory}); retrying",
                             operationName,
                             attempt,
                             MaxAiAttempts,

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/OpenAIRuntimeService.cs
@@ -310,6 +310,17 @@ namespace Unity.AI.Runtime
             return lastResult;
         }
 
+        private static string ResolveNarrativeContent(AIOperationResult result)
+        {
+            return result.Outcome switch
+            {
+                AIOperationOutcome.Success => result.Content,
+                AIOperationOutcome.PermanentFailure => "AI service not available - service not configured.",
+                AIOperationOutcome.TransientFailure => "AI request failed - service temporarily unavailable.",
+                _ => "AI request failed - please try again later."
+            };
+        }
+
         private static bool TryParseJsonObjectFromResponse(string response, out JsonElement objectElement)
         {
             objectElement = default;

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/AIOperationResultTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/AIOperationResultTests.cs
@@ -1,0 +1,27 @@
+using Shouldly;
+using Unity.AI.Runtime;
+using Xunit;
+
+namespace Unity.GrantManager.AI.Runtime;
+
+public class AIOperationResultTests
+{
+    [Fact]
+    public void Failure_Factories_Should_Set_Consistent_Failure_Categories()
+    {
+        AIOperationResult.Success().FailureCategory.ShouldBe(AIFailureCategory.None);
+        AIOperationResult.ProviderUnavailable().FailureCategory.ShouldBe(AIFailureCategory.ProviderUnavailable);
+        AIOperationResult.TransientFailure().FailureCategory.ShouldBe(AIFailureCategory.TransientProviderFailure);
+        AIOperationResult.PermanentFailure().FailureCategory.ShouldBe(AIFailureCategory.PermanentProviderFailure);
+        AIOperationResult.InvalidOutput().FailureCategory.ShouldBe(AIFailureCategory.InvalidOutput);
+    }
+
+    [Fact]
+    public void WithOutcome_Should_Resolve_Category_When_Not_Explicit()
+    {
+        var result = AIOperationResult.Success().WithOutcome(AIOperationOutcome.InvalidOutput);
+
+        result.Outcome.ShouldBe(AIOperationOutcome.InvalidOutput);
+        result.FailureCategory.ShouldBe(AIFailureCategory.InvalidOutput);
+    }
+}

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/AIProviderPayloadValidatorTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/AIProviderPayloadValidatorTests.cs
@@ -1,4 +1,5 @@
 using Shouldly;
+using System.Text.Json;
 using Unity.AI.Runtime;
 using Xunit;
 
@@ -6,118 +7,56 @@ namespace Unity.GrantManager.AI.Runtime;
 
 public class AIProviderPayloadValidatorTests
 {
-    [Theory]
-    [InlineData(null, false)]
-    [InlineData("", false)]
-    [InlineData("   ", false)]
-    [InlineData("Some summary text", true)]
-    public void IsValidAttachmentSummaryText_Should_RejectBlankAndAcceptContent(string? input, bool expected)
+    [Fact]
+    public void ValidateApplicationAnalysisJson_Should_Return_InvalidOutput_For_InvalidJson()
     {
-        AIProviderPayloadValidator.IsValidAttachmentSummaryText(input!).ShouldBe(expected);
+        var result = AIProviderPayloadValidator.ValidateApplicationAnalysisJson("not-json");
+
+        result.IsValid.ShouldBeFalse();
+        result.FailureCategory.ShouldBe(AIFailureCategory.InvalidOutput);
+        result.Reason.ShouldContain("not valid JSON");
     }
 
     [Fact]
-    public void IsValidApplicationAnalysisJson_Should_ReturnTrue_ForWellFormedPayload()
+    public void ValidateApplicationAnalysisJson_Should_Return_InvalidOutput_When_Decision_Is_Missing()
     {
-        var json = """
+        var result = AIProviderPayloadValidator.ValidateApplicationAnalysisJson(
+            """
             {
-              "decision": "Approved",
               "errors": [],
               "warnings": [],
               "summaries": [],
               "recommendations": []
             }
-            """;
-        AIProviderPayloadValidator.IsValidApplicationAnalysisJson(json).ShouldBeTrue();
-    }
+            """);
 
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("not json")]
-    [InlineData("[]")]
-    public void IsValidApplicationAnalysisJson_Should_ReturnFalse_ForInvalidInput(string? input)
-    {
-        AIProviderPayloadValidator.IsValidApplicationAnalysisJson(input!).ShouldBeFalse();
+        result.IsValid.ShouldBeFalse();
+        result.FailureCategory.ShouldBe(AIFailureCategory.InvalidOutput);
+        result.Reason.ShouldContain("decision");
     }
 
     [Fact]
-    public void IsValidApplicationAnalysisJson_Should_ReturnFalse_WhenDecisionMissing()
+    public void ValidateApplicationScoringJson_Should_Return_InvalidOutput_When_Answer_Is_Missing()
     {
-        var json = """{"errors":[],"warnings":[],"summaries":[],"recommendations":[]}""";
-        AIProviderPayloadValidator.IsValidApplicationAnalysisJson(json).ShouldBeFalse();
+        var sectionJson = JsonSerializer.Serialize(new[]
+        {
+            new { id = "q1" }
+        });
+
+        var result = AIProviderPayloadValidator.ValidateApplicationScoringJson("{}", sectionJson);
+
+        result.IsValid.ShouldBeFalse();
+        result.FailureCategory.ShouldBe(AIFailureCategory.InvalidOutput);
+        result.Reason.ShouldContain("q1");
     }
 
     [Fact]
-    public void IsValidApplicationAnalysisJson_Should_ReturnFalse_WhenErrorsIsNotArray()
+    public void ValidateAttachmentSummaryText_Should_Return_InvalidOutput_For_Empty_Text()
     {
-        var json = """{"decision":"ok","errors":"bad","warnings":[],"summaries":[],"recommendations":[]}""";
-        AIProviderPayloadValidator.IsValidApplicationAnalysisJson(json).ShouldBeFalse();
-    }
+        var result = AIProviderPayloadValidator.ValidateAttachmentSummaryText(string.Empty);
 
-    [Fact]
-    public void IsValidApplicationAnalysisJson_Should_AcceptMarkdownWrappedJson()
-    {
-        var json = "```json\n{\"decision\":\"ok\",\"errors\":[],\"warnings\":[],\"summaries\":[],\"recommendations\":[]}\n```";
-        AIProviderPayloadValidator.IsValidApplicationAnalysisJson(json).ShouldBeTrue();
-    }
-
-    [Fact]
-    public void IsValidApplicationScoringJson_Should_ReturnTrue_ForWellFormedPayload()
-    {
-        var sectionJson = """[{"id":"q1"},{"id":"q2"}]""";
-        var response = """
-            {
-              "q1": {"answer": "Yes", "confidence": 85},
-              "q2": {"answer": "No",  "confidence": 42}
-            }
-            """;
-        AIProviderPayloadValidator.IsValidApplicationScoringJson(response, sectionJson).ShouldBeTrue();
-    }
-
-    [Fact]
-    public void IsValidApplicationScoringJson_Should_ReturnFalse_WhenSectionJsonIsEmpty()
-    {
-        AIProviderPayloadValidator.IsValidApplicationScoringJson("{}", "[]").ShouldBeFalse();
-    }
-
-    [Fact]
-    public void IsValidApplicationScoringJson_Should_ReturnFalse_WhenAnswerMissing()
-    {
-        var sectionJson = """[{"id":"q1"}]""";
-        var response = """{"q1": {"confidence": 50}}""";
-        AIProviderPayloadValidator.IsValidApplicationScoringJson(response, sectionJson).ShouldBeFalse();
-    }
-
-    [Fact]
-    public void IsValidApplicationScoringJson_Should_ReturnFalse_WhenConfidenceOutOfRange()
-    {
-        var sectionJson = """[{"id":"q1"}]""";
-        var response = """{"q1": {"answer": "Yes", "confidence": 150}}""";
-        AIProviderPayloadValidator.IsValidApplicationScoringJson(response, sectionJson).ShouldBeFalse();
-    }
-
-    [Fact]
-    public void IsValidApplicationScoringJson_Should_ReturnFalse_WhenQuestionMissingFromResponse()
-    {
-        var sectionJson = """[{"id":"q1"},{"id":"q2"}]""";
-        var response = """{"q1": {"answer": "Yes", "confidence": 80}}""";
-        AIProviderPayloadValidator.IsValidApplicationScoringJson(response, sectionJson).ShouldBeFalse();
-    }
-
-    [Fact]
-    public void IsValidApplicationScoringJson_Should_AcceptQuestionsWrappedInObject()
-    {
-        var sectionJson = """{"questions":[{"id":"q1"}]}""";
-        var response = """{"q1": {"answer": "Yes", "confidence": 75}}""";
-        AIProviderPayloadValidator.IsValidApplicationScoringJson(response, sectionJson).ShouldBeTrue();
-    }
-
-    [Fact]
-    public void IsValidApplicationScoringJson_Should_ReturnFalse_WhenConfidenceIsNegative()
-    {
-        var sectionJson = """[{"id":"q1"}]""";
-        var response = """{"q1": {"answer": "Yes", "confidence": -1}}""";
-        AIProviderPayloadValidator.IsValidApplicationScoringJson(response, sectionJson).ShouldBeFalse();
+        result.IsValid.ShouldBeFalse();
+        result.FailureCategory.ShouldBe(AIFailureCategory.InvalidOutput);
+        result.Reason.ShouldContain("empty");
     }
 }


### PR DESCRIPTION
## Summary
- Standardize AI response validation with structured failure reasons and categories.
- Keep retry handling focused on invalid output, transient failure, and permanent failure.
- Tighten validation messages so missing-vs-invalid fields are reported accurately.

## Validation
- `dotnet build applications\Unity.GrantManager\Unity.GrantManager.sln --no-restore`
- `dotnet test applications\Unity.GrantManager\test\Unity.GrantManager.Application.Tests\Unity.GrantManager.Application.Tests.csproj --no-build --filter "FullyQualifiedName~AIProviderPayloadValidatorTests|FullyQualifiedName~AIOperationResultTests|FullyQualifiedName~OpenAIRuntimeServiceTests"`
