### PR TITLE
AB#30134: Drop OrganizationSize Column As Its No Longer Used

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/Applicant.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/Applicant.cs
@@ -13,10 +13,6 @@ public class Applicant : AuditedAggregateRoot<Guid>, IMultiTenant
     public string? OrgNumber { get; set; }
     public string? OrgStatus { get; set; }
     public string? OrganizationType { get; set; }
-    // Retained to protect the DB column from being dropped by EF Core migrations.
-    // No longer read or written by Unity — ApproxNumberOfEmployees is the canonical field.
-    // Do not remove until a DB migration explicitly drops or consolidates the column.
-    public string? OrganizationSize { get; set; }
     public string? Sector { get; set; }
     public string? SubSector { get; set; }
     public string? Status { get; set; }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Migrations/TenantMigrations/20260619213505_DropApplicantOrganizationSize.Designer.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Migrations/TenantMigrations/20260619213505_DropApplicantOrganizationSize.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unity.GrantManager.EntityFrameworkCore;
@@ -12,9 +13,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace Unity.GrantManager.Migrations.TenantMigrations
 {
     [DbContext(typeof(GrantTenantDbContext))]
-    partial class GrantTenantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260619213505_DropApplicantOrganizationSize")]
+    partial class DropApplicantOrganizationSize
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Migrations/TenantMigrations/20260619213505_DropApplicantOrganizationSize.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Migrations/TenantMigrations/20260619213505_DropApplicantOrganizationSize.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unity.GrantManager.Migrations.TenantMigrations
+{
+    /// <inheritdoc />
+    public partial class DropApplicantOrganizationSize : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OrganizationSize",
+                table: "Applicants");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "OrganizationSize",
+                table: "Applicants",
+                type: "text",
+                nullable: true);
+        }
+    }
+}


### PR DESCRIPTION
Note:
- Usage of OrganizationSize was replaced by ApproxNumberOfEmployees in the previous PR.
- Applicant Portal still uses organizationSize thats why its not yet removed in some of the DTO's, but the organizationSize in the DTO are actually getting and writing from ApproxNumberOfEmployees