### PR TITLE
AB#33408: Fix Security Findings When Validating Tenant API Key

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.HttpApi/Controllers/Authentication/FormSubmission/FormsApiTokenAuthFilter.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.HttpApi/Controllers/Authentication/FormSubmission/FormsApiTokenAuthFilter.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Mvc.Filters;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
 using Volo.Abp.MultiTenancy;
 using Volo.Abp.TenantManagement;
 using Unity.GrantManager.ApplicationForms;
@@ -15,23 +17,41 @@ namespace Unity.GrantManager.Controllers.Auth.FormSubmission
         private readonly ITenantRepository _tenantRepository;
         private readonly ICurrentTenant _currentTenant;
         private readonly IApplicationFormTokenAppService _formTokenAppService;
-        private readonly IEnumerable<IFormIdResolver> _formIdResolvers;        
+        private readonly IEnumerable<IFormIdResolver> _formIdResolvers;
+        private readonly IHostEnvironment _hostEnvironment;
 
         public FormsApiTokenAuthFilter(ITenantRepository tenantRepository,
             ICurrentTenant currentTenant,
             IApplicationFormTokenAppService formTokenAppService,
-            IEnumerable<IFormIdResolver> formIdResolvers)
+            IEnumerable<IFormIdResolver> formIdResolvers,
+            IHostEnvironment hostEnvironment)
         {
             _currentTenant = currentTenant;
             _tenantRepository = tenantRepository;
             _formTokenAppService = formTokenAppService;
             _formIdResolvers = formIdResolvers;
+            _hostEnvironment = hostEnvironment;
         }
 
         public async Task OnAuthorizationAsync(AuthorizationFilterContext context)
         {
             var apiToken = await GetTenantApiTokenAsync();
-            if (apiToken == null) { return; } // No API auth tokens setup for the tenant
+            if (string.IsNullOrWhiteSpace(apiToken))
+            {
+                if (_hostEnvironment.IsDevelopment())
+                {
+                    return; // Dev-only convenience: unconfigured tenants pass through locally
+                }
+
+                context.Result = new UnauthorizedObjectResult(new ProblemDetails
+                {
+                    Status = StatusCodes.Status401Unauthorized,
+                    Title = "Unauthorized",
+                    Detail = "API authentication not configured for this tenant",
+                    Type = "https://tools.ietf.org/html/rfc7235#section-3.1"
+                });
+                return;
+            }
 
             if (!context.HttpContext.Request.Headers.TryGetValue(AuthConstants.ApiKeyHeader, out var extractedApiToken))
             {

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/Intake/FormsApiTokenAuthFilterTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/Intake/FormsApiTokenAuthFilterTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.IO;
@@ -30,7 +31,7 @@ namespace Unity.GrantManager.Intake
     {
         private readonly FormsApiTokenAuthFilter _formsApiTokenAuthFilter;
 
-        private readonly ITenantRepository _tenantRepository;        
+        private readonly ITenantRepository _tenantRepository;
         private readonly ICurrentTenant _currentTenant;
         private readonly IApplicationFormTokenAppService _formTokenAppService;
         private readonly IEnumerable<IFormIdResolver> _formIdResolvers;
@@ -46,13 +47,22 @@ namespace Unity.GrantManager.Intake
             _tenantTokenRepository = GetRequiredService<ITenantTokenRepository>();
             _stringEncryptionService = GetRequiredService<StringEncryptionService>();
 
-            _formsApiTokenAuthFilter = new FormsApiTokenAuthFilter(_tenantRepository, _currentTenant, _formTokenAppService, _formIdResolvers);
+            _formsApiTokenAuthFilter = new FormsApiTokenAuthFilter(_tenantRepository, _currentTenant, _formTokenAppService,
+                _formIdResolvers, new TestHostEnvironment { EnvironmentName = Environments.Production });
+        }
+
+        private sealed class TestHostEnvironment : IHostEnvironment
+        {
+            public string EnvironmentName { get; set; } = Environments.Production;
+            public string ApplicationName { get; set; } = "Tests";
+            public string ContentRootPath { get; set; } = ".";
+            public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } = null!;
         }
 
         [Fact]
         [Trait("Category", "Integration")]
-        public async Task OnAuthorizationAsync_AllowLoginWithNoTokenSet()
-        {                     
+        public async Task OnAuthorizationAsync_401_NoTokenSetForTenant_NonDevelopment()
+        {
             // Arrange
             var context = BuildContext(new EventSubscriptionDto()
             {
@@ -69,7 +79,38 @@ namespace Unity.GrantManager.Intake
                 await _formsApiTokenAuthFilter.OnAuthorizationAsync(context);
             }
 
-            // Assert            
+            // Assert — non-Development environments must fail closed when no token is configured.
+            context.Result.ShouldBeOfType<UnauthorizedObjectResult>();
+            var result = context.Result as UnauthorizedObjectResult;
+            result!.Value.ShouldBeOfType<ProblemDetails>();
+            var problemDetails = result.Value as ProblemDetails;
+            problemDetails!.Status.ShouldBe(StatusCodes.Status401Unauthorized);
+            problemDetails.Detail.ShouldBe("API authentication not configured for this tenant");
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public async Task OnAuthorizationAsync_AllowsNoTokenSet_InDevelopmentOnly()
+        {
+            // Arrange
+            var devFilter = new FormsApiTokenAuthFilter(_tenantRepository, _currentTenant, _formTokenAppService,
+                _formIdResolvers, new TestHostEnvironment { EnvironmentName = Environments.Development });
+
+            var context = BuildContext(new EventSubscriptionDto()
+            {
+                FormId = Guid.NewGuid(),
+                FormVersion = Guid.NewGuid(),
+                SubmissionId = Guid.NewGuid(),
+                SubscriptionEvent = "string"
+            });
+
+            // Act
+            using (_currentTenant.Change(Guid.NewGuid(), "Test"))
+            {
+                await devFilter.OnAuthorizationAsync(context);
+            }
+
+            // Assert — Development is the one intentional exception: unconfigured tenants still pass through.
             context.Result.ShouldBe(null);
         }
 


### PR DESCRIPTION
Current situation: Intake process proceeds even if Tenant API Key (X-Api-Key) is not configured in Unity
Situation After the Fix:  For Non-Development environment, the intake process will throw "401 Unauthorized" if Tenant API Key is not configured in Unity