### PR TITLE
AB#32666 move AI persistence ownership to AI module

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIPromptTemplateProvider.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIPromptTemplateProvider.cs
@@ -1,41 +1,17 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Unity.AI.Domain;
 using Volo.Abp.DependencyInjection;
-using Volo.Abp.Data;
-using Volo.Abp.Domain.Repositories;
-using Volo.Abp.MultiTenancy;
 
 namespace Unity.AI.Runtime;
 
 public class AIPromptTemplateProvider(
-    IRepository<AIPrompt, Guid> promptRepository,
-    IDataFilter<IMultiTenant> multiTenantDataFilter) : IAIPromptTemplateProvider, ITransientDependency
+    IAIPromptTemplateStore promptTemplateStore) : IAIPromptTemplateProvider, ITransientDependency
 {
     public async Task<AIPromptTemplateSnapshot> GetRequiredPromptAsync(
         string promptType,
         string promptVersion,
         CancellationToken cancellationToken = default)
     {
-        var normalizedPromptVersion = OpenAIPromptRenderer.ResolvePromptVersion(promptVersion);
-        var versionNumber = OpenAIPromptRenderer.ResolvePromptVersionNumber(normalizedPromptVersion);
-
-        using (multiTenantDataFilter.Disable())
-        {
-            var prompt = await promptRepository.FindAsync(p =>
-                p.TenantId == null && p.Name == promptType && p.VersionNumber == versionNumber);
-            if (prompt == null || !prompt.IsActive)
-            {
-                throw new InvalidOperationException(
-                    $"AI prompt '{promptType}' version '{normalizedPromptVersion}' is not configured.");
-            }
-
-            return new AIPromptTemplateSnapshot(
-                normalizedPromptVersion,
-                prompt.SystemPrompt,
-                prompt.UserPrompt,
-                prompt.MetadataJson);
-        }
+        return await promptTemplateStore.GetRequiredPromptAsync(promptType, promptVersion, cancellationToken);
     }
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIPromptTemplateProvider.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIPromptTemplateProvider.cs
@@ -7,11 +7,9 @@ namespace Unity.AI.Runtime;
 public class AIPromptTemplateProvider(
     IAIPromptTemplateStore promptTemplateStore) : IAIPromptTemplateProvider, ITransientDependency
 {
-    public async Task<AIPromptTemplateSnapshot> GetRequiredPromptAsync(
+    public Task<AIPromptTemplateSnapshot> GetRequiredPromptAsync(
         string promptType,
         string promptVersion,
         CancellationToken cancellationToken = default)
-    {
-        return await promptTemplateStore.GetRequiredPromptAsync(promptType, promptVersion, cancellationToken);
-    }
+        => promptTemplateStore.GetRequiredPromptAsync(promptType, promptVersion, cancellationToken);
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIPromptTemplateStore.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIPromptTemplateStore.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Unity.AI.Domain;
+using Volo.Abp.Data;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.MultiTenancy;
+
+namespace Unity.AI.Runtime;
+
+public class AIPromptTemplateStore(
+    IRepository<AIPrompt, Guid> promptRepository,
+    IDataFilter<IMultiTenant> multiTenantDataFilter) : IAIPromptTemplateStore, ITransientDependency
+{
+    public async Task<AIPromptTemplateSnapshot> GetRequiredPromptAsync(
+        string promptType,
+        string promptVersion,
+        CancellationToken cancellationToken = default)
+    {
+        var normalizedPromptVersion = OpenAIPromptRenderer.ResolvePromptVersion(promptVersion);
+        var versionNumber = OpenAIPromptRenderer.ResolvePromptVersionNumber(normalizedPromptVersion);
+
+        using (multiTenantDataFilter.Disable())
+        {
+            var prompt = await promptRepository.FindAsync(p =>
+                p.TenantId == null && p.Name == promptType && p.VersionNumber == versionNumber);
+            if (prompt == null || !prompt.IsActive)
+            {
+                throw new InvalidOperationException(
+                    $"AI prompt '{promptType}' version '{normalizedPromptVersion}' is not configured.");
+            }
+
+            return new AIPromptTemplateSnapshot(
+                normalizedPromptVersion,
+                prompt.SystemPrompt,
+                prompt.UserPrompt,
+                prompt.MetadataJson);
+        }
+    }
+}

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIPromptTemplateStore.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/AIPromptTemplateStore.cs
@@ -24,7 +24,8 @@ public class AIPromptTemplateStore(
         using (multiTenantDataFilter.Disable())
         {
             var prompt = await promptRepository.FindAsync(p =>
-                p.TenantId == null && p.Name == promptType && p.VersionNumber == versionNumber);
+                p.TenantId == null && p.Name == promptType && p.VersionNumber == versionNumber,
+                cancellationToken: cancellationToken);
             if (prompt == null || !prompt.IsActive)
             {
                 throw new InvalidOperationException(

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/IAIPromptTemplateProvider.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/IAIPromptTemplateProvider.cs
@@ -1,5 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Unity.AI.Runtime;
 
-public interface IAIPromptTemplateProvider : IAIPromptTemplateStore
+public interface IAIPromptTemplateProvider
 {
+    Task<AIPromptTemplateSnapshot> GetRequiredPromptAsync(
+        string promptType,
+        string promptVersion,
+        CancellationToken cancellationToken = default);
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/IAIPromptTemplateProvider.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/IAIPromptTemplateProvider.cs
@@ -1,12 +1,5 @@
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Unity.AI.Runtime;
 
-public interface IAIPromptTemplateProvider
+public interface IAIPromptTemplateProvider : IAIPromptTemplateStore
 {
-    Task<AIPromptTemplateSnapshot> GetRequiredPromptAsync(
-        string promptType,
-        string promptVersion,
-        CancellationToken cancellationToken = default);
 }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/IAIPromptTemplateStore.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/AI/Runtime/IAIPromptTemplateStore.cs
@@ -1,0 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Unity.AI.Runtime;
+
+public interface IAIPromptTemplateStore
+{
+    Task<AIPromptTemplateSnapshot> GetRequiredPromptAsync(
+        string promptType,
+        string promptVersion,
+        CancellationToken cancellationToken = default);
+}

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/AIPromptTemplateProviderTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/Runtime/AIPromptTemplateProviderTests.cs
@@ -1,11 +1,11 @@
 using NSubstitute;
 using Shouldly;
 using System;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Unity.AI.Domain;
 using Unity.AI.Prompts;
 using Unity.AI.Runtime;
-using Unity.AI;
 using Volo.Abp.Data;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.MultiTenancy;
@@ -16,7 +16,25 @@ namespace Unity.GrantManager.AI.Runtime;
 public class AIPromptTemplateProviderTests
 {
     [Fact]
-    public async Task GetRequiredPromptAsync_Should_Return_Prompt_Definition_From_Database()
+    public async Task GetRequiredPromptAsync_Should_Delegate_To_Store()
+    {
+        var store = Substitute.For<IAIPromptTemplateStore>();
+        store.GetRequiredPromptAsync(AIPromptTypes.ApplicationAnalysis, "v1", default)
+            .Returns(new AIPromptTemplateSnapshot("v1", "SYSTEM", "USER", "{\"RULES\":\"- rule\"}"));
+
+        var provider = new AIPromptTemplateProvider(store);
+
+        var snapshot = await provider.GetRequiredPromptAsync(AIPromptTypes.ApplicationAnalysis, "v1");
+
+        snapshot.PromptVersion.ShouldBe("v1");
+        snapshot.SystemPrompt.ShouldBe("SYSTEM");
+        snapshot.UserPrompt.ShouldBe("USER");
+        snapshot.MetadataJson.ShouldBe("{\"RULES\":\"- rule\"}");
+        await store.Received(1).GetRequiredPromptAsync(AIPromptTypes.ApplicationAnalysis, "v1", default);
+    }
+
+    [Fact]
+    public async Task GetRequiredPromptAsync_Should_Return_Prompt_Definition_From_Store()
     {
         var prompt = new AIPrompt(
             Guid.NewGuid(),
@@ -57,13 +75,14 @@ public class AIPromptTemplateProviderTests
         var multiTenantDataFilter = Substitute.For<IDataFilter<IMultiTenant>>();
         multiTenantDataFilter.Disable().Returns(Substitute.For<IDisposable>());
 
-        promptRepository.FindAsync(Arg.Any<System.Linq.Expressions.Expression<Func<AIPrompt, bool>>>())
+        promptRepository.FindAsync(Arg.Any<Expression<Func<AIPrompt, bool>>>())
             .Returns(callInfo =>
             {
-                var predicate = callInfo.Arg<System.Linq.Expressions.Expression<Func<AIPrompt, bool>>>();
+                var predicate = callInfo.Arg<Expression<Func<AIPrompt, bool>>>();
                 return Task.FromResult(prompt != null && predicate.Compile()(prompt) ? prompt : null);
             });
 
-        return new AIPromptTemplateProvider(promptRepository, multiTenantDataFilter);
+        var store = new AIPromptTemplateStore(promptRepository, multiTenantDataFilter);
+        return new AIPromptTemplateProvider(store);
     }
 }


### PR DESCRIPTION
## Summary
- Split the AI prompt persistence lookup behind a module-owned store.
- Keep the runtime provider as a thin delegator so the persistence boundary is explicit.

## Validation
- dotnet test applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/Unity.GrantManager.Application.Tests.csproj --filter "FullyQualifiedName~AIPromptTemplateProviderTests"
