### PR TITLE
AB#33411: Security Finding-Validate The IDs Belong To The Tenant On Download

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.HttpApi/Controllers/AttachmentController.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.HttpApi/Controllers/AttachmentController.cs
@@ -13,11 +13,14 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Unity.GrantManager.Applications;
+using Unity.GrantManager.Assessments;
 using Unity.GrantManager.Attachments;
 using Unity.GrantManager.Intakes;
 using Unity.GrantManager.Models;
 using Unity.Notifications.Emails;
 using Volo.Abp.AspNetCore.Mvc;
+using Volo.Abp.Domain.Repositories;
 using Volo.Abp.MultiTenancy;
 using Volo.Abp.Validation;
 
@@ -64,6 +67,9 @@ namespace Unity.GrantManager.Controllers
         private readonly ICurrentTenant _currentTenant;
         private readonly ILibreOfficeConversionService _libreOfficeConversionService;
         private readonly IAttachmentPreviewAppService _attachmentPreviewAppService;
+        private readonly IApplicantRepository _applicantRepository;
+        private readonly IApplicationRepository _applicationRepository;
+        private readonly IAssessmentRepository _assessmentRepository;
         // LazyServiceProvider is populated via property injection when ASP.NET Core activates this
         // controller through DI/routing. Unit tests that construct AttachmentController directly
         // (new AttachmentController(...)) bypass that activation, leaving it null - guard against
@@ -87,7 +93,10 @@ namespace Unity.GrantManager.Controllers
             IEmailLogAttachmentUploadService emailLogAttachmentUploadService,
             ICurrentTenant currentTenant,
             ILibreOfficeConversionService libreOfficeConversionService,
-            IAttachmentPreviewAppService attachmentPreviewAppService)
+            IAttachmentPreviewAppService attachmentPreviewAppService,
+            IApplicantRepository applicantRepository,
+            IApplicationRepository applicationRepository,
+            IAssessmentRepository assessmentRepository)
         {
             _fileAppService = fileAppService;
             _configuration = configuration;
@@ -96,6 +105,9 @@ namespace Unity.GrantManager.Controllers
             _currentTenant = currentTenant;
             _libreOfficeConversionService = libreOfficeConversionService;
             _attachmentPreviewAppService = attachmentPreviewAppService;
+            _applicantRepository = applicantRepository;
+            _applicationRepository = applicationRepository;
+            _assessmentRepository = assessmentRepository;
         }
 
         [HttpGet("applicant/{applicantId}/download/{fileName}")]
@@ -114,6 +126,11 @@ namespace Unity.GrantManager.Controllers
             if (string.IsNullOrWhiteSpace(fileName))
             {
                 return BadRequest(badRequestFileMsg);
+            }
+
+            if (!Guid.TryParse(applicantId, out var parsedApplicantId) || await _applicantRepository.FindAsync(parsedApplicantId) == null)
+            {
+                return NotFound(NotFoundFileMsg);
             }
 
             var folder = _configuration["S3:ApplicantS3Folder"] ?? throw new AbpValidationException("Missing server configuration: S3:ApplicantS3Folder");
@@ -163,6 +180,11 @@ namespace Unity.GrantManager.Controllers
                 return BadRequest(badRequestFileMsg);
             }
 
+            if (!Guid.TryParse(applicationId, out var parsedApplicationId) || await _applicationRepository.FindAsync(parsedApplicationId) == null)
+            {
+                return NotFound(NotFoundFileMsg);
+            }
+
             var folder = _configuration["S3:ApplicationS3Folder"] ?? throw new AbpValidationException("Missing server configuration: S3:ApplicationS3Folder");
 
             if (!folder.EndsWith('/'))
@@ -208,6 +230,11 @@ namespace Unity.GrantManager.Controllers
             if (string.IsNullOrWhiteSpace(fileName))
             {
                 return BadRequest(badRequestFileMsg);
+            }
+
+            if (!Guid.TryParse(assessmentId, out var parsedAssessmentId) || await _assessmentRepository.FindAsync(parsedAssessmentId) == null)
+            {
+                return NotFound(NotFoundFileMsg);
             }
 
             var folder = _configuration["S3:AssessmentS3Folder"] ?? throw new AbpValidationException("Missing server configuration: S3:AssessmentS3Folder");
@@ -336,6 +363,7 @@ namespace Unity.GrantManager.Controllers
             if (string.IsNullOrWhiteSpace(applicationId)) return BadRequest("Application ID must be provided.");
             if (!Guid.TryParse(applicationId, out var parsedApplicationId)) return BadRequest("Application ID must be a valid GUID.");
             if (string.IsNullOrWhiteSpace(fileName)) return BadRequest(badRequestFileMsg);
+            if (await _applicationRepository.FindAsync(parsedApplicationId) == null) return NotFound(NotFoundFileMsg);
             if (!LibreOfficeInstallationCache.IsInstalled(() => _libreOfficeConversionService.IsInstalled())) return StatusCode(503, new { error = libreOfficeNotInstalledMsg });
             try
             {
@@ -357,6 +385,7 @@ namespace Unity.GrantManager.Controllers
             if (string.IsNullOrWhiteSpace(assessmentId)) return BadRequest("Assessment ID must be provided.");
             if (!Guid.TryParse(assessmentId, out var parsedAssessmentId)) return BadRequest("Assessment ID must be a valid GUID.");
             if (string.IsNullOrWhiteSpace(fileName)) return BadRequest(badRequestFileMsg);
+            if (await _assessmentRepository.FindAsync(parsedAssessmentId) == null) return NotFound(NotFoundFileMsg);
             if (!LibreOfficeInstallationCache.IsInstalled(() => _libreOfficeConversionService.IsInstalled())) return StatusCode(503, new { error = libreOfficeNotInstalledMsg });
             try
             {
@@ -376,11 +405,13 @@ namespace Unity.GrantManager.Controllers
         {
             if (!ModelState.IsValid) return BadRequest(ModelState);
             if (string.IsNullOrWhiteSpace(applicantId)) return BadRequest("Applicant ID must be provided.");
+            if (!Guid.TryParse(applicantId, out var parsedApplicantId)) return BadRequest("Applicant ID must be a valid GUID.");
             if (string.IsNullOrWhiteSpace(fileName)) return BadRequest(badRequestFileMsg);
+            if (await _applicantRepository.FindAsync(parsedApplicantId) == null) return NotFound(NotFoundFileMsg);
             if (!_libreOfficeConversionService.IsInstalled()) return StatusCode(503, new { error = libreOfficeNotInstalledMsg });
             try
             {
-                var blob = await _attachmentPreviewAppService.GetOrCreatePreviewPdfAsync(AttachmentType.APPLICANT, Guid.Parse(applicantId), fileName);
+                var blob = await _attachmentPreviewAppService.GetOrCreatePreviewPdfAsync(AttachmentType.APPLICANT, parsedApplicantId, fileName);
                 if (blob?.Content == null) return NotFound(NotFoundFileMsg);
                 return File(blob.Content, PdfContentType);
             }

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Web.Tests/Components/AttachmentControllerTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Web.Tests/Components/AttachmentControllerTests.cs
@@ -5,6 +5,8 @@ using NSubstitute;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Unity.GrantManager.Applications;
+using Unity.GrantManager.Assessments;
 using Unity.GrantManager.Attachments;
 using Unity.GrantManager.Controllers;
 using Unity.GrantManager.Intakes;
@@ -30,7 +32,7 @@ namespace Unity.GrantManager.Components
             var currentTenant = Substitute.For<ICurrentTenant>();
             var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
             var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
-            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
             var applicationId = Guid.NewGuid();
             var userId = "testUserId";
             var userName = "testUserName";
@@ -66,7 +68,7 @@ namespace Unity.GrantManager.Components
             var currentTenant = Substitute.For<ICurrentTenant>();
             var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
             var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
-            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
             var applicationId = Guid.NewGuid();
             var userId = "testUserId";
             var userName = "testUserName";
@@ -105,7 +107,7 @@ namespace Unity.GrantManager.Components
             var currentTenant = Substitute.For<ICurrentTenant>();
             var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
             var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
-            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
             var applicationId = Guid.NewGuid();
             var userId = "testUserId";
             var userName = "testUserName";
@@ -149,7 +151,7 @@ namespace Unity.GrantManager.Components
             var currentTenant = Substitute.For<ICurrentTenant>();
             var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
             var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
-            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
             var applicationId = Guid.NewGuid();
             var userId = "testUserId";
             var userName = "testUserName";
@@ -193,7 +195,7 @@ namespace Unity.GrantManager.Components
             var currentTenant = Substitute.For<ICurrentTenant>();
             var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
             var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
-            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
             var applicationId = Guid.NewGuid();
             var userId = "testUserId";
             var userName = "testUserName";
@@ -238,7 +240,7 @@ namespace Unity.GrantManager.Components
             var currentTenant = Substitute.For<ICurrentTenant>();
             var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
             var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
-            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
             var applicationId = Guid.NewGuid();
             var userId = "testUserId";
             var userName = "testUserName";
@@ -281,7 +283,7 @@ namespace Unity.GrantManager.Components
             var currentTenant = Substitute.For<ICurrentTenant>();
             var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
             var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
-            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
             var applicationId = Guid.NewGuid();
             var userId = "testUserId";
             var userName = "testUserName";
@@ -322,7 +324,7 @@ namespace Unity.GrantManager.Components
             var currentTenant = Substitute.For<ICurrentTenant>();
             var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
             var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
-            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
             var applicationId = Guid.NewGuid();
             var userId = "testUserId";
             var userName = "testUserName";
@@ -362,7 +364,7 @@ namespace Unity.GrantManager.Components
             var currentTenant = Substitute.For<ICurrentTenant>();
             var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
             var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
-            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
             var applicationId = Guid.NewGuid();
             var userId = "testUserId";
             var userName = "testUserName";
@@ -410,7 +412,7 @@ namespace Unity.GrantManager.Components
             var currentTenant = Substitute.For<ICurrentTenant>();
             var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
             var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
-            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
             var applicationId = Guid.NewGuid();
             var userId = "testUserId";
             var userName = "testUserName";
@@ -459,7 +461,7 @@ namespace Unity.GrantManager.Components
             var currentTenant = Substitute.For<ICurrentTenant>();
             var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
             var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
-            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
             var applicationId = Guid.NewGuid();
             var userId = "testUserId";
             var userName = "testUserName";
@@ -508,7 +510,7 @@ namespace Unity.GrantManager.Components
             var currentTenant = Substitute.For<ICurrentTenant>();
             var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
             var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
-            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
             var applicationId = Guid.NewGuid();
             var userId = "testUserId";
             var userName = "testUserName";
@@ -544,7 +546,7 @@ namespace Unity.GrantManager.Components
             var currentTenant = Substitute.For<ICurrentTenant>();
             var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
             var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
-            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
             var applicationId = Guid.NewGuid();
             var userId = "testUserId";
             var userName = "testUserName";
@@ -586,7 +588,7 @@ namespace Unity.GrantManager.Components
             var currentTenant = Substitute.For<ICurrentTenant>();
             var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
             var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
-            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
             var emailLogId = Guid.NewGuid();
 
             // S3:EmailAttachmentMaxFileSize is 20 MB - stricter than the general S3:MaxFileSize
@@ -637,7 +639,7 @@ namespace Unity.GrantManager.Components
             var currentTenant = Substitute.For<ICurrentTenant>();
             var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
             var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
-            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
             var emailLogId = Guid.NewGuid();
 
             // 22 MB - under the general 25 MB cap, but over the 20 MB default email per-file cap.
@@ -686,7 +688,7 @@ namespace Unity.GrantManager.Components
             var currentTenant = Substitute.For<ICurrentTenant>();
             var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
             var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
-            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
             var emailLogId = Guid.NewGuid();
 
             // Each file is 15 MB - under the 20 MB per-file cap - but 30 MB combined exceeds the
@@ -734,7 +736,7 @@ namespace Unity.GrantManager.Components
             var currentTenant = Substitute.For<ICurrentTenant>();
             var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
             var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
-            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
             var emailLogId = Guid.NewGuid();
 
             // Each file is 15 MB - under both the general S3:MaxFileSize (25 MB) and the
@@ -793,7 +795,7 @@ namespace Unity.GrantManager.Components
             var currentTenant = Substitute.For<ICurrentTenant>();
             var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
             var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
-            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
 
             // Act
             Task<IActionResult> download = attachmentController.DownloadChefsAttachment(formSubmissionId, chefsFileAttachmentId, fileName);
@@ -803,6 +805,129 @@ namespace Unity.GrantManager.Components
             Assert.NotNull(downloadedFile);
             Assert.Equal(fileName, downloadedFile.FileDownloadName);
             Assert.Equal(contentType,downloadedFile.ContentType);
+        }
+
+        // Security regression tests (CWE-639 / IDOR): the controller must confirm the id in the
+        // route belongs to a real, tenant-scoped entity before ever touching S3. FindAsync returning
+        // null stands in for both "no such id" and "id belongs to another tenant" - ABP's automatic
+        // IMultiTenant query filter makes those indistinguishable at the repository level, which is
+        // exactly the property this fix relies on.
+
+        [Fact]
+        public async Task DownloadApplicantAttachment_ApplicantNotFoundOrWrongTenant_ReturnsNotFound()
+        {
+            // Arrange
+            var builder = new ConfigurationBuilder().AddJsonFile($"appsettings.json", optional: false);
+            var configuration = builder.Build();
+            var fileAppService = Substitute.For<IFileAppService>();
+            var submissionAppService = Substitute.For<ISubmissionAppService>();
+            var emailLogAttachmentUploadService = Substitute.For<IEmailLogAttachmentUploadService>();
+            var currentTenant = Substitute.For<ICurrentTenant>();
+            var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
+            var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
+            var applicantRepository = Substitute.For<IApplicantRepository>();
+            applicantRepository.FindAsync(Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<System.Threading.CancellationToken>())
+                .Returns((Applicant?)null);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, applicantRepository, Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
+
+            var fileName = "secret.pdf";
+            fileAppService.GetBlobAsync(Arg.Any<GetBlobRequestDto>())
+                .Returns(new BlobDto { Name = fileName, Content = [1, 2, 3], ContentType = "application/pdf" });
+
+            // Act
+            var result = await attachmentController.DownloadApplicantAttachment(Guid.NewGuid().ToString(), fileName);
+
+            // Assert
+            Assert.IsType<NotFoundObjectResult>(result);
+            await fileAppService.DidNotReceive().GetBlobAsync(Arg.Any<GetBlobRequestDto>());
+        }
+
+        [Fact]
+        public async Task DownloadApplicationAttachment_ApplicationNotFoundOrWrongTenant_ReturnsNotFound()
+        {
+            // Arrange
+            var builder = new ConfigurationBuilder().AddJsonFile($"appsettings.json", optional: false);
+            var configuration = builder.Build();
+            var fileAppService = Substitute.For<IFileAppService>();
+            var submissionAppService = Substitute.For<ISubmissionAppService>();
+            var emailLogAttachmentUploadService = Substitute.For<IEmailLogAttachmentUploadService>();
+            var currentTenant = Substitute.For<ICurrentTenant>();
+            var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
+            var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
+            var applicationRepository = Substitute.For<IApplicationRepository>();
+            applicationRepository.FindAsync(Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<System.Threading.CancellationToken>())
+                .Returns((Application?)null);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), applicationRepository, Substitute.For<IAssessmentRepository>());
+
+            var fileName = "secret.pdf";
+            fileAppService.GetBlobAsync(Arg.Any<GetBlobRequestDto>())
+                .Returns(new BlobDto { Name = fileName, Content = [1, 2, 3], ContentType = "application/pdf" });
+
+            // Act
+            var result = await attachmentController.DownloadApplicationAttachment(Guid.NewGuid().ToString(), fileName);
+
+            // Assert
+            Assert.IsType<NotFoundObjectResult>(result);
+            await fileAppService.DidNotReceive().GetBlobAsync(Arg.Any<GetBlobRequestDto>());
+        }
+
+        [Fact]
+        public async Task DownloadAssessmentAttachment_AssessmentNotFoundOrWrongTenant_ReturnsNotFound()
+        {
+            // Arrange
+            var builder = new ConfigurationBuilder().AddJsonFile($"appsettings.json", optional: false);
+            var configuration = builder.Build();
+            var fileAppService = Substitute.For<IFileAppService>();
+            var submissionAppService = Substitute.For<ISubmissionAppService>();
+            var emailLogAttachmentUploadService = Substitute.For<IEmailLogAttachmentUploadService>();
+            var currentTenant = Substitute.For<ICurrentTenant>();
+            var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
+            var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
+            var assessmentRepository = Substitute.For<IAssessmentRepository>();
+            assessmentRepository.FindAsync(Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<System.Threading.CancellationToken>())
+                .Returns((Assessment?)null);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, Substitute.For<IApplicantRepository>(), Substitute.For<IApplicationRepository>(), assessmentRepository);
+
+            var fileName = "secret.pdf";
+            fileAppService.GetBlobAsync(Arg.Any<GetBlobRequestDto>())
+                .Returns(new BlobDto { Name = fileName, Content = [1, 2, 3], ContentType = "application/pdf" });
+
+            // Act
+            var result = await attachmentController.DownloadAssessmentAttachment(Guid.NewGuid().ToString(), fileName);
+
+            // Assert
+            Assert.IsType<NotFoundObjectResult>(result);
+            await fileAppService.DidNotReceive().GetBlobAsync(Arg.Any<GetBlobRequestDto>());
+        }
+
+        [Fact]
+        public async Task PreviewApplicantAttachment_ApplicantNotFoundOrWrongTenant_ReturnsNotFound()
+        {
+            // Arrange
+            var builder = new ConfigurationBuilder().AddJsonFile($"appsettings.json", optional: false);
+            var configuration = builder.Build();
+            var fileAppService = Substitute.For<IFileAppService>();
+            var submissionAppService = Substitute.For<ISubmissionAppService>();
+            var emailLogAttachmentUploadService = Substitute.For<IEmailLogAttachmentUploadService>();
+            var currentTenant = Substitute.For<ICurrentTenant>();
+            var libreOfficeConversionService = Substitute.For<ILibreOfficeConversionService>();
+            libreOfficeConversionService.IsInstalled().Returns(true);
+            var attachmentPreviewAppService = Substitute.For<IAttachmentPreviewAppService>();
+            var applicantRepository = Substitute.For<IApplicantRepository>();
+            applicantRepository.FindAsync(Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<System.Threading.CancellationToken>())
+                .Returns((Applicant?)null);
+            var attachmentController = new AttachmentController(fileAppService, configuration, submissionAppService, emailLogAttachmentUploadService, currentTenant, libreOfficeConversionService, attachmentPreviewAppService, applicantRepository, Substitute.For<IApplicationRepository>(), Substitute.For<IAssessmentRepository>());
+
+            var fileName = "secret.pdf";
+            attachmentPreviewAppService.GetOrCreatePreviewPdfAsync(AttachmentType.APPLICANT, Arg.Any<Guid>(), fileName)
+                .Returns(new BlobDto { Name = fileName, Content = [1, 2, 3], ContentType = "application/pdf" });
+
+            // Act
+            var result = await attachmentController.PreviewApplicantAttachment(Guid.NewGuid().ToString(), fileName);
+
+            // Assert
+            Assert.IsType<NotFoundObjectResult>(result);
+            await attachmentPreviewAppService.DidNotReceive().GetOrCreatePreviewPdfAsync(Arg.Any<AttachmentType>(), Arg.Any<Guid>(), Arg.Any<string>());
         }
     }
 }


### PR DESCRIPTION
This code is to add checking in Download/Preview Attachments to make sure that the Applicant/Assessment/Application IDs belong to the user's tenant before allowing the Download Or Preview of the attachment.
No background workers/consumers got impacted by this changes.