### PR TITLE
feature/AB#32199 - Permission-User Matrix

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/PermissionRoleMatrix.cshtml.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/PermissionRoleMatrix.cshtml.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -5,10 +6,12 @@ using System.Threading.Tasks;
 using Unity.GrantManager.Repositories;
 using Volo.Abp.AspNetCore.Mvc.UI.RazorPages;
 using Volo.Abp.Authorization.Permissions;
+using Volo.Abp.Identity;
 using Volo.Abp.Localization;
 
 namespace Unity.GrantManager.Web.Pages.Identity.Roles;
 
+[Authorize(IdentityPermissions.Roles.ManagePermissions)]
 public class PermissionRoleMatrixModel(IPermissionRoleMatrixRepository repository, IPermissionDefinitionManager permissionDefinitionManager) : AbpPageModel
 {
     public bool IsExpanded { get; private set; }

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/PermissionRoleMatrix.cshtml.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/PermissionRoleMatrix.cshtml.cs
@@ -11,7 +11,7 @@ using Volo.Abp.Localization;
 
 namespace Unity.GrantManager.Web.Pages.Identity.Roles;
 
-[Authorize(IdentityPermissions.Roles.ManagePermissions)]
+[Authorize(IdentityPermissions.Roles.Default)]
 public class PermissionRoleMatrixModel(IPermissionRoleMatrixRepository repository, IPermissionDefinitionManager permissionDefinitionManager) : AbpPageModel
 {
     public bool IsExpanded { get; private set; }

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/PermissionRoleMatrix.js
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/PermissionRoleMatrix.js
@@ -34,6 +34,16 @@
         });
     }
 
+    const adjustTableLayout = function () {
+        globalThis.requestAnimationFrame(function () {
+            localTable.columns.adjust();
+
+            if (localTable.fixedHeader) {
+                localTable.fixedHeader.adjust();
+            }
+        });
+    };
+
     $.fn.dataTable.Buttons.defaults.dom.button.className = 'btn flex-none';
     let localTable = $('#permissionTable').DataTable({
         paging: false,
@@ -122,6 +132,11 @@
     // Hide spinner and show table after initialization
     $('.loading-spinner').hide();
     $('#permissionTable').show();
+    adjustTableLayout();
+
+    $(globalThis).on('resize', function () {
+        adjustTableLayout();
+    });
 
     // Add click handlers to role column headers using data-role-header attribute
     $(document).on('click', 'th[data-role-header]', function () {

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/PermissionRoleMatrix.js
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/PermissionRoleMatrix.js
@@ -1,5 +1,5 @@
 ﻿$(document).ready(function () {
-    const urlParams = new URLSearchParams(window.location.search);
+    const urlParams = new URLSearchParams(globalThis.location.search);
     const isExpanded = urlParams.get('Render') === 'Expanded';
     const exportTitle = `${abp.currentTenant.name}_${(new Date()).toISOString().slice(0, 10)}_Permission-Role Matrix`;
 
@@ -11,7 +11,7 @@
     );
     _permissionsModal.onClose(function () {
         // Refresh the page to show updated permissions
-        window.location.reload();
+        globalThis.location.reload();
     });
 
     const roleColumnIndexes = [];
@@ -65,7 +65,7 @@
                     : '<i class="fl fl-fullscreen align-middle"></i> <span>View Expanded</span>',
                 className: 'btn-light rounded-1',
                 action: function (e, dt, button, config) {
-                    window.location = isExpanded
+                    globalThis.location = isExpanded
                         ? '/Identity/Roles/PermissionRoleMatrix'
                         : '/Identity/Roles/PermissionRoleMatrix?Render=Expanded';
                 }

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/index.js
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Roles/index.js
@@ -123,8 +123,9 @@ $(function () {
         {
             text: '<i class="fl fl-multi-select align-middle"></i><span>View Role Matrix</span>',
             className: 'btn-light rounded-1',
+            available: () => abp.auth.isGranted('AbpIdentity.Roles'),
             action: function (e, dt, button, config) {
-                window.location = '/Identity/Roles/PermissionRoleMatrix'
+                globalThis.location = '/Identity/Roles/PermissionRoleMatrix'
             }
         },
         {

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.cshtml
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.cshtml
@@ -45,6 +45,9 @@
             left: 50%;
             text-align: center;
         }
+        #permissionUserTable .pum-roles { display: none; }
+        #permissionUserTable.show-roles .pum-value { display: none; }
+        #permissionUserTable.show-roles .pum-roles { display: inline; }
     </style>
 }
 
@@ -97,8 +100,9 @@
                                 <td>@(L[permission.PermissionDisplayName].Value)</td>
                                 @foreach (var user in Model.Users)
                                 {
-                                    var hasPermission = permission.UserPermissions.TryGetValue(user.UserId, out var val) && val;
-                                    <td>@(hasPermission ? "TRUE" : string.Empty)</td>
+                                    permission.UserPermissions.TryGetValue(user.UserId, out var summary);
+                                    var hasPermission = summary?.HasPermission ?? false;
+                                    <td class="@(hasPermission ? "pum-has-permission" : "")"><span class="pum-value">@(hasPermission ? "TRUE" : string.Empty)</span>@if (hasPermission) {<span class="pum-roles">@summary!.GrantSources</span>}</td>
                                 }
                             </tr>
                         }
@@ -153,8 +157,9 @@
 
                                 @foreach (var user in Model.Users)
                                 {
-                                    var hasPermission = permission.UserPermissions.TryGetValue(user.UserId, out var val) && val;
-                                    <td>@(hasPermission ? "TRUE" : string.Empty)</td>
+                                    permission.UserPermissions.TryGetValue(user.UserId, out var summary);
+                                    var hasPermission = summary?.HasPermission ?? false;
+                                    <td class="@(hasPermission ? "pum-has-permission" : "")"><span class="pum-value">@(hasPermission ? "TRUE" : string.Empty)</span>@if (hasPermission) {<span class="pum-roles">@summary!.GrantSources</span>}</td>
                                 }
                             </tr>
                         }

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.cshtml
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.cshtml
@@ -1,0 +1,166 @@
+@page
+
+@using Microsoft.Extensions.Localization
+@using Unity.GrantManager.Localization
+@using Volo.Abp.AspNetCore.Mvc.UI.Layout
+@using Volo.Abp.MultiTenancy
+
+@model Unity.Identity.Web.Pages.Identity.Users.PermissionUserMatrixModel
+
+@inject ICurrentTenant CurrentTenant
+@inject IPageLayout PageLayout
+@inject IStringLocalizer<GrantManagerResource> L
+
+@tagHelperPrefix th:
+
+@{
+    PageLayout.Content.Title = "Permission-User Matrix";
+    ViewBag.PageTitle = "Permission-User Matrix";
+    int rowCount = 1;
+    int maxDepth = Model.PermissionUserMatrix.Any() ? Model.PermissionUserMatrix.Max(item => item.Depth) : 0;
+    int headerLevel = maxDepth + 1;
+
+    var filteredPermissions = Model.ShowNotDefined
+        ? Model.PermissionUserMatrix.Where(p => !p.IsDefined)
+        : Model.PermissionUserMatrix.Where(p => p.IsDefined);
+}
+
+@section scripts {
+    <th:abp-script src="/Pages/Identity/Users/PermissionUserMatrix.js" />
+    <th:abp-script src="/Pages/AbpPermissionManagement/permission-management-modal.js" />
+}
+
+@section styles {
+    <style>
+        #permissionTableContainer {
+            position: relative;
+            min-height: 200px;
+        }
+        #permissionUserTable {
+            display: none;
+        }
+        .loading-spinner {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            text-align: center;
+        }
+    </style>
+}
+
+<div class="container-fluid px-0">
+    <div class="action-bar p-2 filter-search-action-bar">
+        <div class="unity-page-titlebar">
+            <h4 id="PermissionUserMatrixTitle">Permission-User Matrix - @CurrentTenant.Name</h4>
+        </div>
+        <div class="filter-search-action-bar_search-wrapper">
+            <input type="search" id="search" placeholder="Search" class="tbl-search" aria-label="Search permissions">
+        </div>
+
+        <div class="btn-group" id="app_custom_buttons">
+        </div>
+
+        <div id="dynamicButtonContainerId" class="dynamic-buttons-div button-gap-1"></div>
+    </div>
+    <div class="p-3 pt-0">
+        <div id="permissionTableContainer" class="p-3 pt-0">
+            <div class="loading-spinner">
+                <p>Loading permission matrix...</p>
+            </div>
+            <table id="permissionUserTable" class="table table-bordered" aria-describedby="PermissionUserMatrixTitle">
+                @if (!Model.IsExpanded)
+                {
+                    <thead>
+                        <tr>
+                            <th scope="col">#</th>
+                            <th scope="col">L</th>
+                            <th scope="col">Permission Group</th>
+                            <th scope="col">Permission</th>
+                            <th scope="col">Description</th>
+                            @foreach (var user in Model.Users)
+                            {
+                                <th scope="col" class="user-name" data-user-header="@user.UserId" data-user-name="@user.UserName">@user.DisplayLabel</th>
+                            }
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var permission in filteredPermissions)
+                        {
+                            <tr>
+                                <td>@rowCount.ToString("D2")</td>
+                                @{
+                                    rowCount++;
+                                }
+                                <td>@permission.Depth.ToString("D1")</td>
+                                <td>@permission.GroupName</td>
+                                <td>@permission.PermissionName</td>
+                                <td>@(L[permission.PermissionDisplayName].Value)</td>
+                                @foreach (var user in Model.Users)
+                                {
+                                    var hasPermission = permission.UserPermissions.TryGetValue(user.UserId, out var val) && val;
+                                    <td>@(hasPermission ? "TRUE" : string.Empty)</td>
+                                }
+                            </tr>
+                        }
+                    </tbody>
+                }
+                else
+                {
+                    <thead>
+                        <tr>
+                            <th scope="col" rowspan="2" data-dt-order="disable">#</th>
+                            <th scope="col" rowspan="2" data-dt-order="disable">L</th>
+                            <th scope="col" rowspan="2">Permission Group</th>
+                            <th scope="colgroup" colspan="@headerLevel" data-dt-order="disable">Permission</th>
+                            <th scope="col" rowspan="2">Description</th>
+                            @foreach (var user in Model.Users)
+                            {
+                                <th scope="col" rowspan="2" class="user-name" data-user-header="@user.UserId" data-user-name="@user.UserName">@user.DisplayLabel</th>
+                            }
+                        </tr>
+                        <tr>
+                            @for (int groupLevel = 1; groupLevel < headerLevel + 1; groupLevel++)
+                            {
+                                <th scope="col">Level @groupLevel</th>
+                            }
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var permission in filteredPermissions)
+                        {
+                            <tr>
+                                <td>
+                                    @rowCount.ToString("D2")
+                                </td>
+                                @{
+                                    rowCount++;
+                                }
+                                <td>@permission.Depth.ToString("D1")</td>
+                                <td>@permission.GroupName</td>
+                                @for (int i = 0; i < permission.Depth; i++)
+                                {
+                                    <td></td>
+                                }
+
+                                <td>@permission.PermissionName</td>
+
+                                @for (int j = permission.Depth; j < maxDepth; j++)
+                                {
+                                    <td></td>
+                                }
+
+                                <td>@permission.PermissionDisplayName</td>
+
+                                @foreach (var user in Model.Users)
+                                {
+                                    var hasPermission = permission.UserPermissions.TryGetValue(user.UserId, out var val) && val;
+                                    <td>@(hasPermission ? "TRUE" : string.Empty)</td>
+                                }
+                            </tr>
+                        }
+                    </tbody>
+                }
+            </table>
+        </div>
+    </div>
+</div>

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.cshtml.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.cshtml.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -5,10 +6,12 @@ using System.Threading.Tasks;
 using Unity.GrantManager.Repositories;
 using Volo.Abp.AspNetCore.Mvc.UI.RazorPages;
 using Volo.Abp.Authorization.Permissions;
+using Volo.Abp.Identity;
 using Volo.Abp.Localization;
 
 namespace Unity.Identity.Web.Pages.Identity.Users;
 
+[Authorize(IdentityPermissions.Users.ManagePermissions)]
 public class PermissionUserMatrixModel(IPermissionRoleMatrixRepository repository, IPermissionDefinitionManager permissionDefinitionManager) : AbpPageModel
 {
     public bool IsExpanded { get; private set; }

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.cshtml.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.cshtml.cs
@@ -11,7 +11,7 @@ using Volo.Abp.Localization;
 
 namespace Unity.Identity.Web.Pages.Identity.Users;
 
-[Authorize(IdentityPermissions.Users.ManagePermissions)]
+[Authorize(IdentityPermissions.Users.Default)]
 public class PermissionUserMatrixModel(IPermissionRoleMatrixRepository repository, IPermissionDefinitionManager permissionDefinitionManager) : AbpPageModel
 {
     public bool IsExpanded { get; private set; }

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.cshtml.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.cshtml.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Unity.GrantManager.Repositories;
+using Volo.Abp.AspNetCore.Mvc.UI.RazorPages;
+using Volo.Abp.Authorization.Permissions;
+using Volo.Abp.Localization;
+
+namespace Unity.Identity.Web.Pages.Identity.Users;
+
+public class PermissionUserMatrixModel(IPermissionRoleMatrixRepository repository, IPermissionDefinitionManager permissionDefinitionManager) : AbpPageModel
+{
+    public bool IsExpanded { get; private set; }
+    public bool ShowNotDefined { get; private set; } = false;
+    public required IList<PermissionUserMatrixRowDto> PermissionUserMatrix { get; set; }
+    public required IList<UserInfoDto> Users { get; set; }
+
+    public async Task OnGetAsync()
+    {
+        IsExpanded = Request.Query["Render"].ToString().Equals("Expanded", StringComparison.OrdinalIgnoreCase);
+        ShowNotDefined = Request.Query["Show"].ToString().Equals("NotDefined", StringComparison.OrdinalIgnoreCase);
+
+        var result = await repository.GetPermissionUserMatrixAsync();
+        PermissionUserMatrix = result.Rows;
+        Users = result.Users;
+
+        var definedPermissionSet = await permissionDefinitionManager.GetPermissionsAsync();
+        var definedPermissionNames = new HashSet<string>(definedPermissionSet.Select(x => x.Name));
+
+        foreach (var item in PermissionUserMatrix)
+        {
+            item.IsDefined = definedPermissionNames.Contains(item.PermissionName);
+
+            var displayName = item.PermissionDisplayName;
+            if (displayName.Length > 2 && displayName.StartsWith("L:"))
+            {
+                var parts = displayName.AsSpan(2).ToString().Split(',');
+                if (parts.Length == 2)
+                {
+                    var resourceName = parts[0];
+                    var name = parts[1];
+                    var localizable = new LocalizableString(name, resourceName);
+                    var localized = await localizable.LocalizeAsync(StringLocalizerFactory);
+                    item.PermissionDisplayName = localized?.Value ?? displayName;
+                }
+            }
+        }
+    }
+}

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.js
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.js
@@ -32,6 +32,26 @@ $(document).ready(function () {
         });
     }
 
+    const exportOptions = {
+        columns: ':visible:not(.notexport)',
+        format: {
+            body: function (data, row, column, node) {
+                if (!node) {
+                    return data;
+                }
+
+                const $cell = $(node).clone();
+                if (showingRoles) {
+                    $cell.find('.pum-value').remove();
+                } else {
+                    $cell.find('.pum-roles').remove();
+                }
+
+                return $cell.text().trim();
+            }
+        }
+    };
+
     let showingRoles = false;
 
     const adjustTableLayout = function () {
@@ -60,7 +80,7 @@ $(document).ready(function () {
         columnDefs: columnDefs,
         buttons: [
             {
-                text: '<i class="fl fl-review-user align-middle"></i> <span>View Expanded</span> <span>Show Roles</span>',
+                text: '<i class="fl fl-review-user align-middle"></i> <span>Show Roles</span>',
                 className: 'btn-light rounded-1',
                 action: function (e, dt, button) {
                     showingRoles = !showingRoles;
@@ -91,18 +111,14 @@ $(document).ready(function () {
                 text: 'Copy',
                 title: exportTitle,
                 className: 'custom-table-btn flex-none btn btn-secondary',
-                exportOptions: {
-                    columns: ':visible:not(.notexport)'
-                }
+                exportOptions: exportOptions
             },
             {
                 extend: 'csv',
                 text: 'Export',
                 title: exportTitle,
                 className: 'custom-table-btn flex-none btn btn-secondary',
-                exportOptions: {
-                    columns: ':visible:not(.notexport)'
-                }
+                exportOptions: exportOptions
             }
         ],
         createdRow: function (row) {

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.js
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.js
@@ -32,6 +32,8 @@ $(document).ready(function () {
         });
     }
 
+    let showingRoles = false;
+
     $.fn.dataTable.Buttons.defaults.dom.button.className = 'btn flex-none';
     let localTable = $('#permissionUserTable').DataTable({
         paging: false,
@@ -47,6 +49,20 @@ $(document).ready(function () {
         dom: 'Blfrtip',
         columnDefs: columnDefs,
         buttons: [
+            {
+                text: '<i class="fl fl-review-user align-middle"></i> <span>View Expanded</span> <span>Show Roles</span>',
+                className: 'btn-light rounded-1',
+                action: function (e, dt, button) {
+                    showingRoles = !showingRoles;
+                    if (showingRoles) {
+                        $('#permissionUserTable').addClass('show-roles');
+                        $(button).find('span').text('Hide Roles');
+                    } else {
+                        $('#permissionUserTable').removeClass('show-roles');
+                        $(button).find('span').text('Show Roles');
+                    }
+                }
+            },
             {
                 text: isExpanded
                     ? '<i class="fl fl-back-to-window align-middle"></i> <span>View Simple</span>'
@@ -78,13 +94,7 @@ $(document).ready(function () {
             }
         ],
         createdRow: function (row) {
-            $('td', row).each(function () {
-                const cellText = $(this).text().trim();
-
-                if (cellText === 'TRUE') {
-                    $(this).addClass('bg-success text-dark bg-opacity-25 fw-bold border border-success dt-center');
-                }
-            });
+            $('td.pum-has-permission', row).addClass('bg-success text-dark bg-opacity-25 fw-bold border border-success dt-center');
         },
         initComplete: function () {
             const table = this.api();

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.js
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.js
@@ -86,10 +86,10 @@ $(document).ready(function () {
                     showingRoles = !showingRoles;
                     if (showingRoles) {
                         $('#permissionUserTable').addClass('show-roles');
-                        $(button).find('span').text('Hide Roles');
+                        $(button).find('.toggle-roles-text').text('Hide Roles');
                     } else {
                         $('#permissionUserTable').removeClass('show-roles');
-                        $(button).find('span').text('Show Roles');
+                        $(button).find('.toggle-roles-text').text('Show Roles');
                     }
 
                     adjustTableLayout();

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.js
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.js
@@ -1,0 +1,141 @@
+$(document).ready(function () {
+    const urlParams = new URLSearchParams(globalThis.location.search);
+    const isExpanded = urlParams.get('Render') === 'Expanded';
+    const exportTitle = `${abp.currentTenant.name}_${(new Date()).toISOString().slice(0, 10)}_Permission-User Matrix`;
+
+    const currentUserName = abp.currentUser.userName;
+
+    let _permissionsModal = new abp.ModalManager(
+        abp.appPath + 'AbpPermissionManagement/PermissionManagementModal'
+    );
+    _permissionsModal.onClose(function () {
+        globalThis.location.reload();
+    });
+
+    const userColumnIndexes = [];
+    $('#permissionUserTable th[data-user-header]').each(function () {
+        userColumnIndexes.push($(this).index());
+    });
+
+    const columnDefs = [
+        {
+            targets: 0,
+            orderable: true,
+            className: 'notexport'
+        }
+    ];
+
+    if (userColumnIndexes.length > 0) {
+        columnDefs.push({
+            targets: userColumnIndexes,
+            orderable: false
+        });
+    }
+
+    $.fn.dataTable.Buttons.defaults.dom.button.className = 'btn flex-none';
+    let localTable = $('#permissionUserTable').DataTable({
+        paging: false,
+        searching: true,
+        ordering: true,
+        fixedHeader: {
+            header: true,
+            footer: false,
+            headerOffset: 0
+        },
+        scrollX: true,
+        scrollCollapse: true,
+        dom: 'Blfrtip',
+        columnDefs: columnDefs,
+        buttons: [
+            {
+                text: isExpanded
+                    ? '<i class="fl fl-back-to-window align-middle"></i> <span>View Simple</span>'
+                    : '<i class="fl fl-fullscreen align-middle"></i> <span>View Expanded</span>',
+                className: 'btn-light rounded-1',
+                action: function () {
+                    globalThis.location = isExpanded
+                        ? '/Identity/Users/PermissionUserMatrix'
+                        : '/Identity/Users/PermissionUserMatrix?Render=Expanded';
+                }
+            },
+            {
+                extend: 'copy',
+                text: 'Copy',
+                title: exportTitle,
+                className: 'custom-table-btn flex-none btn btn-secondary',
+                exportOptions: {
+                    columns: ':visible:not(.notexport)'
+                }
+            },
+            {
+                extend: 'csv',
+                text: 'Export',
+                title: exportTitle,
+                className: 'custom-table-btn flex-none btn btn-secondary',
+                exportOptions: {
+                    columns: ':visible:not(.notexport)'
+                }
+            }
+        ],
+        createdRow: function (row) {
+            $('td', row).each(function () {
+                const cellText = $(this).text().trim();
+
+                if (cellText === 'TRUE') {
+                    $(this).addClass('bg-success text-dark bg-opacity-25 fw-bold border border-success dt-center');
+                }
+            });
+        },
+        initComplete: function () {
+            const table = this.api();
+
+            // Disable sorting on user columns
+            $('th[data-user-header]').removeClass('sorting').addClass('sorting_disabled');
+
+            const headers = table.columns().header().toArray().map(header => $(header).text().trim());
+
+            // Highlight the current user's column
+            headers.forEach((header, index) => {
+                const $th = $(table.column(index).header());
+                const userName = $th.attr('data-user-name');
+                if (userName && userName.toLowerCase() === currentUserName?.toLowerCase()) {
+                    $th.addClass('text-decoration-underline');
+                    table.column(index).nodes().to$().filter(function () {
+                        return !$(this).text().trim();
+                    }).addClass('bg-light');
+                }
+            });
+        }
+    });
+
+    localTable.buttons().container().prependTo('#dynamicButtonContainerId');
+
+    $('#search').on('input', function () {
+        localTable.search($(this).val()).draw();
+    });
+
+    // Hide spinner and show table after initialization
+    $('.loading-spinner').hide();
+    $('#permissionUserTable').show();
+
+    // Click on user column header → open ABP permissions modal for that user
+    $(document).on('click', 'th[data-user-header]', function () {
+        const userId = $(this).attr('data-user-header');
+        const userName = $(this).attr('data-user-name');
+        _permissionsModal.open({
+            providerName: 'U',
+            providerKey: userId,
+            providerKeyDisplayName: userName
+        });
+    });
+
+    $(document).on('mouseover', 'th[data-user-header]', function () {
+        $(this).css('cursor', 'pointer');
+        if (!$(this).attr('title')) {
+            $(this).attr('title', 'Click to manage permissions for this user');
+        }
+    });
+
+    // Workaround - required until Datatables.net 2.x
+    $('th[data-user-header]').removeClass('sorting').addClass('sorting_disabled');
+});

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.js
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.js
@@ -80,7 +80,7 @@ $(document).ready(function () {
         columnDefs: columnDefs,
         buttons: [
             {
-                text: '<i class="fl fl-review-user align-middle"></i> <span>Show Roles</span>',
+                text: '<i class="fl fl-review-user align-middle"></i> <span class="toggle-roles-text">Show Roles</span>',
                 className: 'btn-light rounded-1',
                 action: function (e, dt, button) {
                     showingRoles = !showingRoles;

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.js
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/PermissionUserMatrix.js
@@ -34,6 +34,16 @@ $(document).ready(function () {
 
     let showingRoles = false;
 
+    const adjustTableLayout = function () {
+        globalThis.requestAnimationFrame(function () {
+            localTable.columns.adjust();
+
+            if (localTable.fixedHeader) {
+                localTable.fixedHeader.adjust();
+            }
+        });
+    };
+
     $.fn.dataTable.Buttons.defaults.dom.button.className = 'btn flex-none';
     let localTable = $('#permissionUserTable').DataTable({
         paging: false,
@@ -61,6 +71,8 @@ $(document).ready(function () {
                         $('#permissionUserTable').removeClass('show-roles');
                         $(button).find('span').text('Show Roles');
                     }
+
+                    adjustTableLayout();
                 }
             },
             {
@@ -127,6 +139,11 @@ $(document).ready(function () {
     // Hide spinner and show table after initialization
     $('.loading-spinner').hide();
     $('#permissionUserTable').show();
+    adjustTableLayout();
+
+    $(globalThis).on('resize', function () {
+        adjustTableLayout();
+    });
 
     // Click on user column header → open ABP permissions modal for that user
     $(document).on('click', 'th[data-user-header]', function () {

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/index.js
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/index.js
@@ -225,6 +225,13 @@ $(function () {
     $.fn.dataTable.Buttons.defaults.dom.button.className = 'btn flex-none';
     let actionButtons = [
         {
+            text: '<i class="fl fl-multi-select align-middle"></i><span>View User Matrix</span>',
+            className: 'btn-light rounded-1',
+            action: function (e, dt, button, config) {
+                globalThis.location = '/Identity/Users/PermissionUserMatrix';
+            }
+        },
+        {
             text: '<i class="fl fl-add-to align-middle"></i> <span>' + lg('Common:Command:Create') + '</span>',
             titleAttr: lg('Common:Command:Create'),
             id: 'CreateIntakeButton',

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/index.js
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/index.js
@@ -225,7 +225,7 @@ $(function () {
     $.fn.dataTable.Buttons.defaults.dom.button.className = 'btn flex-none';
     let actionButtons = [
         {
-            text: '<i class="fl fl-multi-select align-middle"></i><span>View User Matrix</span>',
+            text: '<i class="fl fl-multi-select align-middle"></i> <span>View User Matrix</span>',
             className: 'btn-light rounded-1',
             action: function (e, dt, button, config) {
                 globalThis.location = '/Identity/Users/PermissionUserMatrix';

--- a/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/index.js
+++ b/applications/Unity.GrantManager/modules/Unity.Identity.Web/src/Pages/Identity/Users/index.js
@@ -227,6 +227,7 @@ $(function () {
         {
             text: '<i class="fl fl-multi-select align-middle"></i> <span>View User Matrix</span>',
             className: 'btn-light rounded-1',
+            available: () => abp.auth.isGranted('AbpIdentity.Users'),
             action: function (e, dt, button, config) {
                 globalThis.location = '/Identity/Users/PermissionUserMatrix';
             }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/PermissionRoleMatrixRepository.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/PermissionRoleMatrixRepository.cs
@@ -69,11 +69,97 @@ public class PermissionRoleMatrixRepository(IDbContextProvider<GrantManagerDbCon
         // Recursively calculate the depth of the parent permission
         return 1 + CalculatePermissionDepth(parentPermission, permissions);
     }
+
+    public async Task<PermissionUserMatrixResult> GetPermissionUserMatrixAsync()
+    {
+        var dbContext = await GetDbContextAsync();
+
+        var permissions = await dbContext.Set<PermissionDefinitionRecord>()
+            .Where(p => p.IsEnabled && p.MultiTenancySide != MultiTenancySides.Host)
+            .ToListAsync();
+
+        var permissionGrants = await dbContext.Set<PermissionGrant>()
+            .Where(pg => pg.TenantId == CurrentTenant.Id)
+            .ToListAsync();
+
+        var users = await dbContext.Set<IdentityUser>()
+            .Where(u => u.IsActive && !u.IsDeleted && u.TenantId == CurrentTenant.Id)
+            .OrderBy(u => u.Surname ?? u.UserName)
+            .ToListAsync();
+
+        var userIds = users.Select(u => u.Id).ToHashSet();
+
+        var userRoles = await dbContext.Set<IdentityUserRole>()
+            .Where(ur => userIds.Contains(ur.UserId))
+            .ToListAsync();
+
+        var roles = await dbContext.Set<IdentityRole>()
+            .ToListAsync();
+
+        var roleIdToName = roles.ToDictionary(r => r.Id, r => r.Name);
+
+        // Build a lookup: userId → set of role names
+        var userRoleNames = userRoles
+            .GroupBy(ur => ur.UserId)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(ur => roleIdToName.TryGetValue(ur.RoleId, out var name) ? name : null)
+                       .Where(n => n != null)
+                       .ToHashSet()
+            );
+
+        var userInfos = users.Select(u => new UserInfoDto
+        {
+            UserId = u.Id.ToString(),
+            UserName = u.UserName,
+            DisplayLabel = $"{u.Surname}, {u.Name}".Trim() ?? u.UserName
+        }).ToList();
+
+        var rows = permissions
+            .Select(permission => new PermissionUserMatrixRowDto
+            {
+                GroupName = permission.GroupName,
+                PermissionName = permission.Name,
+                PermissionDisplayName = permission.DisplayName,
+                Depth = CalculatePermissionDepth(permission.Name, permissions),
+                UserPermissions = users.ToDictionary(
+                    user => user.Id.ToString(),
+                    user =>
+                    {
+                        // Check for direct user grant
+                        var hasDirectGrant = permissionGrants.Any(pg =>
+                            pg.Name == permission.Name &&
+                            pg.ProviderName == "U" &&
+                            pg.ProviderKey == user.Id.ToString());
+
+                        if (hasDirectGrant) return true;
+
+                        // Check for inherited grant via any of the user's roles
+                        if (!userRoleNames.TryGetValue(user.Id, out var roleNamesForUser))
+                            return false;
+
+                        return permissionGrants.Any(pg =>
+                            pg.Name == permission.Name &&
+                            pg.ProviderName == "R" &&
+                            roleNamesForUser.Contains(pg.ProviderKey, StringComparer.OrdinalIgnoreCase));
+                    })
+            })
+            .OrderBy(p => p.GroupName)
+            .ThenBy(p => p.PermissionName)
+            .ToList();
+
+        return new PermissionUserMatrixResult
+        {
+            Rows = rows,
+            Users = userInfos
+        };
+    }
 }
 
 public interface IPermissionRoleMatrixRepository
 {
     Task<IList<PermissionRoleMatrixDto>> GetPermissionRoleMatrixAsync();
+    Task<PermissionUserMatrixResult> GetPermissionUserMatrixAsync();
 }
 
 public class PermissionRoleMatrixDto
@@ -84,4 +170,27 @@ public class PermissionRoleMatrixDto
     public int Depth { get; set; }
     public required Dictionary<string, bool> RolePermissions { get; set; }
     public bool IsDefined { get; set; } = false;
+}
+
+public class PermissionUserMatrixResult
+{
+    public IList<PermissionUserMatrixRowDto> Rows { get; set; } = [];
+    public IList<UserInfoDto> Users { get; set; } = [];
+}
+
+public class PermissionUserMatrixRowDto
+{
+    public required string GroupName { get; set; }
+    public required string PermissionName { get; set; }
+    public required string PermissionDisplayName { get; set; }
+    public int Depth { get; set; }
+    public required Dictionary<string, bool> UserPermissions { get; set; }
+    public bool IsDefined { get; set; } = false;
+}
+
+public class UserInfoDto
+{
+    public required string UserId { get; set; }
+    public required string UserName { get; set; }
+    public required string DisplayLabel { get; set; }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/PermissionRoleMatrixRepository.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/PermissionRoleMatrixRepository.cs
@@ -93,12 +93,14 @@ public class PermissionRoleMatrixRepository(IDbContextProvider<GrantManagerDbCon
             .Where(ur => userIds.Contains(ur.UserId))
             .ToListAsync();
 
+        var roleIds = userRoles.Select(ur => ur.RoleId).ToHashSet();
         var roles = await dbContext.Set<IdentityRole>()
+            .Where(r => roleIds.Contains(r.Id))
             .ToListAsync();
 
         var roleIdToName = roles.ToDictionary(r => r.Id, r => r.Name);
 
-        // Build a lookup: userId → set of role names
+        // Build a lookup: userId to set of role names
         var userRoleNames = userRoles
             .GroupBy(ur => ur.UserId)
             .ToDictionary(
@@ -112,7 +114,9 @@ public class PermissionRoleMatrixRepository(IDbContextProvider<GrantManagerDbCon
         {
             UserId = u.Id.ToString(),
             UserName = u.UserName,
-            DisplayLabel = $"{u.Surname}, {u.Name}".Trim() ?? u.UserName
+            DisplayLabel = string.IsNullOrWhiteSpace(u.Surname) && string.IsNullOrWhiteSpace(u.Name)
+                 ? u.UserName
+                 : $"{u.Surname}, {u.Name}".Trim(' ', ',')
         }).ToList();
 
         var rows = permissions

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/PermissionRoleMatrixRepository.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/PermissionRoleMatrixRepository.cs
@@ -126,22 +126,31 @@ public class PermissionRoleMatrixRepository(IDbContextProvider<GrantManagerDbCon
                     user => user.Id.ToString(),
                     user =>
                     {
-                        // Check for direct user grant
+                        var sources = new List<string>();
+
                         var hasDirectGrant = permissionGrants.Any(pg =>
                             pg.Name == permission.Name &&
                             pg.ProviderName == "U" &&
                             pg.ProviderKey == user.Id.ToString());
 
-                        if (hasDirectGrant) return true;
+                        if (hasDirectGrant)
+                        {
+                            sources.Add("DIRECT");
+                        }
 
-                        // Check for inherited grant via any of the user's roles
-                        if (!userRoleNames.TryGetValue(user.Id, out var roleNamesForUser))
-                            return false;
+                        if (userRoleNames.TryGetValue(user.Id, out var roleNamesForUser))
+                        {
+                            sources.AddRange(roleNamesForUser.Where(rn => rn != null).Where(roleName => permissionGrants.Any(pg =>
+                                    pg.Name == permission.Name &&
+                                    pg.ProviderName == "R" &&
+                                    pg.ProviderKey.Equals(roleName, StringComparison.OrdinalIgnoreCase))).Select(roleName => roleName!));
+                        }
 
-                        return permissionGrants.Any(pg =>
-                            pg.Name == permission.Name &&
-                            pg.ProviderName == "R" &&
-                            roleNamesForUser.Contains(pg.ProviderKey, StringComparer.OrdinalIgnoreCase));
+                        return new PermissionGrantSummary
+                        {
+                            HasPermission = sources.Count > 0,
+                            GrantSources = string.Join(", ", sources)
+                        };
                     })
             })
             .OrderBy(p => p.GroupName)
@@ -184,8 +193,14 @@ public class PermissionUserMatrixRowDto
     public required string PermissionName { get; set; }
     public required string PermissionDisplayName { get; set; }
     public int Depth { get; set; }
-    public required Dictionary<string, bool> UserPermissions { get; set; }
+    public required Dictionary<string, PermissionGrantSummary> UserPermissions { get; set; }
     public bool IsDefined { get; set; } = false;
+}
+
+public class PermissionGrantSummary
+{
+    public bool HasPermission { get; set; }
+    public string GrantSources { get; set; } = string.Empty;
 }
 
 public class UserInfoDto


### PR DESCRIPTION
## Pull request overview

Adds a new **Permission–User Matrix** view to the Unity Identity module, backed by an EF Core repository method that assembles permission grant sources per user (direct + role-based). This complements the existing Permission–Role Matrix by providing an admin-facing, per-user view of effective permissions.

**Changes:**
- Added `GetPermissionUserMatrixAsync()` to `IPermissionRoleMatrixRepository` and its EF Core implementation, plus DTOs to return rows + user headers.
- Introduced a new Razor Page (`PermissionUserMatrix`) with DataTables UI behavior (search, export, “show roles” toggle, expanded/simple rendering).
- Added a “View User Matrix” toolbar button on the Users index page; adjusted Role Matrix table layout handling on resize.