### PR TITLE
feature/AB#33552 - Add External Status Visibility to the Audit History

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.SharedKernel/Utils/DateTimeExtensions.cs
+++ b/applications/Unity.GrantManager/modules/Unity.SharedKernel/Utils/DateTimeExtensions.cs
@@ -5,8 +5,10 @@ using System.Runtime.InteropServices;
 namespace Unity.Modules.Shared.Utils;
 public static class DateTimeExtensions
 {
-    // BC Pacific timezone: PST does NOT observe DST in 2026 — fixed UTC-8 year-round.
-    private static readonly TimeSpan BcPstOffset = TimeSpan.FromHours(-8);
+    // BC Pacific timezone: PST/PDT depending on time of year.
+    private const string WindowsPacificId = "Pacific Standard Time";
+    private const string IanaPacificId = "America/Vancouver";
+    private static readonly Lazy<TimeZoneInfo> PacificTimeZone = new(GetPacificTimeZone, isThreadSafe: true);
 
     // BC Mountain timezone: Peace River / NE BC region — MST/MDT, DST still applies.
     private const string WindowsMountainId = "Mountain Standard Time";
@@ -29,13 +31,11 @@ public static class DateTimeExtensions
     }
 
     /// <summary>
-    /// Converts a given UTC time to BC Pacific Standard Time and formats it as a string.
-    /// BC's Pacific timezone does NOT observe Daylight Saving Time in 2026; PST (UTC-8)
-    /// is applied year-round. For the Peace River / NE BC region (Mountain Time), use
-    /// <see cref="FormatMountainTime"/> instead.
+    /// Converts a given UTC time to BC Pacific Time and formats it as a string.
+    /// Added support for historic PST rendering.
     /// </summary>
     /// <param name="utcTime">The UTC time to convert. If <see langword="null"/>, an empty string is returned.</param>
-    /// <returns>A string formatted as "yyyy-MM-dd h:mm tt (PST)".</returns>
+    /// <returns>A string formatted as "yyyy-MM-dd h:mm tt (PST)" or "yyyy-MM-dd h:mm tt (PDT)".</returns>
     public static string FormatPacificTime(DateTime? utcTime)
     {
         if (!utcTime.HasValue)
@@ -45,10 +45,11 @@ public static class DateTimeExtensions
             ? utcTime.Value
             : DateTime.SpecifyKind(utcTime.Value, DateTimeKind.Utc);
 
-        // BC PST is a fixed UTC-8 offset — no DST adjustment in 2026.
-        var bcPstDateTime = new DateTimeOffset(utcTimeValue, TimeSpan.Zero).ToOffset(BcPstOffset);
+        var pacificTz = PacificTimeZone.Value;
+        var ptDateTime = TimeZoneInfo.ConvertTimeFromUtc(utcTimeValue, pacificTz);
+        string abbr = pacificTz.IsDaylightSavingTime(ptDateTime) ? "(PDT)" : "(PST)";
 
-        return $"{bcPstDateTime.ToString("yyyy-MM-dd h:mm tt", CultureInfo.InvariantCulture)} (PST)";
+        return $"{ptDateTime.ToString("yyyy-MM-dd h:mm tt", CultureInfo.InvariantCulture)} {abbr}";
     }
 
     /// <summary>
@@ -72,6 +73,23 @@ public static class DateTimeExtensions
         string abbr = mountainTz.IsDaylightSavingTime(mtDateTime) ? "(MDT)" : "(MST)";
 
         return $"{mtDateTime.ToString("yyyy-MM-dd h:mm tt", CultureInfo.InvariantCulture)} {abbr}";
+    }
+
+    private static TimeZoneInfo GetPacificTimeZone()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            if (TryFindTimeZone(WindowsPacificId, out var tz)) return tz;
+            if (TryFindTimeZone(IanaPacificId, out tz)) return tz;
+        }
+        else
+        {
+            if (TryFindTimeZone(IanaPacificId, out var tz)) return tz;
+            if (TryFindTimeZone(WindowsPacificId, out tz)) return tz;
+        }
+
+        throw new TimeZoneNotFoundException(
+            $"Neither '{WindowsPacificId}' nor '{IanaPacificId}' time zone IDs were found on this system.");
     }
 
     private static TimeZoneInfo GetMountainTimeZone()

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/IHistoryAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/IHistoryAppService.cs
@@ -7,6 +7,7 @@ namespace Unity.GrantManager.History
 {
     public interface IHistoryAppService : IApplicationService
     {
+        Task<List<HistoryDto>> GetEntityPropertyChangesAsync(GetEntityPropertyChangesInput input, Dictionary<string, string>? lookupDictionary = null);
         Task<List<HistoryDto>> GetHistoryList(string? entityId, string filterPropertyName, Dictionary<string, string>? lookupDictionary);
         Task<string> LookupUserName(Guid auditLogId);
     }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/History/GetEntityPropertyChangesInput.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/History/GetEntityPropertyChangesInput.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Unity.GrantManager.History;
+
+public class GetEntityPropertyChangesInput
+{
+    public string? EntityId { get; set; }
+    public string? EntityTypeFullName { get; set; }
+    public string[] PropertyNames { get; set; } = [];
+    public DateTime? StartTime { get; set; }
+    public DateTime? EndTime { get; set; }
+    public int MaxResultCount { get; set; } = 50;
+    public int SkipCount { get; set; }
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/History/HistoryAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/History/HistoryAppService.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading;
+using System.Linq;
 using System.Threading.Tasks;
 using Volo.Abp;
-using Volo.Abp.Auditing;
 using Volo.Abp.AuditLogging;
 using Volo.Abp.Data;
 using Volo.Abp.Domain.ChangeTracking;
@@ -16,72 +15,92 @@ public class HistoryAppService(
     IIdentityUserRepository identityUserRepository,
     IDataFilter softDataFilter) : GrantManagerAppService, IHistoryAppService
 {
+    /// <summary>
+    /// Gets the list of entity property changes based on the provided input parameters.
+    /// </summary>
+    /// <param name="entityId">The ID of the entity for which to retrieve property changes.</param>
+    /// <param name="filterPropertyName">The name of the property to filter changes by.</param>
+    /// <param name="lookupDictionary">An optional dictionary for looking up display values for property changes.</param>
+    /// <returns>A list of history DTOs representing the entity property changes.</returns>
     [DisableEntityChangeTracking]
-    public async Task<List<HistoryDto>> GetHistoryList(string? entityId,
-                                                       string filterPropertyName,
-                                                       Dictionary<string, string>? lookupDictionary)
+    public virtual async Task<List<HistoryDto>> GetHistoryList(
+        string? entityId,
+        string filterPropertyName,
+        Dictionary<string, string>? lookupDictionary)
     {
-        List<HistoryDto> historyList = [];
-        string? sorting = null;
-        int maxResultCount = 50;
-        int skipCount = 0;
-        DateTime? startTime = null;
-        DateTime? endTime = null;
-        bool includeDetails = true;
-        Guid? auditLogId = null;
-        EntityChangeType? changeType = null;
-        string? entityTypeFullName = null;
-        CancellationToken cancellationToken = default;
+        return await GetEntityPropertyChangesAsync(
+            new GetEntityPropertyChangesInput
+            {
+                EntityId = entityId,
+                PropertyNames = [filterPropertyName],
+            },
+            lookupDictionary);
+    }
 
+    /// <summary>
+    /// Gets the list of entity property changes for a specific entity.
+    /// </summary>
+    /// <param name="input">The input parameters for retrieving entity property changes.</param>
+    /// <param name="lookupDictionary">An optional dictionary for looking up display values for property changes.</param>
+    /// <returns>A list of history DTOs representing the entity property changes.</returns>
+    [DisableEntityChangeTracking]
+    public virtual async Task<List<HistoryDto>> GetEntityPropertyChangesAsync(
+        GetEntityPropertyChangesInput input,
+        Dictionary<string, string>? lookupDictionary = null)
+    {
         var entityChanges = await auditLogRepository.GetEntityChangeListAsync(
-            sorting,
-            maxResultCount,
-            skipCount,
-            auditLogId,
-            startTime, endTime,
-            changeType,
-            entityId,
-            entityTypeFullName,
-            includeDetails,
-            cancellationToken);
+            sorting: null,
+            maxResultCount: input.MaxResultCount,
+            skipCount: input.SkipCount,
+            auditLogId: null,
+            startTime: input.StartTime,
+            endTime: input.EndTime,
+            changeType: null,
+            entityId: input.EntityId,
+            entityTypeFullName: input.EntityTypeFullName,
+            includeDetails: true,
+            cancellationToken: default);
+
+        var propertyNames = input.PropertyNames.ToHashSet(StringComparer.Ordinal);
+        var historyList = new List<HistoryDto>();
+        var userNameCache = new Dictionary<Guid, string>();
 
         foreach (var entityChange in entityChanges)
         {
             foreach (var propertyChange in entityChange.PropertyChanges)
             {
-                if (propertyChange.PropertyName == filterPropertyName)
+                if (propertyNames.Count > 0 && !propertyNames.Contains(propertyChange.PropertyName))
                 {
-                    string origninalValue = CleanValue(propertyChange.OriginalValue);
-                    string newValue = CleanValue(propertyChange.NewValue);
-                    // Signal the kind of time so that tolocal knows how to convert it on the page
-                    DateTime utcDateTime = DateTime.SpecifyKind(entityChange.ChangeTime, DateTimeKind.Utc);
-                    HistoryDto historyDto = new()
-                    {
-                        OriginalValue = GetLookupValue(origninalValue, lookupDictionary),
-                        NewValue = GetLookupValue(newValue, lookupDictionary),
-                        ChangeTime = utcDateTime,
-                        UserName = await LookupUserName(entityChange.AuditLogId)
-                    };
-                    historyList.Add(historyDto);
+                    continue;
                 }
+
+                string originalValue = CleanValue(propertyChange.OriginalValue);
+                string newValue = CleanValue(propertyChange.NewValue);
+                DateTime utcDateTime = DateTime.SpecifyKind(entityChange.ChangeTime, DateTimeKind.Utc);
+
+                if (!userNameCache.TryGetValue(entityChange.AuditLogId, out var userName))
+                {
+                    userName = await LookupUserNameAsync(entityChange.AuditLogId);
+                    userNameCache[entityChange.AuditLogId] = userName;
+                }
+
+                historyList.Add(new HistoryDto
+                {
+                    PropertyName = propertyChange.PropertyName,
+                    PropertyTypeFullName = propertyChange.PropertyTypeFullName ?? string.Empty,
+                    OriginalValue = GetLookupValue(originalValue, lookupDictionary),
+                    NewValue = GetLookupValue(newValue, lookupDictionary),
+                    ChangeTime = utcDateTime,
+                    ChangeType = (int)entityChange.ChangeType,
+                    UserName = userName,
+                });
             }
         }
+
         return historyList;
     }
 
-    private static string CleanValue(string? value)
-    {
-        return value?.Replace("\"", "") ?? "";
-    }
-
-    private static string GetLookupValue(string value, Dictionary<string, string>? lookupDictionary)
-    {
-        return lookupDictionary != null && lookupDictionary.TryGetValue(value, out var lookupValue)
-            ? lookupValue
-            : value;
-    }
-
-    public async Task<string> LookupUserName(Guid auditLogId)
+    public virtual async Task<string> LookupUserNameAsync(Guid auditLogId)
     {
         var auditLog = await auditLogRepository.GetAsync(auditLogId);
         if (auditLog?.UserId == null || auditLog.UserId == Guid.Empty)
@@ -95,5 +114,22 @@ public class HistoryAppService(
             var user = await identityUserRepository.FindAsync(userId);
             return user != null ? $"{user.Name} {user.Surname}" : "(Full-Deleted User)";
         }
+    }
+
+    public async Task<string> LookupUserName(Guid auditLogId)
+    {
+        return await LookupUserNameAsync(auditLogId);
+    }
+
+    private static string CleanValue(string? value)
+    {
+        return value?.Replace("\"", "") ?? "";
+    }
+
+    private static string GetLookupValue(string value, Dictionary<string, string>? lookupDictionary)
+    {
+        return lookupDictionary != null && lookupDictionary.TryGetValue(value, out var lookupValue)
+            ? lookupValue
+            : value;
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/History/HistoryAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/History/HistoryAppService.cs
@@ -61,7 +61,7 @@ public class HistoryAppService(
             includeDetails: true,
             cancellationToken: default);
 
-        var propertyNames = input.PropertyNames.ToHashSet(StringComparer.Ordinal);
+        var propertyNames = (input.PropertyNames ?? []).ToHashSet(StringComparer.Ordinal);
         var historyList = new List<HistoryDto>();
         var userNameCache = new Dictionary<Guid, string>();
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
@@ -25,6 +25,7 @@ $(function () {
         setStoredDividerWidth();
         initCommentsWidget();
         initEmailsWidget();
+        initHistoryWidget();
         updateLinksCounters();
         renderSubmission();
         loadAIAnalysis();
@@ -1091,7 +1092,7 @@ function updateLinksCounters() {
                 $('#' + tag).text(count);
             })
             .get();
-    }, 100);
+    }, 100);                  
 }
 
 function initEmailsWidget() {
@@ -1181,6 +1182,23 @@ function initCommentsWidget() {
 
     PubSub.subscribe('ApplicationTags_refresh', () => {
         tagsWidgetManager.refresh();
+    });
+}
+
+function initHistoryWidget() {
+    debugger;
+    let applicationHistoryWidgetManager = new abp.WidgetManager({
+        wrapper: '#applicationHistoryWidget',
+        filterCallback: function () {
+            return {
+                applicationId: $('#DetailsViewApplicationId').val(),
+            };
+        },
+    })
+
+    PubSub.subscribe('ApplicationHistory_refresh', () => {
+        debugger;
+        applicationHistoryWidgetManager.refresh();
     });
 }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.js
@@ -1092,7 +1092,7 @@ function updateLinksCounters() {
                 $('#' + tag).text(count);
             })
             .get();
-    }, 100);                  
+    }, 100);
 }
 
 function initEmailsWidget() {
@@ -1186,18 +1186,18 @@ function initCommentsWidget() {
 }
 
 function initHistoryWidget() {
-    debugger;
     let applicationHistoryWidgetManager = new abp.WidgetManager({
         wrapper: '#applicationHistoryWidget',
         filterCallback: function () {
             return {
-                applicationId: $('#DetailsViewApplicationId').val(),
+                applicationId:
+                    $('#DetailsViewApplicationId').val() ??
+                    '00000000-0000-0000-0000-000000000000',
             };
         },
     })
 
     PubSub.subscribe('ApplicationHistory_refresh', () => {
-        debugger;
         applicationHistoryWidgetManager.refresh();
     });
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicationActionWidget/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ApplicationActionWidget/Default.js
@@ -155,6 +155,7 @@
                     PubSub.publish("application_status_changed", triggerActionEnum);
                     PubSub.publish("refresh_detail_panel_summary");
                     PubSub.publish("init_date_pickers");
+                    PubSub.publish('ApplicationHistory_refresh');
                 })
                 .catch(function () { widgetManager.refresh(); });
         }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/DetailsActionBar/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/DetailsActionBar/Default.js
@@ -301,6 +301,7 @@ $(function () {
 
                     PubSub.publish('application_status_changed', nextPublishedState ? 'Publish' : 'Unpublish');
                     PubSub.publish('refresh_detail_panel_summary');
+                    PubSub.publish('ApplicationHistory_refresh');
                 })
                 .catch(function (error) {
                     abp.notify.error(l('DetailsActionBar:PublishStatusUpdateFailed'));

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/HistoryWidget/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/HistoryWidget/Default.cshtml
@@ -1,8 +1,9 @@
-@using Unity.GrantManager.History
-@using Unity.GrantManager.Web.Views.Shared.Components.HistoryWidget
+@using Microsoft.AspNetCore.Html
 @using Microsoft.AspNetCore.Mvc.Localization
-@using Unity.GrantManager.Localization
 @using Microsoft.Extensions.Localization
+@using Unity.GrantManager.History
+@using Unity.GrantManager.Localization
+@using Unity.GrantManager.Web.Views.Shared.Components.HistoryWidget
 @using Unity.Modules.Shared.Utils
 
 @model HistoryWidgetViewModel
@@ -12,8 +13,7 @@
 @{
     Layout = null;
 }
-<br/>
-<div id="application-history-div" class="mb-2 card border"> 
+<div id="application-history-div" class="mb-2 mt-4 card border">
     <div id="card-header-div" class="card-header bg-default"> 
         <h4 class="mb-0 card-title">Application Status History</h4> 
     </div> 
@@ -31,12 +31,6 @@
 
             @foreach (HistoryDto historyDto in Model.ApplicationStatusHistoryList ?? Enumerable.Empty<HistoryDto>())
             {
-                string fromString = string.Empty;
-                if (!string.IsNullOrEmpty(historyDto?.OriginalValue)) 
-                {
-                    fromString = "from";
-                }
-
                 <div class="mb-2 history-read-mode">
                     <div class="unity-history-block read-mode">
                         <div class="d-flex justify-content-between">
@@ -44,13 +38,23 @@
                                 @historyDto?.UserName
                             </div>
                         </div>
+                        @if (historyDto?.PropertyName == HistoryWidgetViewComponent.Property_ApplicationStatusId)
+                        {
                         <div class="history-lbl">
-                            <div>
-                                Status changed @fromString <span class="status-change">@historyDto?.OriginalValue</span> 
-                                to
-                                <span class="status-change">@historyDto?.NewValue</span>
-                            </div>
+                            Status changed 
+                            @if (!string.IsNullOrEmpty(historyDto?.OriginalValue))
+                            {
+                                <text>from <span class="status-change">@historyDto?.OriginalValue</span></text>
+                            }
+                            to <span class="status-change">@historyDto?.NewValue</span>
                         </div>
+                        }
+                        @if (historyDto?.PropertyName == HistoryWidgetViewComponent.Property_ExternalStatusVisibility)
+                        {
+                        <div class="history-lbl">
+                            External Status Visibility changed to <span class="status-change">@(bool.TryParse(historyDto?.NewValue, out bool newValue) && newValue ? "Published" : "Unpublished")</span>
+                        </div>
+                        }
                         <time datetime="@DateTimeExtensions.FormatTimestamp(historyDto?.ChangeTime)" class="history-time mt-3 fw-bold">
                             @DateTimeExtensions.FormatPacificTime(historyDto?.ChangeTime)
                         </time>

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/HistoryWidget/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/HistoryWidget/Default.cshtml
@@ -1,4 +1,3 @@
-@using Microsoft.AspNetCore.Html
 @using Microsoft.AspNetCore.Mvc.Localization
 @using Microsoft.Extensions.Localization
 @using Unity.GrantManager.History

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/HistoryWidget/HistoryWidgetController.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/HistoryWidget/HistoryWidgetController.cs
@@ -1,11 +1,22 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using System;
 using Volo.Abp.AspNetCore.Mvc;
 
-namespace Unity.GrantManager.Web.Views.Shared.Components.HistoryWidget
+namespace Unity.GrantManager.Web.Views.Shared.Components.HistoryWidget;
+
+[ApiExplorerSettings(IgnoreApi = true)]
+[Route("GrantApplications/Widgets/History")]
+public class HistoryWidgetController : AbpController
 {
-    [ApiExplorerSettings(IgnoreApi = true)]
-    [Route("GrantApplications/Widgets/History")]
-    public class HistoryWidgetController : AbpController
+    [HttpGet]
+    [Route("RefreshHistory")]
+    public IActionResult HistoryWidget(Guid applicationId)
     {
+        if (!ModelState.IsValid)
+        {
+            return ViewComponent("HistoryWidget");
+        }
+
+        return ViewComponent("HistoryWidget", new { applicationId });
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/HistoryWidget/HistoryWidgetController.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/HistoryWidget/HistoryWidgetController.cs
@@ -14,7 +14,7 @@ public class HistoryWidgetController : AbpController
     {
         if (!ModelState.IsValid)
         {
-            return ViewComponent("HistoryWidget");
+            return BadRequest(ModelState);
         }
 
         return ViewComponent("HistoryWidget", new { applicationId });

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/HistoryWidget/HistoryWidgetViewComponent.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/HistoryWidget/HistoryWidgetViewComponent.cs
@@ -1,75 +1,77 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using Volo.Abp.AspNetCore.Mvc.UI.Widgets;
-using Volo.Abp.AspNetCore.Mvc;
 using System;
-using System.Threading.Tasks;
 using System.Collections.Generic;
-using Volo.Abp.AspNetCore.Mvc.UI.Bundling;
+using System.Threading.Tasks;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.History;
+using Volo.Abp.AspNetCore.Mvc;
+using Volo.Abp.AspNetCore.Mvc.UI.Bundling;
+using Volo.Abp.AspNetCore.Mvc.UI.Widgets;
 
-namespace Unity.GrantManager.Web.Views.Shared.Components.HistoryWidget
+namespace Unity.GrantManager.Web.Views.Shared.Components.HistoryWidget;
+
+[Widget(
+    RefreshUrl = "Widgets/History/RefreshHistory",
+    ScriptTypes = [typeof(HistoryWidgetScriptBundleContributor)],
+    StyleTypes = [typeof(HistoryWidgetStyleBundleContributor)],
+    AutoInitialize = true)]
+public class HistoryWidgetViewComponent(
+    IApplicationStatusRepository applicationStatusRepository,
+    IHistoryAppService historyAppService) : AbpViewComponent
 {
-    [Widget(
-        RefreshUrl = "Widgets/History/RefreshHistory",
-        ScriptTypes = [typeof(HistoryWidgetScriptBundleContributor)],
-        StyleTypes = [typeof(HistoryWidgetStyleBundleContributor)],
-        AutoInitialize = true)]
-    public class HistoryWidgetViewComponent : AbpViewComponent
-    {  
-        private readonly IApplicationStatusRepository _applicationStatusRepository;
-        private readonly IHistoryAppService _historyAppService;
+    public const string Property_ApplicationStatusId = "ApplicationStatusId";
+    public const string Property_ExternalStatusVisibility = "ExternalStatusVisibility";
+    public async Task<IViewComponentResult> InvokeAsync(Guid applicationId)
+    {
+        string? entityId = applicationId.ToString();
+        Dictionary<string, string> applicationStatusDict = await GetApplicationStatusDict();
 
-        public HistoryWidgetViewComponent(IApplicationStatusRepository applicationStatusRepository,
-                                          IHistoryAppService historyAppService)
+        HistoryWidgetViewModel model = new()
+        {       
+            ApplicationStatusHistoryList = await historyAppService.GetHistoryList(entityId, "ApplicationStatusId", applicationStatusDict),
+        };
+
+        HistoryWidgetViewModel model2 = new()
         {
-
-            _applicationStatusRepository = applicationStatusRepository;
-            _historyAppService = historyAppService;
-        }
-
-        public async Task<IViewComponentResult> InvokeAsync(Guid applicationId)
-        {
-            string? entityId = applicationId.ToString();
-            Dictionary<string, string> applicationStatusDict = await GetApplicationStatusDict();
-
-            HistoryWidgetViewModel model = new()
-            {       
-                ApplicationStatusHistoryList = await _historyAppService.GetHistoryList(entityId, "ApplicationStatusId", applicationStatusDict),
-            };                 
-
-            return View(model);
-        }
-
-        public async Task<Dictionary<string, string>> GetApplicationStatusDict() {
-            List<ApplicationStatus> applicationStatusList = await _applicationStatusRepository.GetListAsync();
-            Dictionary<string, string> applicationStatusDict = new Dictionary<string, string>();
-            foreach (var applicationStatus in applicationStatusList)
+            ApplicationStatusHistoryList = await historyAppService.GetEntityPropertyChangesAsync(
+            new GetEntityPropertyChangesInput
             {
-                applicationStatusDict.Add(applicationStatus.Id.ToString(), applicationStatus.InternalStatus);
-            }
-            return applicationStatusDict;
-        }
+                EntityId = applicationId.ToString(),
+                PropertyNames = ["ApplicationStatusId", "ExternalStatusVisibility"],
+            }, applicationStatusDict),
+        };
+
+        return View(model2);
     }
 
-    public class HistoryWidgetStyleBundleContributor : BundleContributor
-    {
-        public override void ConfigureBundle(BundleConfigurationContext context)
+    public async Task<Dictionary<string, string>> GetApplicationStatusDict() {
+        List<ApplicationStatus> applicationStatusList = await applicationStatusRepository.GetListAsync();
+        Dictionary<string, string> applicationStatusDict = new Dictionary<string, string>();
+        foreach (var applicationStatus in applicationStatusList)
         {
-            context.Files
-            .AddIfNotContains("/Views/Shared/Components/HistoryWidget/Default.css");
+            applicationStatusDict.Add(applicationStatus.Id.ToString(), applicationStatus.InternalStatus);
         }
+        return applicationStatusDict;
     }
+}
 
-    public class HistoryWidgetScriptBundleContributor : BundleContributor
+public class HistoryWidgetStyleBundleContributor : BundleContributor
+{
+    public override void ConfigureBundle(BundleConfigurationContext context)
     {
-        public override void ConfigureBundle(BundleConfigurationContext context)
-        {
-            context.Files
-            .AddIfNotContains("/Views/Shared/Components/HistoryWidget/Default.js");
-            context.Files
-            .AddIfNotContains("/libs/pubsub-js/src/pubsub.js");
-        }
+        context.Files
+        .AddIfNotContains("/Views/Shared/Components/HistoryWidget/Default.css");
+    }
+}
+
+public class HistoryWidgetScriptBundleContributor : BundleContributor
+{
+    public override void ConfigureBundle(BundleConfigurationContext context)
+    {
+        context.Files
+        .AddIfNotContains("/Views/Shared/Components/HistoryWidget/Default.js");
+        context.Files
+        .AddIfNotContains("/libs/pubsub-js/src/pubsub.js");
     }
 }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/HistoryWidget/HistoryWidgetViewComponent.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/HistoryWidget/HistoryWidgetViewComponent.cs
@@ -32,14 +32,14 @@ public class HistoryWidgetViewComponent(
             new GetEntityPropertyChangesInput
             {
                 EntityId = entityId,
-                PropertyNames = ["ApplicationStatusId", "ExternalStatusVisibility"],
+                PropertyNames = [Property_ApplicationStatusId, Property_ExternalStatusVisibility],
             }, applicationStatusDict),
         };
 
         return View(model);
     }
 
-    public async Task<Dictionary<string, string>> GetApplicationStatusDict() {
+    private async Task<Dictionary<string, string>> GetApplicationStatusDict() {
         List<ApplicationStatus> applicationStatusList = await applicationStatusRepository.GetListAsync();
         Dictionary<string, string> applicationStatusDict = new Dictionary<string, string>();
         foreach (var applicationStatus in applicationStatusList)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/HistoryWidget/HistoryWidgetViewComponent.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/HistoryWidget/HistoryWidgetViewComponent.cs
@@ -27,21 +27,16 @@ public class HistoryWidgetViewComponent(
         Dictionary<string, string> applicationStatusDict = await GetApplicationStatusDict();
 
         HistoryWidgetViewModel model = new()
-        {       
-            ApplicationStatusHistoryList = await historyAppService.GetHistoryList(entityId, "ApplicationStatusId", applicationStatusDict),
-        };
-
-        HistoryWidgetViewModel model2 = new()
         {
             ApplicationStatusHistoryList = await historyAppService.GetEntityPropertyChangesAsync(
             new GetEntityPropertyChangesInput
             {
-                EntityId = applicationId.ToString(),
+                EntityId = entityId,
                 PropertyNames = ["ApplicationStatusId", "ExternalStatusVisibility"],
             }, applicationStatusDict),
         };
 
-        return View(model2);
+        return View(model);
     }
 
     public async Task<Dictionary<string, string>> GetApplicationStatusDict() {


### PR DESCRIPTION
## Pull request overview

This PR extends the Grant Application “History” widget to show audit history for both **Application Status** and the new **External Status Visibility** flag, and wires up client-side refresh triggers so the history updates immediately after publish/unpublish actions.

**Changes:**
- Updated the History widget to request and render audit changes for `ApplicationStatusId` and `ExternalStatusVisibility`.
- Added a generalized `GetEntityPropertyChangesAsync` API (with input DTO) to fetch audit property changes for one or more properties, including simple username caching.
- Improved Pacific time formatting to use the system time zone (PST/PDT) instead of a fixed offset for historic entries.