### PR TITLE
AB#33673 - Creating DataTable Context Menus

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.js
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Web/Pages/PaymentRequests/Index.js
@@ -99,6 +99,9 @@ $(function () {
         {
             text: 'Approve',
             className: 'custom-table-btn flex-none btn btn-secondary payment-status',
+            attr: {
+                'data-selector': 'batch-payment-table-actions'
+            },
             action: function (e, dt, node, config) {
                 // Store payment IDs in distributed cache to avoid URL length limits
                 unity.payments.paymentRequests.paymentBulkActions
@@ -119,6 +122,9 @@ $(function () {
         {
             text: 'Decline',
             className: 'custom-table-btn flex-none btn btn-secondary payment-status',
+            attr: {
+                'data-selector': 'batch-payment-table-actions'
+            },
             action: function (e, dt, node, config) {
                 // Store payment IDs in distributed cache to avoid URL length limits
                 unity.payments.paymentRequests.paymentBulkActions
@@ -139,6 +145,9 @@ $(function () {
         {
             text: 'History',
             className: 'custom-table-btn flex-none btn btn-secondary history',
+            attr: {
+                'data-selector': 'batch-payment-table-actions'
+            },
             action: function (e, dt, node, config) {
                 location.href = '/PaymentHistory/Details?PaymentId=' + selectedPaymentIds[0];
             }
@@ -322,7 +331,9 @@ $(function () {
                 dtApi.ajax.reload(null, false);
             }
             initialLoad = false;
-        }
+        },
+        enableContextMenu: true,
+        contextMenuActionsSelector: '[data-selector="batch-payment-table-actions"]'
     });
 
     $('.grp-savedStates').text('Save View');

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/Bundling/UnityThemeUX2GlobalScriptContributor.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/Bundling/UnityThemeUX2GlobalScriptContributor.cs
@@ -48,7 +48,8 @@ public class UnityThemeUX2GlobalScriptContributor : BundleContributor
         context.Files.Add("/themes/ux2/layout.js");
         context.Files.Add("/themes/ux2/plugins/filterRow.js");
         context.Files.Add("/themes/ux2/plugins/scrollResize.js");
-        context.Files.Add("/themes/ux2/plugins/colvisAlpha.js");
+        context.Files.Add("/themes/ux2/plugins/colvisAlpha.js");        
+        context.Files.Add("/themes/ux2/plugins/tableContextMenu.js");        
         context.Files.Add("/themes/ux2/table-utils.js");
         context.Files.Add("/themes/ux2/json-editor.js");
         context.Files.Add("/js/DateUtils.js");

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/Bundling/UnityThemeUX2GlobalStyleContributor.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/Bundling/UnityThemeUX2GlobalStyleContributor.cs
@@ -12,6 +12,7 @@ public class UnityThemeUX2GlobalStyleContributor : BundleContributor
         context.Files.Add("/themes/ux2/fluenticons.min.css");
         context.Files.Add("/themes/ux2/layout.css");
         context.Files.Add("/themes/ux2/unity-styles.css");
+        context.Files.Add("/themes/ux2/plugins/tableContextMenu.css");
         context.Files.Add("/themes/ux2/json-editor.css");
 
         context.Files.AddIfNotContains("/libs/datatables.net-bs5/css/dataTables.bootstrap5.min.css");

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/plugins/tableContextMenu.css
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/plugins/tableContextMenu.css
@@ -1,0 +1,54 @@
+/* DataTable Context Menu Styling */
+
+#dt-context-menu {
+    position: fixed;
+    min-width: 200px;
+    max-width: calc(100vw - 1rem);
+    max-height: calc(100vh - 1rem);
+    overflow-y: auto;
+    padding: 0.5rem;
+    margin: 0;
+    list-style: none;
+    background-color: var(--bs-body-bg, #fff);
+    border: var(--bs-border-width, 1px) solid var(--bs-border-color, #dee2e6);
+    border-radius: var(--bs-border-radius, 0.5rem);
+    box-shadow: var(--bs-box-shadow, 0 0.5rem 1rem rgba(0, 0, 0, 0.15));
+    z-index: 10000;
+}
+
+.dt-context-menu-item {
+    padding: 0;
+    margin: 0;
+}
+
+.dt-context-menu-link {
+    display: block;
+    padding: 0.5rem 1rem;
+    text-decoration: none;
+    white-space: nowrap;
+    cursor: pointer;
+    user-select: none;
+    font-size: 0.875rem;
+    border: 2px solid transparent;
+    border-radius: var(--bs-border-radius, 0.5rem);
+    transition: background-color 0.15s ease-in-out, color 0.15s ease-in-out, border-color 0.15s ease-in-out;
+}
+
+.dt-context-menu-link:hover,
+.dt-context-menu-link:focus-visible {
+    color: var(--bc-colors-blue-primary, #2E5DD7);
+    outline: none;
+    border: 2px solid var(--bc-colors-blue-primary, #2E5DD7);
+}
+
+.dt-context-menu-link:active {
+    color: var(--bs-body-bg, #fff);
+    background-color: var(--bc-colors-blue-primary, #2E5DD7);
+}
+
+.dt-context-menu-separator {
+    height: 0;
+    margin: 0.5rem 0;
+    padding: 0;
+    border-top: var(--bs-border-width, 1px) solid var(--bs-border-color, #dee2e6);
+}

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/plugins/tableContextMenu.js
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/plugins/tableContextMenu.js
@@ -1,0 +1,593 @@
+(function ($) {
+    'use strict';
+
+    // Constants
+    const MENU_Z_INDEX = 10000;
+    const MENU_VIEWPORT_PADDING = 8;
+    const OFFSCREEN_OFFSET = '-9999px';
+    const MENU_ID = 'dt-context-menu';
+
+    function getTableSettings(dtApi) {
+        return dtApi?.settings?.()?.[0] ?? null;
+    }
+
+    function getFilterRowPlugin(dtApi) {
+        return getTableSettings(dtApi)?._filterRow ?? null;
+    }
+
+    function getFilterRowElement(dtApi) {
+        return getFilterRowPlugin(dtApi)?.dom?.filterRow ?? $();
+    }
+
+    function getFilterInputs(dtApi) {
+        return getFilterRowElement(dtApi).find('input.custom-filter-input');
+    }
+
+    function getButtonsForTable(dtApi) {
+        return $(dtApi?.buttons?.().nodes?.() ?? []);
+    }
+
+    function getFilterButton(dtApi) {
+        // Try to find filter button through table's button API first
+        const $tableButtons = getButtonsForTable(dtApi);
+        if ($tableButtons.length > 0) {
+            const $filterFromAPI = $tableButtons.filter('[id="btn-toggle-filter"]');
+            if ($filterFromAPI.length > 0) {
+                return $filterFromAPI;
+            }
+        }
+
+        // Fallback: search the table's scope or page-wide
+        const $scopeRoot = getScopeRoot(dtApi);
+        const $filterScoped = $scopeRoot.find('#btn-toggle-filter');
+        if ($filterScoped.length > 0) {
+            return $filterScoped;
+        }
+
+        // Final fallback: page-wide search
+        return $('#btn-toggle-filter');
+    }
+
+    function getScopeRoot(dtApi) {
+        const $container = $(dtApi?.table?.().container?.() ?? []);
+        return $container.closest('.tab-pane, .modal, .card, .content, body').first();
+    }
+
+    function findScopedElements(dtApi, selector) {
+        const $scopeRoot = getScopeRoot(dtApi);
+        const $scopedMatches = $scopeRoot.find(selector);
+        return $scopedMatches.length > 0 ? $scopedMatches : $(selector);
+    }
+
+    function getMenuContainer() {
+        return $('#' + MENU_ID);
+    }
+
+    function getMenuItems($menuContainer) {
+        return $menuContainer.find('.dt-context-menu-link:visible');
+    }
+
+    function focusMenuItem($menuContainer, index) {
+        const $items = getMenuItems($menuContainer);
+        if ($items.length === 0) {
+            return;
+        }
+
+        const normalizedIndex = ((index % $items.length) + $items.length) % $items.length;
+        $items.attr('tabindex', '-1');
+
+        const $target = $items.eq(normalizedIndex);
+        $target.attr('tabindex', '0').trigger('focus');
+        $menuContainer.data('activeIndex', normalizedIndex);
+    }
+
+    function focusFirstMenuItem($menuContainer) {
+        focusMenuItem($menuContainer, 0);
+    }
+
+    function rememberFocusTarget(element) {
+        const $menuContainer = getMenuContainer();
+        $menuContainer.data('returnFocus', element ?? null);
+    }
+
+    function restoreFocus() {
+        const $menuContainer = getMenuContainer();
+        const returnFocus = $menuContainer.data('returnFocus');
+        if (!returnFocus || typeof returnFocus.focus !== 'function') {
+            return;
+        }
+
+        const hadTabIndex = returnFocus.hasAttribute('tabindex');
+        if (!hadTabIndex) {
+            returnFocus.setAttribute('tabindex', '-1');
+        }
+
+        returnFocus.focus();
+
+        if (!hadTabIndex) {
+            returnFocus.addEventListener('blur', function cleanupFocusTarget() {
+                returnFocus.removeAttribute('tabindex');
+            }, { once: true });
+        }
+    }
+
+    function handleMenuKeydown(e) {
+        const $menuContainer = getMenuContainer();
+        const $items = getMenuItems($menuContainer);
+        const currentIndex = $items.index(globalThis.document.activeElement);
+
+        if ($items.length === 0) {
+            return;
+        }
+
+        switch (e.key) {
+            case 'ArrowDown':
+                e.preventDefault();
+                focusMenuItem($menuContainer, currentIndex + 1);
+                break;
+            case 'ArrowUp':
+                e.preventDefault();
+                focusMenuItem($menuContainer, currentIndex - 1);
+                break;
+            case 'Home':
+                e.preventDefault();
+                focusMenuItem($menuContainer, 0);
+                break;
+            case 'End':
+                e.preventDefault();
+                focusMenuItem($menuContainer, $items.length - 1);
+                break;
+            case 'Tab':
+                hideMenu();
+                break;
+            case ' ':
+                if (currentIndex > -1) {
+                    e.preventDefault();
+                    $items.eq(currentIndex).trigger('click');
+                }
+                break;
+            case 'Escape':
+                e.preventDefault();
+                hideMenu();
+                break;
+            default:
+                break;
+        }
+    }
+
+    function appendMenuAction($menuContainer, label, handler) {
+        $menuContainer.append(
+            $('<li class="dt-context-menu-item" role="none"></li>').append(
+                $('<a href="#" class="dt-context-menu-link" role="menuitem" tabindex="-1">')
+                    .text(label)
+                    .on('click', handler)
+                    .on('mouseover', function () {
+                        getMenuItems($menuContainer).blur(); // When mouse enters an item, remove focus from all items so :hover takes precedence
+                    })
+            )
+        );
+    }
+
+    function positionMenu($menuContainer, clientX, clientY) {
+        $menuContainer.css({
+            position: 'fixed',
+            display: 'block',
+            visibility: 'hidden',
+            zIndex: MENU_Z_INDEX
+        });
+
+        const menuWidth = $menuContainer.outerWidth() ?? 0;
+        const menuHeight = $menuContainer.outerHeight() ?? 0;
+        const maxLeft = Math.max(MENU_VIEWPORT_PADDING, globalThis.innerWidth - menuWidth - MENU_VIEWPORT_PADDING);
+        const maxTop = Math.max(MENU_VIEWPORT_PADDING, globalThis.innerHeight - menuHeight - MENU_VIEWPORT_PADDING);
+        const left = Math.min(Math.max(MENU_VIEWPORT_PADDING, clientX), maxLeft);
+        const top = Math.min(Math.max(MENU_VIEWPORT_PADDING, clientY), maxTop);
+
+        $menuContainer.css({
+            left: left + 'px',
+            top: top + 'px',
+            visibility: 'visible'
+        });
+    }
+
+    function showMenu($menuContainer, clientX, clientY, focusTarget) {
+        rememberFocusTarget(focusTarget);
+        positionMenu($menuContainer, clientX, clientY);
+        $menuContainer.attr('aria-hidden', 'false');
+        focusFirstMenuItem($menuContainer);
+    }
+
+    /**
+     * Handle filter column lookup and auto-population.
+     */
+    function handleFilterAction(e, $cell, dtApi) {
+        e.preventDefault();
+        hideMenu();
+
+        const cellText = ($cell.text() ?? '').trim();
+        const filterRow = getFilterRowPlugin(dtApi);
+
+        // Show the filter row if not already visible
+        filterRow?.show?.();
+
+        // Resolve the column name for the clicked cell
+        try {
+            const cellInfo = dtApi.cell($cell[0])?.index?.();
+            if (!cellInfo) {
+                return;
+            }
+
+            const colIdx = cellInfo.column;
+            const settings = dtApi.settings?.();
+            const aoColumns = settings?.[0]?.aoColumns;
+            if (!aoColumns?.[colIdx]) {
+                return;
+            }
+
+            const colName = aoColumns[colIdx].name;
+            if (!colName) {
+                return;
+            }
+
+            // Find the filter input for this column and set the value
+            const filterRowElement = getFilterRowElement(dtApi);
+            const $input = filterRowElement.find('input.custom-filter-input').filter(function () {
+                return $(this).data('column-name') === colName;
+            });
+
+            if ($input.length > 0) {
+                $input.val(cellText).trigger('keyup');
+            }
+        } catch (err) {
+            console.debug('Filter action error:', err);
+        }
+    }
+
+    /**
+     * Handle clear filter action.
+     */
+    function handleClearFilterAction(e, dtApi) {
+        e.preventDefault();
+        hideMenu();
+
+        const filterRow = getFilterRowPlugin(dtApi);
+        filterRow?.clearFilters?.();
+    }
+
+    /**
+     * Handle generic toolbar button click.
+     */
+    function handleToolbarButtonClick(e, $btn) {
+        e.preventDefault();
+        hideMenu();
+        $btn?.[0]?.click?.();
+    }
+
+    /**
+     * Check if a button is enabled (not hidden/disabled).
+     */
+    function isButtonEnabled($btn) {
+        return !$btn.hasClass('action-bar-btn-unavailable')
+            && !$btn.prop('disabled')
+            && !$btn.hasClass('d-none')
+            && !$btn.hasClass('dt-button-disabled');
+    }
+
+    /**
+     * Handle dismiss on outside click.
+     */
+    function dismissClickHandler(e) {
+        if (!$(e.target).closest('#' + MENU_ID).length) {
+            hideMenu();
+        }
+    }
+
+    /**
+     * Handle dismiss on scroll.
+     */
+    function dismissScrollHandler() {
+        hideMenu();
+    }
+
+    /**
+     * Handle row selection with callback.
+     */
+    function handleRowSelection(dtApi, rowIndex, callback) {
+        requestAnimationFrame(function () {
+            const selectedRows = dtApi.rows({ selected: true }).indexes();
+            if (!selectedRows.includes(rowIndex)) {
+                dtApi.rows({ selected: true }).deselect();
+                dtApi.row(rowIndex).select();
+            }
+            requestAnimationFrame(callback);
+        });
+    }
+
+    /**
+     * Hide the context menu and clean up event handlers.
+     */
+    function hideMenu() {
+        const $menuContainer = getMenuContainer();
+        if ($menuContainer.length > 0) {
+            $menuContainer
+                .hide()
+                .attr('aria-hidden', 'true')
+                .off('keydown.dt-context-menu')
+                .removeData('activeIndex');
+        }
+
+        $(document).off('click.dt-context-menu');
+        $(globalThis).off('scroll.dt-context-menu resize.dt-context-menu');
+
+        restoreFocus();
+    }
+
+    /**
+     * Copy text to clipboard with fallback.
+     */
+    function copyToClipboard(text) {
+        if (navigator.clipboard?.writeText) {
+            navigator.clipboard.writeText(text)
+                .then(() => {
+                    abp.notify.success((abp.localization.getResource('GrantManager')('DataTable:ContextMenu:CopiedToClipboard') ?? 'Copied to clipboard'),'Success');
+                })
+                .catch(() => {
+                    fallbackCopy(text);
+                });
+        } else {
+            fallbackCopy(text);
+        }
+    }
+
+    /**
+     * Fallback copy using textarea hack (legacy support).
+     */
+    function fallbackCopy(text) {
+        const $textarea = $('<textarea>')
+            .val(text)
+            .css({
+                position: 'fixed',
+                left: OFFSCREEN_OFFSET,
+                top: OFFSCREEN_OFFSET
+            })
+            .appendTo('body');
+
+        try {
+            $textarea[0]?.select?.();
+            const execCommand = document['execCommand']?.bind(document);
+            const success = execCommand ? execCommand('copy') : false;
+            if (success) {
+                abp.notify.success(
+                    (abp.localization.getResource('GrantManager')('DataTable:ContextMenu:CopiedToClipboard') ?? 'Copied to clipboard'),
+                    'Success'
+                );
+            } else {
+                abp.notify.error('Copy failed. Please try again.', 'Error');
+            }
+        } catch (err) {
+            console.debug('Fallback copy error:', err);
+            abp.notify.error('Copy failed. Please try again.', 'Error');
+        } finally {
+            $textarea.remove();
+        }
+    }
+
+    /**
+     * Add filter toolbar item to menu.
+     */
+    function addFilterItem(toolbarItems, labels, dtApi) {
+        const $filterBtn = getFilterButton(dtApi);
+        const filterRowPlugin = getFilterRowPlugin(dtApi);
+        if ($filterBtn.length > 0 && $filterBtn.is(':visible') && filterRowPlugin) {
+            toolbarItems.push({
+                label: labels.filter,
+                filterAction: true
+            });
+        }
+    }
+
+    /**
+     * Add clear filter toolbar item to menu if filters are active.
+     */
+    function addClearFilterItem(toolbarItems, labels, dtApi) {
+        const filterRowPlugin = getFilterRowPlugin(dtApi);
+        if (filterRowPlugin) {
+            const hasColumnFilters = getFilterInputs(dtApi).toArray().some(function (element) {
+                return Boolean($(element).val()?.trim?.());
+            });
+            const hasSearchFilter = Boolean(dtApi.search?.()?.trim?.());
+            const hasActiveFilters = hasColumnFilters || hasSearchFilter;
+
+            if (hasActiveFilters) {
+                toolbarItems.push({
+                    label: labels.clearFilter,
+                    clearFilterAction: true
+                });
+            }
+        }
+    }
+
+    /**
+     * Render filter menu item.
+     */
+    function renderFilterMenuItem($menuContainer, item, $cell, dtApi) {
+        appendMenuAction($menuContainer, item.label, function (e) {
+            handleFilterAction(e, $cell, dtApi);
+        });
+    }
+
+    /**
+     * Render clear filter menu item.
+     */
+    function renderClearFilterMenuItem($menuContainer, item, dtApi) {
+        appendMenuAction($menuContainer, item.label, function (e) {
+            handleClearFilterAction(e, dtApi);
+        });
+    }
+
+    /**
+     * Render toolbar button menu item.
+     */
+    function renderToolbarButtonMenuItem($menuContainer, item) {
+        appendMenuAction($menuContainer, item.label, function (e) {
+            handleToolbarButtonClick(e, item.$btn);
+        });
+    }
+
+    /**
+     * Render custom action menu item.
+     */
+    function renderCustomActionMenuItem($menuContainer, $btn, btnText) {
+        appendMenuAction($menuContainer, btnText, function (e) {
+            handleToolbarButtonClick(e, $btn);
+        });
+    }
+
+    /**
+     * Initialize a context menu for a DataTable.
+     * Features:
+     * - Right-click selection: if row not selected, select it; if already selected, keep selection
+     * - Copy: copies the right-clicked cell's rendered text to clipboard
+     * - Toolbar items: Filtering
+     * - Custom actions: mirrors visible/enabled ActionBar buttons
+     * 
+     * @param {DataTables.Api} dtApi - The initialized DataTable API instance
+     * @param {Object} options - Configuration options
+     * @param {boolean} [options.enabled=true] - Whether context menu is enabled
+     * @param {string} [options.actionsSelector='[data-selector$="-table-actions"]'] - Selector for custom action buttons
+     * @param {boolean} [options.copyEnabled=true] - Whether Copy action is available
+     * @param {Object} [options.labels={}] - Localization overrides { copy, filter, clearFilter }
+     */
+    globalThis.initializeTableContextMenu = function (dtApi, options) {
+        options = options ?? {};
+
+        const enabled = options.enabled !== false;
+        const actionsSelector = options.actionsSelector ?? '[data-selector$="-table-actions"]';
+        const copyEnabled = options.copyEnabled !== false;
+        const labels = options.labels ?? {};
+
+        if (!enabled || !dtApi?.table) {
+            return;
+        }
+
+        // Initialize labels with defaults
+        const l = abp.localization.getResource('GrantManager');
+        const defaultLabels = {
+            copy: l('DataTable:ContextMenu:Copy') ?? 'Copy',
+            filter: l('DataTable:ContextMenu:Filter') ?? 'Filter',
+            clearFilter: l('DataTable:ContextMenu:ClearFilter') ?? 'Clear Filters'
+        };
+
+        const finalLabels = $.extend({}, defaultLabels, labels);
+
+        // Create menu container (single, reused)
+        let $menuContainer = getMenuContainer();
+        if ($menuContainer.length === 0) {
+            $menuContainer = $('<ul id="dt-context-menu" class="dt-context-menu" style="display: none;" role="menu" aria-hidden="true"></ul>');
+            $('body').append($menuContainer);
+        }
+
+        // Event handler for right-click on table
+        const dtBody = dtApi.table()?.body?.();
+        if (dtBody) {
+            $(dtBody).off('contextmenu.dt-context-menu').on('contextmenu.dt-context-menu', function (e) {
+                // Allow browser's default context menu when Ctrl is held
+                if (e.ctrlKey) {
+                    return;
+                }
+
+                e.preventDefault();
+                e.stopPropagation();
+
+                const $cell = $(e.target).closest('td, th');
+                if ($cell.length === 0) {
+                    return;
+                }
+
+                const $row = $cell.closest('tr');
+                const rowNode = $row[0];
+                if (!rowNode) {
+                    return;
+                }
+
+                const rowIndex = dtApi.row(rowNode)?.index?.();
+                if (rowIndex === undefined || rowIndex === -1) {
+                    return;
+                }
+
+                handleRowSelection(dtApi, rowIndex, () => {
+                    buildAndShowMenu(e.clientX, e.clientY, $cell, dtApi, finalLabels, actionsSelector, copyEnabled);
+                });
+            });
+        }
+
+        /**
+         * Build and display the context menu at the given coordinates.
+         */
+        function buildAndShowMenu(pageX, pageY, $cell, dtApi, labels, actionsSelector, copyEnabled) {
+            const $menuContainer = getMenuContainer();
+            $menuContainer.empty();
+
+            // Copy
+            if (copyEnabled) {
+                const cellText = ($cell.text() ?? '').trim();
+                appendMenuAction($menuContainer, labels.copy, function (e) {
+                    e.preventDefault();
+                    copyToClipboard(cellText);
+                    hideMenu();
+                });
+            }
+
+            // Toolbar
+            const toolbarItems = [];
+
+            addFilterItem(toolbarItems, labels, dtApi);
+            addClearFilterItem(toolbarItems, labels, dtApi);
+
+            if (toolbarItems.length > 0) {
+                if (copyEnabled)
+                    $menuContainer.append($('<li class="dt-context-menu-separator"></li>'));
+
+                toolbarItems.forEach(function (item) {
+                    if (item.filterAction) {
+                        renderFilterMenuItem($menuContainer, item, $cell, dtApi);
+                    } else if (item.clearFilterAction) {
+                        renderClearFilterMenuItem($menuContainer, item, dtApi);
+                    } else if (item.$btn?.length > 0) {
+                        renderToolbarButtonMenuItem($menuContainer, item);
+                    }
+                });
+            }
+
+            // Custom Actions (ActionBar buttons)
+            const $customBtns = findScopedElements(dtApi, actionsSelector).filter(function () {
+                return isButtonEnabled($(this));
+            });
+
+            if ($customBtns.length > 0) {
+                if (copyEnabled || toolbarItems.length > 0)
+                    $menuContainer.append($('<li class="dt-context-menu-separator"></li>'));
+
+                $customBtns.each(function () {
+                    const $btn = $(this);
+                    const btnText = ($btn.text() ?? '').trim();
+
+                    if (btnText?.length > 0) {
+                        renderCustomActionMenuItem($menuContainer, $btn, btnText);
+                    }
+                });
+            }
+
+            // Attach event handlers
+            $(document).off('click.dt-context-menu').on('click.dt-context-menu', dismissClickHandler);
+            $(globalThis)
+                .off('scroll.dt-context-menu resize.dt-context-menu')
+                .on('scroll.dt-context-menu', dismissScrollHandler)
+                .on('resize.dt-context-menu', dismissScrollHandler);
+            $menuContainer.off('keydown.dt-context-menu').on('keydown.dt-context-menu', handleMenuKeydown);
+
+            showMenu($menuContainer, pageX, pageY, $cell[0]);
+        }
+    };
+
+}(jQuery));

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/table-utils.js
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/table-utils.js
@@ -230,7 +230,10 @@ function initializeDataTable(options) {
         onStateLoaded,
         fixedHeaders = false,
         lengthMenu = [25, 50, 75, 100, -1],
-        deferRender = false
+        deferRender = false,
+        enableContextMenu = false,
+        contextMenuActionsSelector = '[data-selector$="-table-actions"]',
+        contextMenuLabels = {}
     } = options;
 
     // Process columns and visibility
@@ -451,6 +454,16 @@ function initializeDataTable(options) {
     // Initialize ScrollResize plugin for dynamic scroll body sizing
     if (fixedHeaders && DataTable.ScrollResize) {
         iDt.settings()[0]._scrollResize = new DataTable.ScrollResize(iDt);
+    }
+
+    // Initialize Context Menu plugin if enabled
+    if (enableContextMenu && typeof window.initializeTableContextMenu === 'function') {
+        initializeTableContextMenu(iDt, {
+            enabled: true,
+            actionsSelector: contextMenuActionsSelector,
+            copyEnabled: true,
+            labels: contextMenuLabels
+        });
     }
 
     return iDt;

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/table-utils.js
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/table-utils.js
@@ -457,7 +457,7 @@ function initializeDataTable(options) {
     }
 
     // Initialize Context Menu plugin if enabled
-    if (enableContextMenu && typeof window.initializeTableContextMenu === 'function') {
+    if (enableContextMenu && typeof globalThis.initializeTableContextMenu === 'function') {
         initializeTableContextMenu(iDt, {
             enabled: true,
             actionsSelector: contextMenuActionsSelector,

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain.Shared/Localization/GrantManager/en.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain.Shared/Localization/GrantManager/en.json
@@ -573,6 +573,11 @@
     "TenantList:ConfigurationAction": "Configuration",
     "TenantList:LicencePlate": "Licence Plate",
     "TenantList:CasClientCode": "CAS Client Code",
-    "TenantList:SearchMinChars": "Please enter at least 2 characters to search."
+    "TenantList:SearchMinChars": "Please enter at least 2 characters to search.",
+
+    "DataTable:ContextMenu:Copy": "Copy",
+    "DataTable:ContextMenu:CopiedToClipboard": "Copied to clipboard",
+    "DataTable:ContextMenu:Filter": "Filter",
+    "DataTable:ContextMenu:ClearFilter": "Clear Filters"
   }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Applicants/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Applicants/Index.js
@@ -607,9 +607,10 @@ $(function () {
                 }
             }
             return null;
-        }
+        },
+        enableContextMenu: true,
+        contextMenuActionsSelector: '[data-selector="applicants-table-actions"]'
     });
-
 
     // Handle row selection and publish events for ActionBar
     dataTable.on('select', function (e, dt, type, indexes) {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Index.js
@@ -128,7 +128,9 @@
         dynamicButtonContainerId: 'dynamicButtonContainerId',
         useNullPlaceholder: true,
         externalSearchId: 'search-forms',
-        fixedHeaders: true
+        fixedHeaders: true,
+        enableContextMenu: true,
+        contextMenuActionsSelector: '[data-selector="forms-table-actions"]'
     });
 
     createModal.onResult(function () {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Index.js
@@ -462,7 +462,9 @@ $(function () {
                     dtApi.ajax.reload(null, false);
                 }
                 initialLoad = false; // Reset flag after use
-            }
+            },
+            enableContextMenu: true,
+            contextMenuActionsSelector: '[data-selector="applications-table-actions"]'
         });
 
         dataTable.on('select', function (e, dt, type, indexes) {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantPrograms/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantPrograms/Index.js
@@ -61,7 +61,9 @@
         dataTableName: 'UserGrantProgramsTable',
         dynamicButtonContainerId: 'dynamicButtonContainerId',
         externalSearchId: 'search-grant-programs',
-        disableColumnSelect: true
+        disableColumnSelect: true,
+        enableContextMenu: true,
+        contextMenuActionsSelector: '[data-selector="programs-table-actions"]'
     });
 });
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Intakes/Index.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Intakes/Index.js
@@ -108,7 +108,9 @@
         dynamicButtonContainerId: 'dynamicButtonContainerId',
         useNullPlaceholder: true,
         externalSearchId: 'search-intakes',
-        fixedHeaders: true
+        fixedHeaders: true,
+        enableContextMenu: true,
+        contextMenuActionsSelector: '[data-selector="intakes-table-actions"]'
     });
 
     createModal.onResult(function () {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/PaymentHistory/Details.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/PaymentHistory/Details.js
@@ -42,6 +42,8 @@
         dataTableName: 'AuditHistoryTable',
         dynamicButtonContainerId: 'dynamicButtonContainerId',
         externalSearchId: 'search-payment-history',
+        enableContextMenu: true,
+        contextMenuActionsSelector: '[data-selector="paymenthistory-table-actions"]'
     });
 
     function getColumns() {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicantsActionBar/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicantsActionBar/Default.cshtml
@@ -26,6 +26,7 @@
         {
             <abp-button id="mergeApplicants"
                         text="Merge"
+                        data-selector="applicants-table-actions"
                         class="custom-table-btn flex-none btn btn-secondary d-none"
                         button-type="Secondary" />
         }


### PR DESCRIPTION
Custom context menu can be added to any data table, via their options:
        enableContextMenu = false,
        contextMenuActionsSelector = '[data-selector$="-table-actions"]',
        contextMenuLabels = {}

Default functionality is right click will also select the current row being hovered.
If an UNSELECTED row is right-clicked, all selections will be cleared and only the current row selected. If an already SELECTED row is right-clicked, then all of the current selection remains so that the context menu will affect all currently selected rows.

Default actions included:
Copy: Copies current cell value to clipboard
Filter: Applies current cell value to the filter row, if filter row plugin enabled
Clear Filters: Clears all filter row values
Custom Actions: Context menu actions uses the data-selector property  to determine the custom action buttons associated with a data table. Visibility and logic remains purely with the buttons / actions themselves.

Includes accessibility features of keyboard navigation

To bypass the custom context menu, CTRL-Rightclick will open the browser's default context menu

Tables with the new context menu set:
-PaymentRequests
--PaymentHistory
-GrantApplicants
-GrantApplications
-ApplicationForms
-GrantPrograms
-Intakes
