### PR TITLE
AB#33749 simplify AI text normalization

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Extraction/TextExtractionService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Extraction/TextExtractionService.cs
@@ -61,7 +61,7 @@ namespace Unity.AI.Extraction
                     _ => ExtractByContentType(fileName, fileContent, normalizedContentType, cancellationToken)
                 };
 
-                return Task.FromResult(NormalizeAndLimitText(rawText, fileName));
+                return Task.FromResult(NormalizeAndLimitText(rawText));
             }
             catch (OperationCanceledException)
             {
@@ -656,7 +656,7 @@ namespace Unity.AI.Extraction
             }) ?? string.Empty;
         }
 
-        private string NormalizeAndLimitText(string text, string fileName)
+        private string NormalizeAndLimitText(string text)
         {
             var normalized = NormalizeExtractedText(text);
 

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Extraction/TextExtractionService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Extraction/TextExtractionService.cs
@@ -659,7 +659,6 @@ namespace Unity.AI.Extraction
         private string NormalizeAndLimitText(string text, string fileName)
         {
             var normalized = NormalizeExtractedText(text);
-            normalized = RemoveLeadingFileNameArtifact(normalized, fileName);
 
             if (normalized.Length > MaxExtractedTextLength)
             {
@@ -681,66 +680,12 @@ namespace Unity.AI.Extraction
                 .Replace("\r\n", "\n")
                 .Replace('\r', '\n');
 
-            normalized = LowerToUpperWordBoundaryRegex().Replace(normalized, " ");
-            normalized = PunctuationToWordBoundaryRegex().Replace(normalized, " ");
-            normalized = ColonDashSpacingRegex().Replace(normalized, ": - ");
-            normalized = HyphenSpacingRegex().Replace(normalized, " - ");
-            normalized = KeywordBoundaryRegex().Replace(normalized, " ");
             normalized = MultipleSpacesRegex().Replace(normalized, " ");
             normalized = NewlineWhitespaceRegex().Replace(normalized, "\n");
             normalized = MultipleNewlinesRegex().Replace(normalized, "\n");
 
             return normalized.Trim();
         }
-
-        private static string RemoveLeadingFileNameArtifact(string text, string fileName)
-        {
-            if (string.IsNullOrWhiteSpace(text) || string.IsNullOrWhiteSpace(fileName))
-            {
-                return text;
-            }
-
-            var rawStem = Path.GetFileNameWithoutExtension(fileName)?.Trim();
-            if (string.IsNullOrWhiteSpace(rawStem))
-            {
-                return text;
-            }
-
-            var decodedStem = Uri.UnescapeDataString(rawStem);
-            foreach (var candidate in new[] { rawStem, decodedStem })
-            {
-                if (string.IsNullOrWhiteSpace(candidate))
-                {
-                    continue;
-                }
-
-                if (text.StartsWith(candidate, StringComparison.OrdinalIgnoreCase))
-                {
-                    var stripped = text.Substring(candidate.Length).TrimStart(' ', '-', ':', '.', '\t');
-                    if (!string.IsNullOrWhiteSpace(stripped))
-                    {
-                        return stripped;
-                    }
-                }
-            }
-
-            return text;
-        }
-
-        [GeneratedRegex(@"(?<=[a-z])(?=[A-Z])")]
-        private static partial Regex LowerToUpperWordBoundaryRegex();
-
-        [GeneratedRegex(@"(?<=[\.\,\:\;\)])(?=[A-Za-z0-9])")]
-        private static partial Regex PunctuationToWordBoundaryRegex();
-
-        [GeneratedRegex(@":-")]
-        private static partial Regex ColonDashSpacingRegex();
-
-        [GeneratedRegex(@"(?<=\S)- (?=[A-Za-z])")]
-        private static partial Regex HyphenSpacingRegex();
-
-        [GeneratedRegex(@"(?<=[a-z])(?=(project|funding|budget|community|summary|notes|details|planning|outcomes|background|services)\b)", RegexOptions.IgnoreCase)]
-        private static partial Regex KeywordBoundaryRegex();
 
         [GeneratedRegex(@"[ \t]+")]
         private static partial Regex MultipleSpacesRegex();


### PR DESCRIPTION
## Summary
- Simplifies AI text normalization by removing the regex rewrites that were splitting proper nouns and mixed-case words.
- Keeps only the basic cleanup path so attachment summaries are less likely to silently corrupt names.

## Validation
- Reviewed the final diff on the branch.
