### PR TITLE
AB#33391 add AI generation log context

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/AIGenerationLogScope.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/AIGenerationLogScope.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Unity.GrantManager.GrantApplications.Automation.BackgroundJobs;
+
+internal static class AIGenerationLogScope
+{
+    public static IDisposable? Begin(
+        ILogger logger,
+        string operationType,
+        Guid applicationId,
+        Guid? tenantId,
+        string requestKey,
+        string? promptVersion,
+        Guid? requestedByUserId)
+    {
+        return logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["AIOperationType"] = operationType,
+            ["AIApplicationId"] = applicationId,
+            ["AITenantId"] = tenantId,
+            ["AIGenerationRequestKey"] = requestKey,
+            ["AIPromptVersion"] = promptVersion,
+            ["AIRequestedByUserId"] = requestedByUserId
+        });
+    }
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationAnalysisJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationAnalysisJob.cs
@@ -22,6 +22,15 @@ public class GenerateApplicationAnalysisJob(
 {
     public override async Task ExecuteAsync(GenerateApplicationAnalysisBackgroundJobArgs args)
     {
+        using var logScope = AIGenerationLogScope.Begin(
+            logger,
+            AIGenerationRequestKeyHelper.ApplicationAnalysisOperationType,
+            args.ApplicationId,
+            args.TenantId,
+            args.RequestKey,
+            args.PromptVersion,
+            args.RequestedByUserId);
+
         using (currentTenant.Change(args.TenantId))
         {
             await AIGenerationRequestJobHelper.MarkRunningInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationScoringJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateApplicationScoringJob.cs
@@ -24,6 +24,15 @@ public class GenerateApplicationScoringJob(
 {
     public override async Task ExecuteAsync(GenerateApplicationScoringBackgroundJobArgs args)
     {
+        using var logScope = AIGenerationLogScope.Begin(
+            logger,
+            AIGenerationRequestKeyHelper.ApplicationScoringOperationType,
+            args.ApplicationId,
+            args.TenantId,
+            args.RequestKey,
+            args.PromptVersion,
+            args.RequestedByUserId);
+
         using (currentTenant.Change(args.TenantId))
         {
             await AIGenerationRequestJobHelper.MarkRunningInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateAttachmentSummaryJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/GenerateAttachmentSummaryJob.cs
@@ -22,6 +22,15 @@ public class GenerateAttachmentSummaryJob(
 {
     public override async Task ExecuteAsync(GenerateAttachmentSummaryBackgroundJobArgs args)
     {
+        using var logScope = AIGenerationLogScope.Begin(
+            logger,
+            AIGenerationRequestKeyHelper.AttachmentSummaryOperationType,
+            args.ApplicationId,
+            args.TenantId,
+            args.RequestKey,
+            args.PromptVersion,
+            args.RequestedByUserId);
+
         using (currentTenant.Change(args.TenantId))
         {
             await AIGenerationRequestJobHelper.MarkRunningInNewUowAsync(unitOfWorkManager, generationRequestRepository, args.RequestKey);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/RunApplicationAIPipelineJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/BackgroundJobs/RunApplicationAIPipelineJob.cs
@@ -33,6 +33,15 @@ public class RunApplicationAIPipelineJob(
 {
     public override async Task ExecuteAsync(RunApplicationAIPipelineJobArgs args)
     {
+        using var logScope = AIGenerationLogScope.Begin(
+            logger,
+            AIGenerationRequestKeyHelper.PipelineOperationType,
+            args.ApplicationId,
+            args.TenantId,
+            args.RequestKey,
+            args.PromptVersion,
+            args.RequestedByUserId);
+
         if (string.IsNullOrWhiteSpace(args.RequestKey))
         {
             throw new ArgumentException("RequestKey is required.", nameof(args));


### PR DESCRIPTION
Summary
This PR adds a shared logging scope for AI generation background jobs so request correlation context is attached without logging payloads.

Validation
- `dotnet build applications\Unity.GrantManager\Unity.GrantManager.sln --no-restore`
- `dotnet test applications\Unity.GrantManager\test\Unity.GrantManager.Application.Tests\Unity.GrantManager.Application.Tests.csproj --no-build --filter "FullyQualifiedName~AIGenerationQueueTests|FullyQualifiedName~RunApplicationAIPipelineJobTests"`