### PR TITLE
AB#33493: Sanitize HTML of Scoresheets

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/Scoresheet/Default.cshtml
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/Scoresheet/Default.cshtml
@@ -1,6 +1,5 @@
 ﻿﻿@using Microsoft.AspNetCore.Mvc.Localization
 @using Unity.Flex.Localization;
-@using Unity.Flex.Web.Views.Shared.Components.Scoresheet;
 @using Volo.Abp.Authorization.Permissions;
 @inject IHtmlLocalizer<FlexResource> L
 @inject IPermissionChecker PermissionChecker
@@ -99,7 +98,8 @@
                                         data-maxlength="@question.GetMaxLength()" 
                                         data-yesvalue="@question.GetYesValue()" 
                                         data-novalue="@question.GetNoValue()" 
-                                        data-questiondesc="@question.Description" 
+                                        data-questionlabel="@question.Label"
+                                        data-questiondesc="@question.Description"
                                         data-definition="@question.Definition"
                                         data-rows="@question.GetRowsValue()"
                                         data-required="@question.GetIsRequiredValue()">

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/Scoresheet/Scoresheet.js
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/Scoresheet/Scoresheet.js
@@ -1,3 +1,58 @@
+function sanitizeHtml(html) {
+    if (!html) return '';
+
+    const ALLOWED_TAGS = new Set([
+        'a', 'b', 'blockquote', 'br', 'code', 'del', 'em',
+        'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i',
+        'li', 'ol', 'p', 'pre', 's', 'span', 'strong', 'u', 'ul'
+    ]);
+    const ALLOWED_ATTRS = new Set(['href', 'rel', 'target', 'title']);
+    const ALLOWED_SCHEMES = ['http:', 'https:', 'mailto:'];
+    const STRIP_WITH_CONTENT = new Set(['script', 'style', 'iframe', 'noscript', 'object', 'embed']);
+
+    const template = document.createElement('template');
+    template.innerHTML = html;
+
+    // Process bottom-up so children are handled before their parent is unwrapped/removed
+    const elements = Array.from(template.content.querySelectorAll('*')).reverse();
+    for (const el of elements) {
+        const tag = el.tagName.toLowerCase();
+        if (STRIP_WITH_CONTENT.has(tag)) {
+            el.remove();
+        } else if (!ALLOWED_TAGS.has(tag)) {
+            el.replaceWith(...Array.from(el.childNodes));
+        } else {
+            for (const attr of Array.from(el.attributes)) {
+                if (!ALLOWED_ATTRS.has(attr.name)) {
+                    el.removeAttribute(attr.name);
+                } else if (attr.name === 'href') {
+                    try {
+                        const url = new URL(el.getAttribute('href'), location.href);
+                        if (!ALLOWED_SCHEMES.includes(url.protocol)) {
+                            el.removeAttribute('href');
+                        }
+                    } catch (e) {
+                        console.warn('sanitizeHtml: invalid href removed:', e);
+                        el.removeAttribute('href');
+                    }
+                }
+            }
+        }
+    }
+
+    const wrapper = document.createElement('div');
+    wrapper.appendChild(template.content);
+    return wrapper.innerHTML;
+}
+
+function escapeHtml(text) {
+    return String(text)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
 $(function () {
 
     function makeScoresheetsSortable() {
@@ -149,7 +204,7 @@ $(function () {
                 <form method="post" id="section-form-${hashCode(item.innerText)}" onSubmit="return false;">
                 <h2 class="accordion-header" id="panel-${hashCode(item.innerText)}">
                     <button class="accordion-button preview-btn unt-accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-${hashCode(item.innerText)}" aria-expanded="true" aria-controls="collapse-${hashCode(item.innerText)}">
-                        ${sectionNumber}.  ${item.dataset.label}
+                        ${sectionNumber}.  ${escapeHtml(item.dataset.label)}
                     </button>
                 </h2>
                 <div id="collapse-${hashCode(item.innerText)}" class="accordion-collapse collapse show" aria-labelledby="panel-${hashCode(item.innerText)}">
@@ -163,7 +218,7 @@ $(function () {
                     <div class="accordion-item">
                         <h2 class="accordion-header" id="nested-panel${hashCode(item.innerText)}">
                             <button class="accordion-button question-btn collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#nested-collapse${hashCode(item.innerText)}" aria-expanded="true" aria-controls="nested-collapse${hashCode(item.innerText)}">
-                                ${sectionNumber}.${questionNumber}  ${item.innerText} ${item.dataset.required == 'True' ? '*' : ''}
+                                ${sectionNumber}.${questionNumber}  ${sanitizeHtml(item.dataset.questionlabel)} ${item.dataset.required == 'True' ? '*' : ''}
                             </button>
                         </h2>
                         <div id="nested-collapse${hashCode(item.innerText)}" class="accordion-collapse collapse" aria-labelledby="nested-panel${hashCode(item.innerText)}">
@@ -219,7 +274,7 @@ $(function () {
     function buildTextAreaFieldPreview(item) {
         let req = item.dataset.required ? "required" : null;
         return `
-                    <p>${item.dataset.questiondesc}</p>
+                    <p>${sanitizeHtml(item.dataset.questiondesc)}</p>
                     <div class="mb-3">
                         <label for="answer-text-${item.dataset.id}" class="form-label unt-form-label">Answer</label>
                         <textarea rows="${item.dataset.rows}" type="text" ${req} class="form-control answer-text-input" minlength="${item.dataset.minlength}" maxlength="${item.dataset.maxlength}" 
@@ -238,7 +293,7 @@ $(function () {
         }).join('');
 
         return `
-                    <p>${item.dataset.questiondesc}</p>
+                    <p>${sanitizeHtml(item.dataset.questiondesc)}</p>
                     <div class="mb-3">
                         <label for="answer-selectlist-${item.dataset.id}" class="form-label unt-form-label">Answer</label>
                         <select id="answer-selectlist-${item.dataset.id}"
@@ -254,7 +309,7 @@ $(function () {
     function buildNumberFieldPreview(item) {
         let req = item.dataset.required ? "required" : null;
         return `
-                    <p>${item.dataset.questiondesc}</p>
+                    <p>${sanitizeHtml(item.dataset.questiondesc)}</p>
                     <div class="mb-3">
                         <label for="answer-number-${item.dataset.id}" class="form-label unt-form-label">Answer</label>
                         <input type="number" ${req} class="form-control answer-number-input" min="${item.dataset.min}" max="${item.dataset.max}" 
@@ -266,7 +321,7 @@ $(function () {
 
     function buildYesNoFieldPreview(item) {
         return `
-                    <p>${item.dataset.questiondesc}</p>
+                    <p>${sanitizeHtml(item.dataset.questiondesc)}</p>
                     <div class="mb-3">
                         <label for="answer-yesno-${item.dataset.id}" class="form-label unt-form-label">Answer</label>
                         <select id="answer-yesno-${item.dataset.id}"
@@ -287,7 +342,7 @@ $(function () {
         let req = item.dataset.required ? "required" : null;
 
         return `
-                    <p>${item.dataset.questiondesc}</p>
+                    <p>${sanitizeHtml(item.dataset.questiondesc)}</p>
                     <div class="mb-3">
                         <label for="answer-text-${item.dataset.id}" class="form-label unt-form-label">Answer</label>
                         <input type="text" ${req} class="form-control answer-text-input" minlength="${item.dataset.minlength}" maxlength="${item.dataset.maxlength}" 

--- a/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/Scoresheet/Scoresheet.js
+++ b/applications/Unity.GrantManager/modules/Unity.Flex/src/Unity.Flex.Web/Views/Shared/Components/Scoresheet/Scoresheet.js
@@ -1,45 +1,50 @@
+const _SANITIZE_ALLOWED_TAGS = new Set([
+    'a', 'b', 'blockquote', 'br', 'code', 'del', 'em',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i',
+    'li', 'ol', 'p', 'pre', 's', 'span', 'strong', 'u', 'ul'
+]);
+const _SANITIZE_ALLOWED_ATTRS = new Set(['href', 'rel', 'target', 'title']);
+const _SANITIZE_ALLOWED_SCHEMES = new Set(['http:', 'https:', 'mailto:']);
+const _SANITIZE_STRIP_WITH_CONTENT = new Set(['script', 'style', 'iframe', 'noscript', 'object', 'embed']);
+
+function _isSafeHref(href) {
+    try {
+        const url = new URL(href, location.href);
+        return _SANITIZE_ALLOWED_SCHEMES.has(url.protocol);
+    } catch (e) {
+        console.warn('sanitizeHtml: invalid href removed:', e);
+        return false;
+    }
+}
+
+function _sanitizeElement(el) {
+    for (const attr of Array.from(el.attributes)) {
+        if (_SANITIZE_ALLOWED_ATTRS.has(attr.name)) {
+            if (attr.name === 'href' && !_isSafeHref(el.getAttribute('href'))) {
+                el.removeAttribute('href');
+            }
+        } else {
+            el.removeAttribute(attr.name);
+        }
+    }
+}
+
 function sanitizeHtml(html) {
     if (!html) return '';
-
-    const ALLOWED_TAGS = new Set([
-        'a', 'b', 'blockquote', 'br', 'code', 'del', 'em',
-        'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i',
-        'li', 'ol', 'p', 'pre', 's', 'span', 'strong', 'u', 'ul'
-    ]);
-    const ALLOWED_ATTRS = new Set(['href', 'rel', 'target', 'title']);
-    const ALLOWED_SCHEMES = ['http:', 'https:', 'mailto:'];
-    const STRIP_WITH_CONTENT = new Set(['script', 'style', 'iframe', 'noscript', 'object', 'embed']);
-
     const template = document.createElement('template');
     template.innerHTML = html;
-
     // Process bottom-up so children are handled before their parent is unwrapped/removed
     const elements = Array.from(template.content.querySelectorAll('*')).reverse();
     for (const el of elements) {
         const tag = el.tagName.toLowerCase();
-        if (STRIP_WITH_CONTENT.has(tag)) {
+        if (_SANITIZE_STRIP_WITH_CONTENT.has(tag)) {
             el.remove();
-        } else if (!ALLOWED_TAGS.has(tag)) {
-            el.replaceWith(...Array.from(el.childNodes));
+        } else if (_SANITIZE_ALLOWED_TAGS.has(tag)) {
+            _sanitizeElement(el);
         } else {
-            for (const attr of Array.from(el.attributes)) {
-                if (!ALLOWED_ATTRS.has(attr.name)) {
-                    el.removeAttribute(attr.name);
-                } else if (attr.name === 'href') {
-                    try {
-                        const url = new URL(el.getAttribute('href'), location.href);
-                        if (!ALLOWED_SCHEMES.includes(url.protocol)) {
-                            el.removeAttribute('href');
-                        }
-                    } catch (e) {
-                        console.warn('sanitizeHtml: invalid href removed:', e);
-                        el.removeAttribute('href');
-                    }
-                }
-            }
+            el.replaceWith(...Array.from(el.childNodes));
         }
     }
-
     const wrapper = document.createElement('div');
     wrapper.appendChild(template.content);
     return wrapper.innerHTML;
@@ -47,10 +52,10 @@ function sanitizeHtml(html) {
 
 function escapeHtml(text) {
     return String(text)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;');
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;');
 }
 
 $(function () {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Utilities/HtmlHelperExtensions.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Utilities/HtmlHelperExtensions.cs
@@ -6,11 +6,34 @@ namespace Unity.GrantManager.Web.Utilities;
 
 public static class HtmlHelperExtensions
 {
-    private static readonly HtmlSanitizer _sanitizer = new();
+    private static readonly HtmlSanitizer _sanitizer = BuildSanitizer();
 
     public static IHtmlContent SanitizeRaw(this IHtmlHelper _, string? value)
     {
         if (string.IsNullOrEmpty(value)) return HtmlString.Empty;
         return new HtmlString(_sanitizer.Sanitize(value));
+    }
+
+    private static HtmlSanitizer BuildSanitizer()
+    {
+        var sanitizer = new HtmlSanitizer();
+
+        sanitizer.AllowedTags.Clear();
+        sanitizer.AllowedTags.UnionWith(
+        [
+            "a", "b", "blockquote", "br", "code", "del", "em",
+            "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i",
+            "li", "ol", "p", "pre", "s", "span", "strong", "u", "ul"
+        ]);
+
+        sanitizer.AllowedAttributes.Clear();
+        sanitizer.AllowedAttributes.UnionWith(["href", "rel", "target", "title"]);
+
+        sanitizer.AllowedSchemes.Clear();
+        sanitizer.AllowedSchemes.UnionWith(["http", "https", "mailto"]);
+
+        sanitizer.AllowedCssProperties.Clear();
+
+        return sanitizer;
     }
 }


### PR DESCRIPTION
Sanitize HTML in scoresheet labels and descriptions to allow only safe tags (br, strong, ul, etc.) and safe attributes. This blocks CSS injection via &lt;style&gt; tags and inline style attributes, XSS via event handlers (onerror, onclick) and javascript: URLs, and rendering of disallowed elements (iframe, script).