### PR TITLE
AB#33395 define AI operation input contracts

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/AI/Operations/ApplicationAnalysisOperationInputDto.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/AI/Operations/ApplicationAnalysisOperationInputDto.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Unity.AI.Models;
+
+namespace Unity.AI.Operations
+{
+    public class ApplicationAnalysisOperationInputDto
+    {
+        [JsonPropertyName("applicationId")]
+        public Guid ApplicationId { get; set; }
+
+        [JsonPropertyName("schema")]
+        public JsonElement Schema { get; set; }
+
+        [JsonPropertyName("data")]
+        public JsonElement Data { get; set; }
+
+        [JsonPropertyName("attachments")]
+        public List<AIAttachmentItem> Attachments { get; set; } = new();
+
+        [JsonPropertyName("promptVersion")]
+        public string? PromptVersion { get; set; }
+    }
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/AI/Operations/ApplicationScoringOperationInputDto.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application.Contracts/AI/Operations/ApplicationScoringOperationInputDto.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Unity.AI.Models;
+
+namespace Unity.AI.Operations
+{
+    public class ApplicationScoringOperationInputDto
+    {
+        [JsonPropertyName("applicationId")]
+        public Guid ApplicationId { get; set; }
+
+        [JsonPropertyName("data")]
+        public JsonElement Data { get; set; }
+
+        [JsonPropertyName("attachments")]
+        public List<AIAttachmentItem> Attachments { get; set; } = new();
+
+        [JsonPropertyName("sections")]
+        public List<ApplicationScoringSectionOperationInputDto> Sections { get; set; } = new();
+
+        [JsonPropertyName("promptVersion")]
+        public string? PromptVersion { get; set; }
+    }
+
+    public class ApplicationScoringSectionOperationInputDto
+    {
+        [JsonPropertyName("sectionName")]
+        public string SectionName { get; set; } = string.Empty;
+
+        [JsonPropertyName("sectionSchema")]
+        public JsonElement SectionSchema { get; set; }
+    }
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationAnalysisService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationAnalysisService.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationAnalysisService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationAnalysisService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Unity.AI;
 using Unity.AI.Models;
 using Unity.AI.Requests;
+using Unity.AI.Runtime;
 using Unity.GrantManager.Applications;
 using Volo.Abp.DependencyInjection;
 

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationAnalysisService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationAnalysisService.cs
@@ -1,11 +1,10 @@
-using Microsoft.Extensions.Logging;
 using System;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Unity.AI.Prompts;
+using Unity.AI;
+using Unity.AI.Models;
 using Unity.AI.Requests;
-using Unity.AI.Runtime;
 using Unity.GrantManager.Applications;
 using Volo.Abp.DependencyInjection;
 
@@ -13,59 +12,26 @@ namespace Unity.AI.Operations
 {
     public class ApplicationAnalysisService(
         IApplicationRepository applicationRepository,
-        IApplicationFormSubmissionRepository applicationFormSubmissionRepository,
-        IApplicationFormVersionRepository applicationFormVersionRepository,
-        IApplicationChefsFileAttachmentRepository applicationChefsFileAttachmentRepository,
         IAIService aiService,
-        IAIGenerationPrerequisiteValidator aiGenerationPrerequisiteValidator,
-        ILogger<ApplicationAnalysisService> logger) : IApplicationAnalysisService, ITransientDependency
+        IAIGenerationPrerequisiteValidator aiGenerationPrerequisiteValidator) : IApplicationAnalysisService, ITransientDependency
     {
-        public async Task<string> RegenerateAndSaveAsync(Guid applicationId, string? promptVersion = null, CancellationToken cancellationToken = default)
+        public async Task<string> RegenerateAndSaveAsync(ApplicationAnalysisOperationInputDto input, CancellationToken cancellationToken = default)
         {
-            await aiGenerationPrerequisiteValidator.EnsureApplicationAnalysisAvailableAsync(applicationId);
-
-            var application = await applicationRepository.GetAsync(applicationId);
-            var formSubmission = await applicationFormSubmissionRepository.GetByApplicationAsync(applicationId);
-            var attachments = await applicationChefsFileAttachmentRepository.GetListAsync(a => a.ApplicationId == applicationId);
-            var formSchema = await GetFormSchemaAsync(formSubmission?.ApplicationFormVersionId);
-
-            var attachmentSummaries = PromptDataPayloadBuilder.BuildAttachmentSummaries(attachments);
-            var formFieldConfiguration = await PromptDataPayloadBuilder.BuildFormFieldConfigurationAsync(
-                applicationFormVersionRepository,
-                formSubmission?.ApplicationFormVersionId,
-                logger);
+            await aiGenerationPrerequisiteValidator.EnsureApplicationAnalysisAvailableAsync(input.ApplicationId);
 
             var analysis = await aiService.GenerateApplicationAnalysisAsync(new ApplicationAnalysisRequest
             {
-                Schema = JsonSerializer.SerializeToElement(formFieldConfiguration),
-                Data = PromptDataPayloadBuilder.BuildPromptDataPayload(application, formSubmission, formSchema, logger),
-                Attachments = attachmentSummaries,
-                PromptVersion = promptVersion,
+                Schema = input.Schema,
+                Data = input.Data,
+                Attachments = input.Attachments,
+                PromptVersion = input.PromptVersion,
             }, cancellationToken);
 
             var analysisJson = JsonSerializer.Serialize(analysis, AIJsonDefaults.Indented);
+            var application = await applicationRepository.GetAsync(input.ApplicationId);
             application.AIAnalysis = analysisJson;
             await applicationRepository.UpdateAsync(application);
             return analysisJson;
-        }
-
-        private async Task<string?> GetFormSchemaAsync(Guid? formVersionId)
-        {
-            if (formVersionId == null)
-            {
-                return null;
-            }
-
-            try
-            {
-                var formVersion = await applicationFormVersionRepository.GetAsync(formVersionId.Value);
-                return string.IsNullOrWhiteSpace(formVersion?.FormSchema) ? null : formVersion.FormSchema;
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Unable to load form schema for prompt data generation for form version {FormVersionId}.", formVersionId);
-                return null;
-            }
         }
 
     }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
@@ -128,6 +128,15 @@ namespace Unity.AI.Operations
 
         private static JsonElement BuildBatchSectionSchema(IReadOnlyCollection<ApplicationScoringSectionOperationInputDto> sections)
         {
+            foreach (var section in sections)
+            {
+                if (section.SectionSchema.ValueKind != JsonValueKind.Array)
+                {
+                    throw new InvalidOperationException(
+                        $"Section schema for '{section.SectionName}' must be a JSON array.");
+                }
+            }
+
             var questions = new List<JsonElement>();
             foreach (var section in sections)
             {

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
@@ -5,63 +5,31 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Unity.Flex.Domain.Scoresheets;
+using Unity.AI;
 using Unity.AI.Models;
-using Unity.AI.Prompts;
 using Unity.AI.Requests;
 using Unity.AI.Runtime;
-using Unity.AI.Localization;
 using Unity.GrantManager.Applications;
-using Volo.Abp;
 using Volo.Abp.DependencyInjection;
-using Microsoft.Extensions.Localization;
 
 namespace Unity.AI.Operations
 {
     public class ApplicationScoringService(
         IApplicationRepository applicationRepository,
-        IApplicationFormRepository applicationFormRepository,
-        IApplicationFormSubmissionRepository applicationFormSubmissionRepository,
-        IApplicationFormVersionRepository applicationFormVersionRepository,
-        IApplicationChefsFileAttachmentRepository applicationChefsFileAttachmentRepository,
-        IScoresheetRepository scoresheetRepository,
         IAIService aiService,
         AIExecutionModeResolver executionModeResolver,
-        ILogger<ApplicationScoringService> logger,
-        IStringLocalizer<AIResource> localizer) : IApplicationScoringService, ITransientDependency
+        ILogger<ApplicationScoringService> logger) : IApplicationScoringService, ITransientDependency
     {
-        public async Task<string> RegenerateAndSaveAsync(Guid applicationId, string? promptVersion = null, CancellationToken cancellationToken = default)
+        public async Task<string> RegenerateAndSaveAsync(ApplicationScoringOperationInputDto input, CancellationToken cancellationToken = default)
         {
-            var application = await applicationRepository.GetAsync(applicationId);
-            var applicationForm = await applicationFormRepository.GetAsync(application.ApplicationFormId);
-            if (applicationForm.ScoresheetId == null)
-            {
-                throw new UserFriendlyException(localizer[AILocalizationKeys.ScoringRequiresScoresheet]);
-            }
-
-            var scoresheet = await scoresheetRepository.GetWithChildrenAsync(applicationForm.ScoresheetId.Value);
-            if (scoresheet == null || !scoresheet.Sections.Any() || !scoresheet.Sections.SelectMany(s => s.Fields).Any())
-            {
-                throw new UserFriendlyException(localizer[AILocalizationKeys.ScoringRequiresScoresheetFields]);
-            }
-
-            var attachments = await applicationChefsFileAttachmentRepository.GetListAsync(a => a.ApplicationId == applicationId);
-            var attachmentSummaries = PromptDataPayloadBuilder.BuildAttachmentSummaries(
-                attachments,
-                excludeWhitespaceOnlySummaries: false);
-
-            var formSubmission = await applicationFormSubmissionRepository.GetByApplicationAsync(applicationId);
-            var formSchema = await GetFormSchemaAsync(formSubmission?.ApplicationFormVersionId);
-            var promptData = PromptDataPayloadBuilder.BuildPromptDataPayload(application, formSubmission, formSchema, logger);
-
-            var sections = scoresheet.Sections.OrderBy(s => s.Order).ToList();
+            var sections = input.Sections;
             var mode = executionModeResolver.ResolveMode(AIExecutionModeResolver.ApplicationScoringOperation);
 
             var perSectionResults = await AIExecutionStrategy.RunAsync(
                 sections,
                 mode,
-                section => ProcessSectionAsync(applicationId, section, promptData, attachmentSummaries, promptVersion, cancellationToken),
-                batch => ProcessSectionsAsync(applicationId, batch, promptData, attachmentSummaries, promptVersion, cancellationToken));
+                section => ProcessSectionAsync(input.ApplicationId, section, input.Data, input.Attachments, input.PromptVersion, cancellationToken),
+                batch => ProcessSectionsAsync(input.ApplicationId, batch, input.Data, input.Attachments, input.PromptVersion, cancellationToken));
 
             var allSectionResults = new Dictionary<string, object>();
             foreach (var sectionResult in perSectionResults)
@@ -74,6 +42,7 @@ namespace Unity.AI.Operations
 
             var combinedResults = JsonSerializer.Serialize(allSectionResults, AIJsonDefaults.Indented);
             var validatedJson = ValidateApplicationScoringJson(combinedResults);
+            var application = await applicationRepository.GetAsync(input.ApplicationId);
             application.AIScoresheetAnswers = validatedJson;
             await applicationRepository.UpdateAsync(application);
             return validatedJson;
@@ -81,7 +50,7 @@ namespace Unity.AI.Operations
 
         private async Task<Dictionary<string, object>> ProcessSectionAsync(
             Guid applicationId,
-            ScoresheetSection section,
+            ApplicationScoringSectionOperationInputDto section,
             JsonElement promptData,
             List<AIAttachmentItem> attachmentSummaries,
             string? promptVersion,
@@ -94,8 +63,8 @@ namespace Unity.AI.Operations
                 {
                     Data = promptData,
                     Attachments = attachmentSummaries,
-                    SectionName = section.Name,
-                    SectionSchema = JsonSerializer.SerializeToElement(BuildSectionQuestionsData(section), AIJsonDefaults.IndentedCamelCase),
+                    SectionName = section.SectionName,
+                    SectionSchema = section.SectionSchema,
                     PromptVersion = promptVersion,
                 };
                 var applicationScoringResponse = await aiService.GenerateApplicationScoringAsync(applicationScoringRequest, cancellationToken);
@@ -111,14 +80,15 @@ namespace Unity.AI.Operations
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Error processing AI application scoring section {SectionName} for application {ApplicationId}", section.Name, applicationId);
+                logger.LogError(ex, "Error processing AI application scoring section {SectionName} for application {ApplicationId}", section.SectionName, applicationId);
             }
+
             return sectionResults;
         }
 
         private async Task<List<Dictionary<string, object>>> ProcessSectionsAsync(
             Guid applicationId,
-            IReadOnlyCollection<ScoresheetSection> sections,
+            IReadOnlyCollection<ApplicationScoringSectionOperationInputDto> sections,
             JsonElement promptData,
             List<AIAttachmentItem> attachmentSummaries,
             string? promptVersion,
@@ -127,17 +97,14 @@ namespace Unity.AI.Operations
             var sectionResults = new Dictionary<string, object>();
             try
             {
-                var questions = sections
-                    .OrderBy(s => s.Order)
-                    .SelectMany(BuildSectionQuestionsData)
-                    .ToList();
+                var questions = BuildBatchSectionSchema(sections);
 
                 var applicationScoringRequest = new ApplicationScoringRequest
                 {
                     Data = promptData,
                     Attachments = attachmentSummaries,
                     SectionName = "All Sections",
-                    SectionSchema = JsonSerializer.SerializeToElement(questions, AIJsonDefaults.IndentedCamelCase),
+                    SectionSchema = questions,
                     PromptVersion = promptVersion,
                 };
                 var applicationScoringResponse = await aiService.GenerateApplicationScoringAsync(applicationScoringRequest, cancellationToken);
@@ -159,25 +126,18 @@ namespace Unity.AI.Operations
             return [sectionResults];
         }
 
-        private static List<object> BuildSectionQuestionsData(ScoresheetSection section)
+        private static JsonElement BuildBatchSectionSchema(IReadOnlyCollection<ApplicationScoringSectionOperationInputDto> sections)
         {
-            var sectionQuestionsData = new List<object>();
-            foreach (var field in section.Fields.OrderBy(f => f.Order))
+            var questions = new List<JsonElement>();
+            foreach (var section in sections)
             {
-                var options = ExtractSelectListOptions(field);
-                sectionQuestionsData.Add(new
+                foreach (var question in section.SectionSchema.EnumerateArray())
                 {
-                    id = field.Id.ToString(),
-                    section = section.Name,
-                    question = field.Label,
-                    description = field.Description,
-                    type = field.Type.ToString(),
-                    options,
-                    allowed_answers = ExtractSelectListOptionNumbers(options)
-                });
+                    questions.Add(question.Clone());
+                }
             }
 
-            return sectionQuestionsData;
+            return JsonSerializer.SerializeToElement(questions, AIJsonDefaults.IndentedCamelCase);
         }
 
         private void CopyAnswers(Dictionary<string, ApplicationScoringAnswer> answers, Dictionary<string, object> results)
@@ -187,25 +147,6 @@ namespace Unity.AI.Operations
             foreach (var property in answersDoc.RootElement.EnumerateObject())
             {
                 results[property.Name] = property.Value.Clone();
-            }
-        }
-
-        private async Task<string?> GetFormSchemaAsync(Guid? formVersionId)
-        {
-            if (formVersionId == null)
-            {
-                return null;
-            }
-
-            try
-            {
-                var formVersion = await applicationFormVersionRepository.GetAsync(formVersionId.Value);
-                return string.IsNullOrWhiteSpace(formVersion?.FormSchema) ? null : formVersion.FormSchema;
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Unable to load form schema for application scoring prompt data generation for form version {FormVersionId}.", formVersionId);
-                return null;
             }
         }
 
@@ -225,46 +166,6 @@ namespace Unity.AI.Operations
             }
 
             return "{}";
-        }
-
-        private static object[]? ExtractSelectListOptions(Question field)
-        {
-            if (field.Type != Unity.Flex.Scoresheets.Enums.QuestionType.SelectList || string.IsNullOrEmpty(field.Definition))
-                return null;
-
-            try
-            {
-                var definition = JsonSerializer.Deserialize<Unity.Flex.Worksheets.Definitions.QuestionSelectListDefinition>(field.Definition);
-                if (definition?.Options != null && definition.Options.Count > 0)
-                {
-                    return definition.Options
-                        .Select((option, index) =>
-                            (object)new
-                            {
-                                number = index + 1,
-                                value = option.Value
-                            })
-                        .ToArray();
-                }
-            }
-            catch (JsonException)
-            {
-                // Ignore malformed definition and return null options.
-            }
-
-            return null;
-        }
-
-        private static string[]? ExtractSelectListOptionNumbers(object[]? options)
-        {
-            if (options == null || options.Length == 0)
-            {
-                return null;
-            }
-
-            return options
-                .Select((_, index) => (index + 1).ToString())
-                .ToArray();
         }
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/IApplicationAnalysisService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/IApplicationAnalysisService.cs
@@ -6,6 +6,6 @@ namespace Unity.AI.Operations
 {
     public interface IApplicationAnalysisService
     {
-        Task<string> RegenerateAndSaveAsync(Guid applicationId, string? promptVersion = null, CancellationToken cancellationToken = default);
+        Task<string> RegenerateAndSaveAsync(ApplicationAnalysisOperationInputDto input, CancellationToken cancellationToken = default);
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/IApplicationScoringService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/IApplicationScoringService.cs
@@ -6,6 +6,6 @@ namespace Unity.AI.Operations
 {
     public interface IApplicationScoringService
     {
-        Task<string> RegenerateAndSaveAsync(Guid applicationId, string? promptVersion = null, CancellationToken cancellationToken = default);
+        Task<string> RegenerateAndSaveAsync(ApplicationScoringOperationInputDto input, CancellationToken cancellationToken = default);
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Prompts/PromptDataPayloadBuilder.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Prompts/PromptDataPayloadBuilder.cs
@@ -91,25 +91,18 @@ namespace Unity.AI.Prompts
                 .ToList();
         }
 
-        public static async Task<object> BuildFormFieldConfigurationAsync(
-            IApplicationFormVersionRepository applicationFormVersionRepository,
-            Guid? formVersionId,
+        public static object BuildFormFieldConfigurationAsync(
+            string? formSchema,
             ILogger logger)
         {
-            if (formVersionId == null)
+            if (string.IsNullOrWhiteSpace(formSchema))
             {
                 return new { message = "Form configuration not available." };
             }
 
             try
             {
-                var formVersion = await applicationFormVersionRepository.GetAsync(formVersionId.Value);
-                if (formVersion == null || string.IsNullOrWhiteSpace(formVersion.FormSchema))
-                {
-                    return new { message = "Form configuration not available." };
-                }
-
-                var schema = JObject.Parse(formVersion.FormSchema);
+                var schema = JObject.Parse(formSchema);
                 var components = schema[ComponentsKey] as JArray;
                 if (components == null || components.Count == 0)
                 {
@@ -128,7 +121,7 @@ namespace Unity.AI.Prompts
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Error extracting form field configuration for form version {FormVersionId}", formVersionId);
+                logger.LogError(ex, "Error extracting form field configuration from form schema.");
                 return new { message = "Form configuration could not be extracted." };
             }
         }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationAnalysisAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationAnalysisAppService.cs
@@ -1,12 +1,18 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Logging;
 using System;
+using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Unity.AI;
 using Unity.AI.Automation;
 using Unity.AI.Features;
 using Unity.AI.Localization;
+using Unity.AI.Models;
+using Unity.AI.Prompts;
 using Unity.AI.Permissions;
 using Unity.AI.Settings;
+using Unity.GrantManager.Applications;
 using Volo.Abp;
 using Volo.Abp.MultiTenancy;
 
@@ -16,8 +22,13 @@ namespace Unity.GrantManager.GrantApplications;
 public class ApplicationAnalysisAppService(
     Unity.AI.Operations.IApplicationAnalysisService applicationAnalysisService,
     IApplicationAIGenerationQueue aiGenerationQueue,
+    IApplicationRepository applicationRepository,
+    IApplicationFormSubmissionRepository applicationFormSubmissionRepository,
+    IApplicationFormVersionRepository applicationFormVersionRepository,
+    IApplicationChefsFileAttachmentRepository applicationChefsFileAttachmentRepository,
     AIFeatureGuard featureGuard,
-    ICurrentTenant currentTenant)
+    ICurrentTenant currentTenant,
+    ILogger<ApplicationAnalysisAppService> logger)
     : AIAppService, IApplicationAnalysisAppService
 {
     public virtual async Task<ApplicationAnalysisResultDto> GenerateApplicationAnalysisAsync(Guid applicationId, string? promptVersion = null)
@@ -35,7 +46,50 @@ public class ApplicationAnalysisAppService(
     [RemoteService(IsEnabled = false)]
     public virtual async Task<ApplicationAnalysisResultDto> GenerateApplicationAnalysisForPipelineAsync(Guid applicationId, string? promptVersion = null)
     {
-        await applicationAnalysisService.RegenerateAndSaveAsync(applicationId, promptVersion);
+        var input = await BuildInputAsync(applicationId, promptVersion);
+        await applicationAnalysisService.RegenerateAndSaveAsync(input);
         return new ApplicationAnalysisResultDto { Completed = true };
+    }
+
+    private async Task<Unity.AI.Operations.ApplicationAnalysisOperationInputDto> BuildInputAsync(Guid applicationId, string? promptVersion)
+    {
+        var application = await applicationRepository.GetAsync(applicationId);
+        var formSubmission = await applicationFormSubmissionRepository.GetByApplicationAsync(applicationId);
+        var attachments = await applicationChefsFileAttachmentRepository.GetListAsync(a => a.ApplicationId == applicationId);
+        var formSchema = await GetFormSchemaAsync(formSubmission?.ApplicationFormVersionId);
+
+        var attachmentSummaries = PromptDataPayloadBuilder.BuildAttachmentSummaries(attachments);
+        var formFieldConfiguration = await PromptDataPayloadBuilder.BuildFormFieldConfigurationAsync(
+            applicationFormVersionRepository,
+            formSubmission?.ApplicationFormVersionId,
+            logger);
+
+        return new Unity.AI.Operations.ApplicationAnalysisOperationInputDto
+        {
+            ApplicationId = applicationId,
+            Schema = JsonSerializer.SerializeToElement(formFieldConfiguration),
+            Data = PromptDataPayloadBuilder.BuildPromptDataPayload(application, formSubmission, formSchema, logger),
+            Attachments = attachmentSummaries,
+            PromptVersion = promptVersion
+        };
+    }
+
+    private async Task<string?> GetFormSchemaAsync(Guid? formVersionId)
+    {
+        if (formVersionId == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var formVersion = await applicationFormVersionRepository.GetAsync(formVersionId.Value);
+            return string.IsNullOrWhiteSpace(formVersion?.FormSchema) ? null : formVersion.FormSchema;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Unable to load form schema for prompt data generation for form version {FormVersionId}.", formVersionId);
+            return null;
+        }
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationAnalysisAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationAnalysisAppService.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Unity.AI;
@@ -59,9 +58,8 @@ public class ApplicationAnalysisAppService(
         var formSchema = await GetFormSchemaAsync(formSubmission?.ApplicationFormVersionId);
 
         var attachmentSummaries = PromptDataPayloadBuilder.BuildAttachmentSummaries(attachments);
-        var formFieldConfiguration = await PromptDataPayloadBuilder.BuildFormFieldConfigurationAsync(
-            applicationFormVersionRepository,
-            formSubmission?.ApplicationFormVersionId,
+        var formFieldConfiguration = PromptDataPayloadBuilder.BuildFormFieldConfigurationAsync(
+            formSchema,
             logger);
 
         return new Unity.AI.Operations.ApplicationAnalysisOperationInputDto

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationScoringAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationScoringAppService.cs
@@ -1,13 +1,19 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Localization;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Unity.AI;
-using Unity.AI.Features;
 using Unity.AI.Localization;
 using Unity.AI.Operations;
+using Unity.AI.Prompts;
 using Unity.AI.Permissions;
 using Unity.AI.Settings;
-using Unity.GrantManager.GrantApplications.Automation.Events;
+using Unity.Flex.Domain.Scoresheets;
+using Unity.GrantManager.Applications;
 using Volo.Abp;
 using Volo.Abp.EventBus.Local;
 
@@ -16,8 +22,16 @@ namespace Unity.GrantManager.GrantApplications;
 [Authorize(AIPermissions.Analysis.GenerateScoring)]
 public class ApplicationScoringAppService(
     IApplicationScoringService applicationScoringService,
+    IApplicationRepository applicationRepository,
+    IApplicationFormRepository applicationFormRepository,
+    IApplicationFormSubmissionRepository applicationFormSubmissionRepository,
+    IApplicationFormVersionRepository applicationFormVersionRepository,
+    IApplicationChefsFileAttachmentRepository applicationChefsFileAttachmentRepository,
+    IScoresheetRepository scoresheetRepository,
     AIFeatureGuard featureGuard,
-    ILocalEventBus localEventBus)
+    ILocalEventBus localEventBus,
+    ILogger<ApplicationScoringAppService> logger,
+    IStringLocalizer<AIResource> localizer)
     : AIAppService, IApplicationScoringAppService
 {
     public virtual async Task<ApplicationScoringResultDto> GenerateApplicationScoringAsync(Guid applicationId, string? promptVersion = null)
@@ -26,7 +40,8 @@ public class ApplicationScoringAppService(
             AIFeatures.Scoring,
             AILocalizationKeys.ScoringDisabled);
 
-        await applicationScoringService.RegenerateAndSaveAsync(applicationId, promptVersion);
+        var input = await BuildInputAsync(applicationId, promptVersion);
+        await applicationScoringService.RegenerateAndSaveAsync(input);
 
         if (UnitOfWorkManager.Current != null)
         {
@@ -58,7 +73,133 @@ public class ApplicationScoringAppService(
     [RemoteService(IsEnabled = false)]
     public virtual async Task<ApplicationScoringResultDto> GenerateApplicationScoringForPipelineAsync(Guid applicationId, string? promptVersion = null)
     {
-        await applicationScoringService.RegenerateAndSaveAsync(applicationId, promptVersion);
+        var input = await BuildInputAsync(applicationId, promptVersion);
+        await applicationScoringService.RegenerateAndSaveAsync(input);
         return new ApplicationScoringResultDto { Completed = true };
+    }
+
+    private async Task<ApplicationScoringOperationInputDto> BuildInputAsync(Guid applicationId, string? promptVersion)
+    {
+        var application = await applicationRepository.GetAsync(applicationId);
+        var applicationForm = await applicationFormRepository.GetAsync(application.ApplicationFormId);
+        if (applicationForm.ScoresheetId == null)
+        {
+            throw new UserFriendlyException(localizer[AILocalizationKeys.ScoringRequiresScoresheet]);
+        }
+
+        var scoresheet = await scoresheetRepository.GetWithChildrenAsync(applicationForm.ScoresheetId.Value);
+        if (scoresheet == null || !scoresheet.Sections.Any() || !scoresheet.Sections.SelectMany(s => s.Fields).Any())
+        {
+            throw new UserFriendlyException(localizer[AILocalizationKeys.ScoringRequiresScoresheetFields]);
+        }
+
+        var attachments = await applicationChefsFileAttachmentRepository.GetListAsync(a => a.ApplicationId == applicationId);
+        var attachmentSummaries = PromptDataPayloadBuilder.BuildAttachmentSummaries(
+            attachments,
+            excludeWhitespaceOnlySummaries: false);
+
+        var formSubmission = await applicationFormSubmissionRepository.GetByApplicationAsync(applicationId);
+        var formSchema = await GetFormSchemaAsync(formSubmission?.ApplicationFormVersionId);
+        var promptData = PromptDataPayloadBuilder.BuildPromptDataPayload(application, formSubmission, formSchema, logger);
+
+        var sections = scoresheet.Sections
+            .OrderBy(s => s.Order)
+            .Select(section => new ApplicationScoringSectionOperationInputDto
+            {
+                SectionName = section.Name,
+                SectionSchema = JsonSerializer.SerializeToElement(BuildSectionQuestionsData(section), AIJsonDefaults.IndentedCamelCase)
+            })
+            .ToList();
+
+        return new ApplicationScoringOperationInputDto
+        {
+            ApplicationId = applicationId,
+            Data = promptData,
+            Attachments = attachmentSummaries,
+            Sections = sections,
+            PromptVersion = promptVersion
+        };
+    }
+
+    private async Task<string?> GetFormSchemaAsync(Guid? formVersionId)
+    {
+        if (formVersionId == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var formVersion = await applicationFormVersionRepository.GetAsync(formVersionId.Value);
+            return string.IsNullOrWhiteSpace(formVersion?.FormSchema) ? null : formVersion.FormSchema;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Unable to load form schema for application scoring prompt data generation for form version {FormVersionId}.", formVersionId);
+            return null;
+        }
+    }
+
+    private static List<object> BuildSectionQuestionsData(ScoresheetSection section)
+    {
+        var sectionQuestionsData = new List<object>();
+        foreach (var field in section.Fields.OrderBy(f => f.Order))
+        {
+            var options = ExtractSelectListOptions(field);
+            sectionQuestionsData.Add(new
+            {
+                id = field.Id.ToString(),
+                section = section.Name,
+                question = field.Label,
+                description = field.Description,
+                type = field.Type.ToString(),
+                options,
+                allowed_answers = ExtractSelectListOptionNumbers(options)
+            });
+        }
+
+        return sectionQuestionsData;
+    }
+
+    private static object[]? ExtractSelectListOptions(Question field)
+    {
+        if (field.Type != Unity.Flex.Scoresheets.Enums.QuestionType.SelectList || string.IsNullOrEmpty(field.Definition))
+        {
+            return null;
+        }
+
+        try
+        {
+            var definition = JsonSerializer.Deserialize<Unity.Flex.Worksheets.Definitions.QuestionSelectListDefinition>(field.Definition);
+            if (definition?.Options != null && definition.Options.Count > 0)
+            {
+                return definition.Options
+                    .Select((option, index) =>
+                        (object)new
+                        {
+                            number = index + 1,
+                            value = option.Value
+                        })
+                    .ToArray();
+            }
+        }
+        catch (JsonException)
+        {
+            // Ignore malformed definition and return null options.
+        }
+
+        return null;
+    }
+
+    private static string[]? ExtractSelectListOptionNumbers(object[]? options)
+    {
+        if (options == null || options.Length == 0)
+        {
+            return null;
+        }
+
+        return options
+            .Select((_, index) => (index + 1).ToString())
+            .ToArray();
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationScoringAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationScoringAppService.cs
@@ -7,13 +7,16 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Unity.AI;
+using Unity.AI.Features;
 using Unity.AI.Localization;
 using Unity.AI.Operations;
 using Unity.AI.Prompts;
+using Unity.AI.Runtime;
 using Unity.AI.Permissions;
 using Unity.AI.Settings;
 using Unity.Flex.Domain.Scoresheets;
 using Unity.GrantManager.Applications;
+using Unity.GrantManager.GrantApplications.Automation.Events;
 using Volo.Abp;
 using Volo.Abp.EventBus.Local;
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationAnalysisJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationAnalysisJob.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
-using Unity.AI.Operations;
 using Unity.AI.RateLimit;
 using Unity.GrantManager.GrantApplications;
 using Volo.Abp.BackgroundJobs;
@@ -13,7 +12,7 @@ using Volo.Abp.Uow;
 namespace Unity.GrantManager.GrantApplications.Automation.BackgroundJobs;
 
 public class GenerateApplicationAnalysisJob(
-    IApplicationAnalysisService applicationAnalysisService,
+    IApplicationAnalysisAppService applicationAnalysisAppService,
     IRepository<AIGenerationRequest, Guid> generationRequestRepository,
     ICurrentTenant currentTenant,
     IUnitOfWorkManager unitOfWorkManager,
@@ -28,8 +27,11 @@ public class GenerateApplicationAnalysisJob(
             try
             {
                 logger.LogInformation("Executing AI application analysis job for application {ApplicationId}.", args.ApplicationId);
-                await applicationAnalysisService.RegenerateAndSaveAsync(args.ApplicationId, args.PromptVersion);
-                logger.LogInformation("Completed AI application analysis job for application {ApplicationId}.", args.ApplicationId);
+                var result = await applicationAnalysisAppService.GenerateApplicationAnalysisForPipelineAsync(args.ApplicationId, args.PromptVersion);
+                if (result.Completed)
+                {
+                    logger.LogInformation("Completed AI application analysis job for application {ApplicationId}.", args.ApplicationId);
+                }
 
                 await AIGenerationRequestJobHelper.StampRateLimitBestEffortAsync(aiRateLimiter, logger, args.RequestedByUserId, args.ApplicationId, args.RequestKey);
                 await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/ApplicationAnalysisServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/ApplicationAnalysisServiceTests.cs
@@ -3,10 +3,10 @@ using NSubstitute;
 using Shouldly;
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Unity.AI;
+using Unity.AI.Models;
 using Unity.AI.Operations;
 using Unity.AI.Requests;
 using Unity.AI.Responses;
@@ -24,90 +24,41 @@ public class ApplicationAnalysisServiceTests : GrantManagerApplicationTestBase
     }
 
     [Fact]
-    public async Task RegenerateAndSaveAsync_Builds_Filtered_Prompt_Payload_From_Form_Submission()
+    public async Task RegenerateAndSaveAsync_Uses_Input_Dto_And_Persists_Analysis()
     {
         var applicationId = Guid.NewGuid();
-        var formVersionId = Guid.NewGuid();
+        var application = WithId(new Application(), applicationId);
         ApplicationAnalysisRequest? capturedRequest = null;
-        var application = WithId(new Application
-        {
-            ApplicationFormId = Guid.NewGuid(),
-            ProjectName = "Fallback project",
-            ReferenceNo = "REF-001",
-            RequestedAmount = 100,
-            TotalProjectBudget = 200,
-            SubmissionDate = new DateTime(2026, 1, 2)
-        }, applicationId);
-        var submission = new ApplicationFormSubmission
-        {
-            ApplicationId = applicationId,
-            ApplicationFormVersionId = formVersionId,
-            Submission = """
-            {
-              "data": {
-                "projectName": "Submitted project",
-                "requestedAmount": 12345,
-                "metadata": { "timezone": "utc" },
-                "files": [{ "name": "large.pdf" }],
-                "ignoredField": "not in schema"
-              }
-            }
-            """
-        };
-        var formVersion = new ApplicationFormVersion
-        {
-            FormSchema = """
-            {
-              "components": [
-                { "key": "projectName", "label": "Project Name", "type": "textfield", "input": true, "validate": { "required": true } },
-                { "key": "requestedAmount", "label": "Requested Amount", "type": "number", "input": true },
-                { "key": "applicantAgent", "label": "Applicant Agent", "type": "textfield", "input": true },
-                { "key": "ignoredField", "label": "Ignored Field", "type": "html", "input": false }
-              ]
-            }
-            """
-        };
 
         var applicationRepository = Substitute.For<IApplicationRepository>();
         applicationRepository.GetAsync(applicationId).Returns(application);
 
-        var submissionRepository = Substitute.For<IApplicationFormSubmissionRepository>();
-        submissionRepository.GetByApplicationAsync(applicationId).Returns(submission);
-
-        var formVersionRepository = Substitute.For<IApplicationFormVersionRepository>();
-        formVersionRepository.GetAsync(formVersionId).Returns(formVersion);
-
-        var attachmentRepository = Substitute.For<IApplicationChefsFileAttachmentRepository>();
-        attachmentRepository
-            .GetListAsync(Arg.Any<Expression<Func<ApplicationChefsFileAttachment, bool>>>())
-            .Returns([
-                new ApplicationChefsFileAttachment
-                {
-                    FileName = " summary.pdf ",
-                    AISummary = " Summary text "
-                },
-                new ApplicationChefsFileAttachment
-                {
-                    FileName = "empty.txt",
-                    AISummary = " "
-                }
-            ]);
-
         var aiService = Substitute.For<IAIService>();
         aiService.GenerateApplicationAnalysisAsync(Arg.Do<ApplicationAnalysisRequest>(request => capturedRequest = request))
             .Returns(new ApplicationAnalysisResponse { Decision = "ok" });
+
         var prerequisiteValidator = Substitute.For<IAIGenerationPrerequisiteValidator>();
 
         var service = new ApplicationAnalysisService(
             applicationRepository,
-            submissionRepository,
-            formVersionRepository,
-            attachmentRepository,
             aiService,
-            prerequisiteValidator,
-            NullLogger<ApplicationAnalysisService>.Instance);
+            prerequisiteValidator);
 
-        var result = await service.RegenerateAndSaveAsync(applicationId, "v1");
+        var result = await service.RegenerateAndSaveAsync(new ApplicationAnalysisOperationInputDto
+        {
+            ApplicationId = applicationId,
+            Schema = JsonSerializer.SerializeToElement(new { projectName = "Project Name" }),
+            Data = JsonSerializer.SerializeToElement(new { projectName = "Submitted project" }),
+            Attachments = new List<AIAttachmentItem>
+            {
+                new()
+                {
+                    Name = "summary.pdf",
+                    Summary = "Summary text"
+                }
+            },
+            PromptVersion = "v1"
+        });
 
         result.ShouldContain("\"Decision\": \"ok\"");
         capturedRequest.ShouldNotBeNull();
@@ -115,68 +66,47 @@ public class ApplicationAnalysisServiceTests : GrantManagerApplicationTestBase
         capturedRequest.Attachments.Count.ShouldBe(1);
         capturedRequest.Attachments[0].Name.ShouldBe("summary.pdf");
         capturedRequest.Attachments[0].Summary.ShouldBe("Summary text");
-
         capturedRequest.Data.GetProperty("projectName").GetString().ShouldBe("Submitted project");
-        capturedRequest.Data.GetProperty("requestedAmount").GetInt32().ShouldBe(12345);
-        capturedRequest.Data.TryGetProperty("metadata", out _).ShouldBeFalse();
-        capturedRequest.Data.TryGetProperty("files", out _).ShouldBeFalse();
-        capturedRequest.Data.TryGetProperty("ignoredField", out _).ShouldBeFalse();
+        capturedRequest.Schema.GetProperty("projectName").GetString().ShouldBe("Project Name");
 
-        var schemaJson = JsonSerializer.Serialize(capturedRequest.Schema);
-        schemaJson.ShouldContain("Project Name (projectName)");
-        schemaJson.ShouldContain("Requested Amount (requestedAmount)");
-        schemaJson.ShouldNotContain("Applicant Agent (applicantAgent)");
+        await prerequisiteValidator.Received(1).EnsureApplicationAnalysisAvailableAsync(applicationId);
         await applicationRepository.Received(1).UpdateAsync(application);
     }
 
     [Fact]
-    public async Task RegenerateAndSaveAsync_Falls_Back_To_Application_Data_When_Submission_Is_Missing()
+    public async Task RegenerateAndSaveAsync_Flows_Without_Repository_Loading_Inputs()
     {
         var applicationId = Guid.NewGuid();
-        var application = WithId(new Application
-        {
-            ProjectName = "Fallback project",
-            ReferenceNo = "REF-002",
-            RequestedAmount = 1500,
-            TotalProjectBudget = 3000,
-            ProjectSummary = "Fallback summary",
-            SubmissionDate = new DateTime(2026, 2, 3)
-        }, applicationId);
+        var application = WithId(new Application(), applicationId);
         ApplicationAnalysisRequest? capturedRequest = null;
 
         var applicationRepository = Substitute.For<IApplicationRepository>();
         applicationRepository.GetAsync(applicationId).Returns(application);
 
-        var submissionRepository = Substitute.For<IApplicationFormSubmissionRepository>();
-        submissionRepository.GetByApplicationAsync(applicationId).Returns((ApplicationFormSubmission?)null);
-
-        var formVersionRepository = Substitute.For<IApplicationFormVersionRepository>();
-        var attachmentRepository = Substitute.For<IApplicationChefsFileAttachmentRepository>();
-        attachmentRepository
-            .GetListAsync(Arg.Any<Expression<Func<ApplicationChefsFileAttachment, bool>>>())
-            .Returns([]);
-
         var aiService = Substitute.For<IAIService>();
         aiService.GenerateApplicationAnalysisAsync(Arg.Do<ApplicationAnalysisRequest>(request => capturedRequest = request))
             .Returns(new ApplicationAnalysisResponse());
+
         var prerequisiteValidator = Substitute.For<IAIGenerationPrerequisiteValidator>();
 
         var service = new ApplicationAnalysisService(
             applicationRepository,
-            submissionRepository,
-            formVersionRepository,
-            attachmentRepository,
             aiService,
-            prerequisiteValidator,
-            NullLogger<ApplicationAnalysisService>.Instance);
+            prerequisiteValidator);
 
-        await service.RegenerateAndSaveAsync(applicationId);
+        await service.RegenerateAndSaveAsync(new ApplicationAnalysisOperationInputDto
+        {
+            ApplicationId = applicationId,
+            Schema = JsonSerializer.SerializeToElement(new { }),
+            Data = JsonSerializer.SerializeToElement(new { project_name = "Fallback project" }),
+            Attachments = [],
+            PromptVersion = null
+        });
 
         capturedRequest.ShouldNotBeNull();
         capturedRequest.Data.GetProperty("project_name").GetString().ShouldBe("Fallback project");
-        capturedRequest.Data.GetProperty("reference_number").GetString().ShouldBe("REF-002");
-        capturedRequest.Data.GetProperty("requested_amount").GetDecimal().ShouldBe(1500);
         capturedRequest.Attachments.ShouldBeEmpty();
+        capturedRequest.PromptVersion.ShouldBeNull();
     }
 
     private static T WithId<T>(T entity, Guid id) where T : Entity<Guid>

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/ApplicationAnalysisServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/ApplicationAnalysisServiceTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Shouldly;
 using System;


### PR DESCRIPTION
Summary
This PR introduces explicit DTO-based input contracts for AI analysis and scoring, moving repository loading and prompt shaping into GrantManager app-service adapters while keeping Unity.AI operation services focused on deterministic inputs and persisted outputs.

Validation
- `dotnet build applications\Unity.GrantManager\Unity.GrantManager.sln --no-restore`
- `dotnet test focused analysis-service tests`