### PR TITLE
AB#33884 restore form mapping targets

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/Mapping/ApplicationFormVersionMappingReadService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/Mapping/ApplicationFormVersionMappingReadService.cs
@@ -121,7 +121,7 @@ public class ApplicationFormVersionMappingReadService(
                 .Where(field => IsMappable(field))
                 .Select(field => new MappingFieldDto
                 {
-                    Name = string.IsNullOrWhiteSpace(field.Key) ? field.Name : field.Key,
+                    Name = $"{field.Name}.{field.Type}",
                     Type = ConvertCustomType(field.Type),
                     IsCustom = true,
                     Label = $"{field.Label} ({worksheet.Name})"

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Mapping.cshtml.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Mapping.cshtml.cs
@@ -112,7 +112,12 @@ namespace Unity.GrantManager.Web.Pages.ApplicationForms
             }
 
             var readModel = await mappingReadService.GetAsync(formVersionId);
-            var properties = readModel.ChefsFields
+            return BuildMappingFields(readModel);
+        }
+
+        internal static List<MapField> BuildMappingFields(ApplicationFormMappingReadModelDto readModel)
+        {
+            var properties = readModel.UnityCoreFields
                 .Select(field => new MapField
                 {
                     Name = field.Name,

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/ApplicationForms/ApplicationFormVersionAppServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/ApplicationForms/ApplicationFormVersionAppServiceTests.cs
@@ -97,7 +97,7 @@ public class ApplicationFormVersionAppServiceTests(ITestOutputHelper outputHelpe
     }
 
     [Fact]
-    public void MappingReadService_Should_Use_CustomField_Key_For_Worksheet_Field_Name()
+    public void MappingReadService_Should_Use_Canonical_CustomField_Name_For_Worksheet_Field_Name()
     {
         var worksheet = new Worksheet(Guid.NewGuid(), "customfields-v1", "Custom Fields");
         var section = new WorksheetSection(Guid.NewGuid(), "section");
@@ -117,9 +117,7 @@ public class ApplicationFormVersionAppServiceTests(ITestOutputHelper outputHelpe
         var result = (WorksheetMappingFieldsDto)method!.Invoke(null, [worksheet])!;
 
         var field = result.Fields.Single();
-        field.Name.ShouldBe("CustomField2");
-        field.Name.ShouldNotContain("custom_customfields-v1");
-        field.Name.ShouldNotContain(".Text");
+        field.Name.ShouldBe("CustomField2.Text");
     }
 
     [Fact]

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/ApplicationForms/ApplicationFormVersionAppServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/ApplicationForms/ApplicationFormVersionAppServiceTests.cs
@@ -117,7 +117,7 @@ public class ApplicationFormVersionAppServiceTests(ITestOutputHelper outputHelpe
         var result = (WorksheetMappingFieldsDto)method!.Invoke(null, [worksheet])!;
 
         var field = result.Fields.Single();
-        field.Name.ShouldBe("CustomField2.Text");
+        field.Name.ShouldBe("custom_customfields-v1_customfield2.Text");
     }
 
     [Fact]

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Web.Tests/Pages/ApplicationForms/MappingModelTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Web.Tests/Pages/ApplicationForms/MappingModelTests.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Linq;
+using Shouldly;
+using Unity.GrantManager.ApplicationForms.Mapping;
+using Unity.GrantManager.Web.Pages.ApplicationForms;
+using Xunit;
+
+namespace Unity.GrantManager.Pages.ApplicationForms;
+
+public class MappingModelTests
+{
+    [Fact]
+    public void BuildMappingFields_Should_Use_Unity_Targets_And_Exclude_Chefs_Sources()
+    {
+        var readModel = new ApplicationFormMappingReadModelDto
+        {
+            ChefsFields =
+            [
+                new MappingFieldDto { Name = "chefsProjectName", Label = "CHEFS Project Name", Type = "textfield" }
+            ],
+            UnityCoreFields =
+            [
+                new MappingFieldDto { Name = "ProjectName", Label = "Project Name", Type = "String" }
+            ],
+            Worksheets =
+            [
+                new WorksheetMappingFieldsDto
+                {
+                    Fields =
+                    [
+                        new MappingFieldDto { Name = "CustomField2.Text", Label = "Custom Field", Type = "String", IsCustom = true }
+                    ]
+                }
+            ]
+        };
+
+        var fields = MappingModel.BuildMappingFields(readModel);
+
+        fields.Select(field => field.Name).ShouldBe(["CustomField2.Text", "ProjectName"]);
+    }
+}


### PR DESCRIPTION
## Summary
- Restore Unity core fields as the mapping-page targets.
- Preserve the original custom-field key format used by saved mappings.
- Add regression coverage for target projection and custom-field keys.

## Validation
- User manually verified the mapping UI.
- git diff --check