### PR TITLE
AB#33863 preserve existing mappings during AI generation

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/DataSeed/AIPromptDataSeeder.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/DataSeed/AIPromptDataSeeder.cs
@@ -813,6 +813,10 @@ public class AIPromptDataSeeder(
         - chefsData.fields contains the CHEFS source fields.
         - unityData.coreFields contains Unity target fields.
         - unityData.customFields contains worksheet-derived Unity target fields.
+        - existingMapping contains the current Unity-to-CHEFS assignments, when any exist.
+        - Return a complete mapping, including existing mappings and any new suggestions.
+        - Preserve every existing non-empty mapping exactly as provided; do not replace or remove it.
+        - Only fill blank existing mappings or add new mappings when supported by the available fields.
         - Only include mappings that are clearly semantically equivalent or strongly related by label, name, type, and purpose.
         - Do not force one-to-one coverage. Omit Unity fields when no CHEFS field is a sensible match.
         - Omit CHEFS fields that do not clearly map to a Unity target field.
@@ -826,7 +830,7 @@ public class AIPromptDataSeeder(
 
     private const string FormMappingMetadataV2 = """
         {
-          "DATA": "Serialized JSON payload containing CHEFS fields, Unity core fields, and worksheet-derived custom fields."
+          "DATA": "Serialized JSON payload containing CHEFS fields, Unity core fields, worksheet-derived custom fields, and the existing mapping."
         }
         """;
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/ApplicationForms/Mapping/ApplicationFormMappingReadModelDto.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/ApplicationForms/Mapping/ApplicationFormMappingReadModelDto.cs
@@ -9,6 +9,7 @@ public class ApplicationFormMappingReadModelDto
     public Guid ApplicationFormId { get; set; }
     public string? ChefsApplicationFormGuid { get; set; }
     public string? ChefsFormVersionGuid { get; set; }
+    public string? ExistingMapping { get; set; }
     public List<MappingFieldDto> ChefsFields { get; set; } = [];
     public List<MappingFieldDto> UnityCoreFields { get; set; } = [];
     public List<WorksheetMappingFieldsDto> Worksheets { get; set; } = [];

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/Mapping/ApplicationFormVersionMappingReadService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/Mapping/ApplicationFormVersionMappingReadService.cs
@@ -46,6 +46,7 @@ public class ApplicationFormVersionMappingReadService(
             ApplicationFormId = formVersion.ApplicationFormId,
             ChefsApplicationFormGuid = formVersion.ChefsApplicationFormGuid,
             ChefsFormVersionGuid = formVersion.ChefsFormVersionGuid,
+            ExistingMapping = formVersion.SubmissionHeaderMapping,
             ChefsFields = BuildChefsFields(formVersion.AvailableChefsFields),
             UnityCoreFields = BuildUnityCoreFields()
         };

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/Mapping/FormMappingPromptDataBuilder.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/Mapping/FormMappingPromptDataBuilder.cs
@@ -6,6 +6,7 @@ internal static class FormMappingPromptDataBuilder
 {
     internal static JsonElement Build(ApplicationFormMappingReadModelDto readModel)
     {
+        var existingMapping = ParseExistingMapping(readModel.ExistingMapping);
         var promptData = new
         {
             chefsData = new
@@ -20,12 +21,31 @@ internal static class FormMappingPromptDataBuilder
             {
                 coreFields = readModel.UnityCoreFields,
                 customFields = readModel.Worksheets
-            }
+            },
+            existingMapping
         };
 
         return JsonSerializer.SerializeToElement(promptData, new JsonSerializerOptions
         {
             WriteIndented = true
         });
+    }
+
+    private static JsonElement ParseExistingMapping(string? existingMapping)
+    {
+        if (string.IsNullOrWhiteSpace(existingMapping))
+        {
+            return JsonSerializer.SerializeToElement(new { });
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(existingMapping);
+            return document.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            return JsonSerializer.SerializeToElement(existingMapping);
+        }
     }
 }

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/ApplicationForms/ApplicationFormVersionAppServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/ApplicationForms/ApplicationFormVersionAppServiceTests.cs
@@ -55,6 +55,7 @@ public class ApplicationFormVersionAppServiceTests(ITestOutputHelper outputHelpe
             ApplicationFormId = formVersion.ApplicationFormId,
             ChefsApplicationFormGuid = "chefs-form",
             ChefsFormVersionGuid = "chefs-version",
+            ExistingMapping = "{\"ProjectName\":\"projectName\"}",
             ChefsFields = new List<MappingFieldDto>
             {
                 new() { Name = "ProjectName", Label = "Project Name", Type = "Text", IsCustom = false }
@@ -82,8 +83,17 @@ public class ApplicationFormVersionAppServiceTests(ITestOutputHelper outputHelpe
         capturedRequest!.Data.GetProperty("chefsData").GetProperty("fields").ValueKind.ShouldBe(System.Text.Json.JsonValueKind.Array);
         capturedRequest.Data.GetProperty("unityData").GetProperty("coreFields").ValueKind.ShouldBe(System.Text.Json.JsonValueKind.Array);
         capturedRequest.Data.GetProperty("unityData").GetProperty("customFields").ValueKind.ShouldBe(System.Text.Json.JsonValueKind.Array);
+        capturedRequest.Data.GetProperty("existingMapping").GetProperty("ProjectName").GetString().ShouldBe("projectName");
         formVersion.SubmissionHeaderMapping.ShouldBe("""{"ProjectName":"projectName"}""");
         await repository.Received(1).UpdateAsync(formVersion, true);
+    }
+
+    [Fact]
+    public void FormMappingPromptData_Should_UseEmptyObject_When_NoExistingMappingIsAvailable()
+    {
+        var promptData = FormMappingPromptDataBuilder.Build(new ApplicationFormMappingReadModelDto());
+
+        promptData.GetProperty("existingMapping").GetRawText().ShouldBe("{}");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Send the current form mapping to the AI alongside CHEFS and Unity fields.
- Instruct the AI to retain existing assignments while completing the final mapping.

## Validation
- Reviewed the focused diff and ran `git diff --check`.