### PR TITLE
AB#33751 dbmigrator configuration

### DIFF
--- a/applications/Unity.GrantManager/.dockerignore
+++ b/applications/Unity.GrantManager/.dockerignore
@@ -3,6 +3,9 @@
 # these files in the first place, since they are gitignored).
 **/appsettings.secrets.json
 **/appsettings.Development.json
+**/.env
+**/.env.*
+**/*.env
 
 # Build artifacts and local tooling state - not needed in the build
 # context and only bloat it / risk copying stale output.

--- a/applications/Unity.GrantManager/.dockerignore
+++ b/applications/Unity.GrantManager/.dockerignore
@@ -1,0 +1,13 @@
+# Local secrets must never end up in a Docker build context / image,
+# even for a locally-run `docker build` outside of CI (which never has
+# these files in the first place, since they are gitignored).
+**/appsettings.secrets.json
+**/appsettings.Development.json
+
+# Build artifacts and local tooling state - not needed in the build
+# context and only bloat it / risk copying stale output.
+**/bin/
+**/obj/
+**/node_modules/
+.git/
+.vs/

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.DbMigrator/README.md
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.DbMigrator/README.md
@@ -16,7 +16,8 @@ Host.CreateDefaultBuilder(args)
     ...
 ```
 
-`AddAppSettingsSecretsJson()` is a helper from the ABP Framework (`Volo.Abp.Core`) that adds an **optional** `appsettings.secrets.json` file to the configuration pipeline. Because it's chained onto the host builder after `Host.CreateDefaultBuilder` has already added its default sources, it loads *after* environment variables and command-line arguments — so any value it defines will override an environment variable of the same key. This is the supported way to layer local secrets on top of whatever environment configuration is already in place.
+`AddAppSettingsSecretsJson()` is a helper from the ABP Framework (`Volo.Abp.Core`) that adds an **optional** `appsettings.secrets.json` file to the configuration pipeline. Because it's chained onto the host builder after `Host.CreateDefaultBuilder` has already added its default sources, it loads *after* those sources (including environment variables and command-line arguments).
+As a result, any value it defines will override values from earlier providers (including env vars and command-line) when the keys match.
 
 Create an `appsettings.secrets.json` file in this project directory with your local connection strings and any other overrides:
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.DbMigrator/README.md
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.DbMigrator/README.md
@@ -6,43 +6,41 @@ This project is responsible for running database migrations for the Unity Grant 
 
 The `appsettings.json` file in this project intentionally excludes sensitive information like database passwords to comply with security best practices and avoid SonarQube or Copilot warnings about checking credentials into source control.
 
-### Option 1: Using appsettings.Development.json (Recommended for Local Development)
+### appsettings.secrets.json (used by this project)
 
-Create an `appsettings.Development.json` file in the DbMigrator project directory with your connection strings including passwords:
+`Program.cs` wires configuration up with:
+
+```csharp
+Host.CreateDefaultBuilder(args)
+    .AddAppSettingsSecretsJson()
+    ...
+```
+
+`AddAppSettingsSecretsJson()` is a helper from the ABP Framework (`Volo.Abp.Core`) that adds an **optional** `appsettings.secrets.json` file to the configuration pipeline. Because it's chained onto the host builder after `Host.CreateDefaultBuilder` has already added its default sources, it loads *after* environment variables and command-line arguments — so any value it defines will override an environment variable of the same key. This is the supported way to layer local secrets on top of whatever environment configuration is already in place.
+
+Create an `appsettings.secrets.json` file in this project directory with your local connection strings and any other overrides:
 
 ```json
 {
-  "ConnectionStrings": {    
+  "ConnectionStrings": {
     "Default": "Host=localhost;port=5432;Database=UnityGrantManager;Username=postgres;Password=your_password_here",
-    "Tenant": "Host=localhost;port=5432;Database=UnityGrantTenant;Username=postgres;Password=your_password_here"
+    "Tenant": "Host=localhost;port=5432;Database=UnityGrantTenant;Username=postgres;Password=your_password_here",
+    "Onboarding": "Host=localhost;port=5432;Database=UnityOnboarding;Username=postgres;Password=your_password_here"
   }
 }
 ```
 
-**Note:** This file is excluded from git via `.gitignore` to keep your credentials secure.
+**Note:** This file is excluded from git via the root [`.gitignore`](../../../../.gitignore) (`/applications/Unity.GrantManager/src/Unity.GrantManager.DbMigrator/appsettings.secrets.json`), so your local credentials are never committed. The `Unity.GrantManager.Web` project uses the same mechanism and has its own gitignore entry for its own `appsettings.secrets.json`.
 
-### Option 2: Using User Secrets
+Because the file is optional, its absence is not an error — omit it entirely if you're configuring everything through environment variables instead.
 
-Alternatively, you can use .NET User Secrets to store sensitive configuration:
+### Production / CI builds
 
-1. Right-click on the `Unity.GrantManager.DbMigrator` project in Visual Studio
-2. Select "Manage User Secrets"
-3. Add your connection strings with passwords:
-
-```json
-{
-  "ConnectionStrings": {    
-    "Default": "Host=localhost;port=5432;Database=UnityGrantManager;Username=postgres;Password=your_password_here",
-    "Tenant": "Host=localhost;port=5432;Database=UnityGrantTenant;Username=postgres;Password=your_password_here"
-  }
-}
-```
-
-User secrets are stored outside of your project directory and are never checked into source control.
+`appsettings.secrets.json` is **not** referenced anywhere in `Unity.GrantManager.DbMigrator.csproj` (unlike `appsettings.json`, which is explicitly included with `CopyToOutputDirectory`), so even if the file exists on a machine building this project, it is not copied into the build or publish output. Combined with the file being gitignored — meaning a fresh CI checkout never has it on disk in the first place — there's no path for local secrets to leak into a DbMigrator build or the resulting Docker image.
 
 ## Running the Migrator
 
-Once you've configured your connection strings using either option above, you can run the migrator:
+Once you've configured your connection strings via `appsettings.secrets.json` (or environment variables), you can run the migrator:
 
 ```bash
 dotnet run

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.DbMigrator/Unity.GrantManager.DbMigrator.csproj
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.DbMigrator/Unity.GrantManager.DbMigrator.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
-    <Nullable>enable</Nullable>    
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,10 +13,10 @@
     <Content Include="appsettings.json">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>    
+    </Content>
   </ItemGroup>
 
-  <ItemGroup>    
+  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.DbMigrator/Unity.GrantManager.DbMigrator.csproj
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.DbMigrator/Unity.GrantManager.DbMigrator.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\common.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
-    <Nullable>enable</Nullable>
+    <Nullable>enable</Nullable>    
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,8 +13,7 @@
     <Content Include="appsettings.json">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <None Remove="appsettings.secrets.json" />
+    </Content>    
   </ItemGroup>
 
   <ItemGroup>    

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.DbMigrator/appsettings.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.DbMigrator/appsettings.json
@@ -2,7 +2,7 @@
   "ConnectionStrings": {
     "Default": "Host=localhost;port=5432;Database=UnityGrantManager;Username=postgres;",
     "Tenant": "Host=localhost;port=5432;Database=UnityGrantTenant;Username=postgres;",
-    "Onboarding": "Host=localhost;port=5432;Database=Onboarding;Username=postgres;"
+    "Onboarding": "Host=localhost;port=5432;Database=UnityOnboarding;Username=postgres;"
   },
   "StringEncryption": {
     "DefaultPassPhrase": "g2IuZx7PwXDvCmlW"


### PR DESCRIPTION
## Pull request overview

Updates the Unity Grant Manager DbMigrator’s local/CI configuration story to use `appsettings.secrets.json` and reduces the risk of secrets being included in Docker build contexts.

**Changes:**
- Document DbMigrator local secrets setup using ABP’s `AddAppSettingsSecretsJson()` and provide an example `appsettings.secrets.json`.
- Adjust DbMigrator configuration defaults (Onboarding DB name) and simplify csproj handling around appsettings files.
- Add an `applications/Unity.GrantManager/.dockerignore` to prevent local secrets/config from being sent in Docker build context.

### Reviewed changes

Copilot reviewed 4 out of 4 changed files in this pull request and generated 4 comments.

| File | Description |
| ---- | ----------- |
| applications/Unity.GrantManager/src/Unity.GrantManager.DbMigrator/Unity.GrantManager.DbMigrator.csproj | Tweaks appsettings content inclusion; minor formatting changes. |
| applications/Unity.GrantManager/src/Unity.GrantManager.DbMigrator/README.md | Replaces local setup guidance to use `appsettings.secrets.json` and explains configuration layering. |
| applications/Unity.GrantManager/src/Unity.GrantManager.DbMigrator/appsettings.json | Updates the Onboarding connection string database name. |
| applications/Unity.GrantManager/.dockerignore | Adds Docker build-context exclusions for local secrets and build artifacts. |




