### PR TITLE
AB#32985: Sanitize HTML tags in Scoresheet

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Utilities/HtmlHelperExtensions.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Utilities/HtmlHelperExtensions.cs
@@ -1,0 +1,16 @@
+using Ganss.Xss;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace Unity.GrantManager.Web.Utilities;
+
+public static class HtmlHelperExtensions
+{
+    private static readonly HtmlSanitizer _sanitizer = new();
+
+    public static IHtmlContent SanitizeRaw(this IHtmlHelper _, string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return HtmlString.Empty;
+        return new HtmlString(_sanitizer.Sanitize(value));
+    }
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentScoresWidget/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/AssessmentScoresWidget/Default.cshtml
@@ -1,4 +1,5 @@
-﻿@using Unity.Flex.Web.Views.Shared.Components.QuestionNumberWidget
+﻿@using Unity.GrantManager.Web.Utilities
+@using Unity.Flex.Web.Views.Shared.Components.QuestionNumberWidget
 @using Unity.Flex.Web.Views.Shared.Components.QuestionTextAreaWidget
 @using Unity.Flex.Web.Views.Shared.Components.QuestionTextWidget
 @using Unity.Flex.Web.Views.Shared.Components.QuestionYesNoWidget
@@ -76,7 +77,7 @@
                                                         <div class="accordion-item">
                                                             <h2 class="accordion-header" id="question-heading-@question.Id">
                                                                 <button class="accordion-button collapsed unt-accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#question-collapse-@question.Id" aria-expanded="true" aria-controls="question-collapse-@question.Id">
-                                                                    @sectionNumber.@questionNumber @question.Label
+                                                                    @sectionNumber.@questionNumber @Html.SanitizeRaw(question.Label)
                                                                     @if (question.Definition?.ConvertDefinition(question.Type)?.GetIsRequired() == true)
                                                                     {
                                                                         <span> *</span>
@@ -91,7 +92,7 @@
                                                             </h2>
                                                             <div id="question-collapse-@question.Id" class="accordion-collapse collapse" aria-labelledby="question-heading-@question.Id">
                                                                 <div class="accordion-body">
-                                                                    <p>@question.Description</p>
+                                                                    <p>@Html.SanitizeRaw(question.Description)</p>
 
                                                                     @switch (question.Type)
                                                                     {


### PR DESCRIPTION
Safe HTML tags in Scoresheets like &lt;br&gt; &lt;h1&gt; etc are allowed.
Javascripts in Scoresheets are disallowed.