### PR TITLE
AB#33401 separate AI execution from persistence adapters

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationAnalysisService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationAnalysisService.cs
@@ -5,17 +5,15 @@ using Unity.AI;
 using Unity.AI.Models;
 using Unity.AI.Requests;
 using Unity.AI.Runtime;
-using Unity.GrantManager.Applications;
 using Volo.Abp.DependencyInjection;
 
 namespace Unity.AI.Operations
 {
     public class ApplicationAnalysisService(
-        IApplicationRepository applicationRepository,
         IAIService aiService,
         IAIGenerationPrerequisiteValidator aiGenerationPrerequisiteValidator) : IApplicationAnalysisService, ITransientDependency
     {
-        public async Task<string> RegenerateAndSaveAsync(ApplicationAnalysisOperationInputDto input, CancellationToken cancellationToken = default)
+        public async Task<string> RegenerateAsync(ApplicationAnalysisOperationInputDto input, CancellationToken cancellationToken = default)
         {
             await aiGenerationPrerequisiteValidator.EnsureApplicationAnalysisAvailableAsync(input.ApplicationId);
 
@@ -28,9 +26,6 @@ namespace Unity.AI.Operations
             }, cancellationToken);
 
             var analysisJson = JsonSerializer.Serialize(analysis, AIJsonDefaults.Indented);
-            var application = await applicationRepository.GetAsync(input.ApplicationId);
-            application.AIAnalysis = analysisJson;
-            await applicationRepository.UpdateAsync(application);
             return analysisJson;
         }
 

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
@@ -9,18 +9,16 @@ using Unity.AI;
 using Unity.AI.Models;
 using Unity.AI.Requests;
 using Unity.AI.Runtime;
-using Unity.GrantManager.Applications;
 using Volo.Abp.DependencyInjection;
 
 namespace Unity.AI.Operations
 {
     public class ApplicationScoringService(
-        IApplicationRepository applicationRepository,
         IAIService aiService,
         AIExecutionModeResolver executionModeResolver,
         ILogger<ApplicationScoringService> logger) : IApplicationScoringService, ITransientDependency
     {
-        public async Task<string> RegenerateAndSaveAsync(ApplicationScoringOperationInputDto input, CancellationToken cancellationToken = default)
+        public async Task<string> RegenerateAsync(ApplicationScoringOperationInputDto input, CancellationToken cancellationToken = default)
         {
             var sections = input.Sections;
             var mode = executionModeResolver.ResolveMode(AIExecutionModeResolver.ApplicationScoringOperation);
@@ -42,9 +40,6 @@ namespace Unity.AI.Operations
 
             var combinedResults = JsonSerializer.Serialize(allSectionResults, AIJsonDefaults.Indented);
             var validatedJson = ValidateApplicationScoringJson(combinedResults);
-            var application = await applicationRepository.GetAsync(input.ApplicationId);
-            application.AIScoresheetAnswers = validatedJson;
-            await applicationRepository.UpdateAsync(application);
             return validatedJson;
         }
 

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/ApplicationScoringService.cs
@@ -135,6 +135,12 @@ namespace Unity.AI.Operations
             var questions = new List<JsonElement>();
             foreach (var section in sections)
             {
+                if (section.SectionSchema.ValueKind != JsonValueKind.Array)
+                {
+                    throw new InvalidOperationException(
+                        $"Section schema for '{section.SectionName}' must be a JSON array.");
+                }
+
                 foreach (var question in section.SectionSchema.EnumerateArray())
                 {
                     questions.Add(question.Clone());

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/IApplicationAnalysisService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/IApplicationAnalysisService.cs
@@ -6,6 +6,6 @@ namespace Unity.AI.Operations
 {
     public interface IApplicationAnalysisService
     {
-        Task<string> RegenerateAndSaveAsync(ApplicationAnalysisOperationInputDto input, CancellationToken cancellationToken = default);
+        Task<string> RegenerateAsync(ApplicationAnalysisOperationInputDto input, CancellationToken cancellationToken = default);
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/IApplicationScoringService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Operations/IApplicationScoringService.cs
@@ -6,6 +6,6 @@ namespace Unity.AI.Operations
 {
     public interface IApplicationScoringService
     {
-        Task<string> RegenerateAndSaveAsync(ApplicationScoringOperationInputDto input, CancellationToken cancellationToken = default);
+        Task<string> RegenerateAsync(ApplicationScoringOperationInputDto input, CancellationToken cancellationToken = default);
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Prompts/PromptDataPayloadBuilder.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Prompts/PromptDataPayloadBuilder.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
-using System.Threading.Tasks;
 using Unity.AI.Models;
 using Unity.GrantManager.Applications;
 
@@ -91,7 +90,7 @@ namespace Unity.AI.Prompts
                 .ToList();
         }
 
-        public static object BuildFormFieldConfigurationAsync(
+        public static object BuildFormFieldConfiguration(
             string? formSchema,
             ILogger logger)
         {

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationAnalysisAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationAnalysisAppService.cs
@@ -61,7 +61,7 @@ public class ApplicationAnalysisAppService(
         var formSchema = await GetFormSchemaAsync(formSubmission?.ApplicationFormVersionId);
 
         var attachmentSummaries = PromptDataPayloadBuilder.BuildAttachmentSummaries(attachments);
-        var formFieldConfiguration = PromptDataPayloadBuilder.BuildFormFieldConfigurationAsync(
+        var formFieldConfiguration = PromptDataPayloadBuilder.BuildFormFieldConfiguration(
             formSchema,
             logger);
 

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationAnalysisAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationAnalysisAppService.cs
@@ -46,7 +46,10 @@ public class ApplicationAnalysisAppService(
     public virtual async Task<ApplicationAnalysisResultDto> GenerateApplicationAnalysisForPipelineAsync(Guid applicationId, string? promptVersion = null)
     {
         var input = await BuildInputAsync(applicationId, promptVersion);
-        await applicationAnalysisService.RegenerateAndSaveAsync(input);
+        var analysisJson = await applicationAnalysisService.RegenerateAsync(input);
+        var application = await applicationRepository.GetAsync(applicationId);
+        application.AIAnalysis = analysisJson;
+        await applicationRepository.UpdateAsync(application);
         return new ApplicationAnalysisResultDto { Completed = true };
     }
 

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationScoringAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/GrantApplications/ApplicationScoringAppService.cs
@@ -44,7 +44,10 @@ public class ApplicationScoringAppService(
             AILocalizationKeys.ScoringDisabled);
 
         var input = await BuildInputAsync(applicationId, promptVersion);
-        await applicationScoringService.RegenerateAndSaveAsync(input);
+        var scoresheetAnswers = await applicationScoringService.RegenerateAsync(input);
+        var application = await applicationRepository.GetAsync(applicationId);
+        application.AIScoresheetAnswers = scoresheetAnswers;
+        await applicationRepository.UpdateAsync(application);
 
         if (UnitOfWorkManager.Current != null)
         {
@@ -77,7 +80,10 @@ public class ApplicationScoringAppService(
     public virtual async Task<ApplicationScoringResultDto> GenerateApplicationScoringForPipelineAsync(Guid applicationId, string? promptVersion = null)
     {
         var input = await BuildInputAsync(applicationId, promptVersion);
-        await applicationScoringService.RegenerateAndSaveAsync(input);
+        var scoresheetAnswers = await applicationScoringService.RegenerateAsync(input);
+        var application = await applicationRepository.GetAsync(applicationId);
+        application.AIScoresheetAnswers = scoresheetAnswers;
+        await applicationRepository.UpdateAsync(application);
         return new ApplicationScoringResultDto { Completed = true };
     }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationAnalysisJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationAnalysisJob.cs
@@ -36,11 +36,8 @@ public class GenerateApplicationAnalysisJob(
             try
             {
                 logger.LogInformation("Executing AI application analysis job for application {ApplicationId}.", args.ApplicationId);
-                var result = await applicationAnalysisAppService.GenerateApplicationAnalysisForPipelineAsync(args.ApplicationId, args.PromptVersion);
-                if (result.Completed)
-                {
-                    logger.LogInformation("Completed AI application analysis job for application {ApplicationId}.", args.ApplicationId);
-                }
+                await applicationAnalysisAppService.GenerateApplicationAnalysisForPipelineAsync(args.ApplicationId, args.PromptVersion);
+                logger.LogInformation("Completed AI application analysis job for application {ApplicationId}.", args.ApplicationId);
 
                 await AIGenerationRequestJobHelper.StampRateLimitBestEffortAsync(aiRateLimiter, logger, args.RequestedByUserId, args.ApplicationId, args.RequestKey);
                 await AIGenerationRequestJobHelper.MarkCompletedInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/ApplicationAnalysisServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Operations/ApplicationAnalysisServiceTests.cs
@@ -9,8 +9,6 @@ using Unity.AI.Models;
 using Unity.AI.Operations;
 using Unity.AI.Requests;
 using Unity.AI.Responses;
-using Unity.GrantManager.Applications;
-using Volo.Abp.Domain.Entities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -23,27 +21,21 @@ public class ApplicationAnalysisServiceTests : GrantManagerApplicationTestBase
     }
 
     [Fact]
-    public async Task RegenerateAndSaveAsync_Uses_Input_Dto_And_Persists_Analysis()
+    public async Task RegenerateAsync_Uses_Input_Dto_And_Returns_Serialized_Response()
     {
         var applicationId = Guid.NewGuid();
-        var application = WithId(new Application(), applicationId);
         ApplicationAnalysisRequest? capturedRequest = null;
-
-        var applicationRepository = Substitute.For<IApplicationRepository>();
-        applicationRepository.GetAsync(applicationId).Returns(application);
 
         var aiService = Substitute.For<IAIService>();
         aiService.GenerateApplicationAnalysisAsync(Arg.Do<ApplicationAnalysisRequest>(request => capturedRequest = request))
             .Returns(new ApplicationAnalysisResponse { Decision = "ok" });
-
         var prerequisiteValidator = Substitute.For<IAIGenerationPrerequisiteValidator>();
 
         var service = new ApplicationAnalysisService(
-            applicationRepository,
             aiService,
             prerequisiteValidator);
 
-        var result = await service.RegenerateAndSaveAsync(new ApplicationAnalysisOperationInputDto
+        var result = await service.RegenerateAsync(new ApplicationAnalysisOperationInputDto
         {
             ApplicationId = applicationId,
             Schema = JsonSerializer.SerializeToElement(new { projectName = "Project Name" }),
@@ -69,31 +61,25 @@ public class ApplicationAnalysisServiceTests : GrantManagerApplicationTestBase
         capturedRequest.Schema.GetProperty("projectName").GetString().ShouldBe("Project Name");
 
         await prerequisiteValidator.Received(1).EnsureApplicationAnalysisAvailableAsync(applicationId);
-        await applicationRepository.Received(1).UpdateAsync(application);
+        await aiService.Received(1).GenerateApplicationAnalysisAsync(Arg.Any<ApplicationAnalysisRequest>(), Arg.Any<System.Threading.CancellationToken>());
     }
 
     [Fact]
-    public async Task RegenerateAndSaveAsync_Flows_Without_Repository_Loading_Inputs()
+    public async Task RegenerateAsync_Flows_Api_Request_To_The_Runtime_Without_Repository_Dependencies()
     {
         var applicationId = Guid.NewGuid();
-        var application = WithId(new Application(), applicationId);
         ApplicationAnalysisRequest? capturedRequest = null;
-
-        var applicationRepository = Substitute.For<IApplicationRepository>();
-        applicationRepository.GetAsync(applicationId).Returns(application);
 
         var aiService = Substitute.For<IAIService>();
         aiService.GenerateApplicationAnalysisAsync(Arg.Do<ApplicationAnalysisRequest>(request => capturedRequest = request))
             .Returns(new ApplicationAnalysisResponse());
-
         var prerequisiteValidator = Substitute.For<IAIGenerationPrerequisiteValidator>();
 
         var service = new ApplicationAnalysisService(
-            applicationRepository,
             aiService,
             prerequisiteValidator);
 
-        await service.RegenerateAndSaveAsync(new ApplicationAnalysisOperationInputDto
+        await service.RegenerateAsync(new ApplicationAnalysisOperationInputDto
         {
             ApplicationId = applicationId,
             Schema = JsonSerializer.SerializeToElement(new { }),
@@ -106,13 +92,5 @@ public class ApplicationAnalysisServiceTests : GrantManagerApplicationTestBase
         capturedRequest.Data.GetProperty("project_name").GetString().ShouldBe("Fallback project");
         capturedRequest.Attachments.ShouldBeEmpty();
         capturedRequest.PromptVersion.ShouldBeNull();
-    }
-
-    private static T WithId<T>(T entity, Guid id) where T : Entity<Guid>
-    {
-        typeof(Entity<Guid>)
-            .GetProperty(nameof(Entity<Guid>.Id))!
-            .SetValue(entity, id);
-        return entity;
     }
 }


### PR DESCRIPTION
Summary
This PR separates AI execution from persistence for application analysis and scoring, moving repository loading and save/update steps into GrantManager app-service adapters while keeping Unity.AI operation services focused on deterministic inputs and JSON shaping.

Validation
- `dotnet build applications\Unity.GrantManager\Unity.GrantManager.sln --no-restore`
- `dotnet test applications\Unity.GrantManager\test\Unity.GrantManager.Application.Tests\Unity.GrantManager.Application.Tests.csproj --no-build --filter "FullyQualifiedName~ApplicationAnalysisServiceTests|FullyQualifiedName~RunApplicationAIPipelineJobTests"`