### PR TITLE
AB#33922 exclude S7721 for JS widget scripts

### DIFF
--- a/applications/Unity.GrantManager/sonar-project.properties
+++ b/applications/Unity.GrantManager/sonar-project.properties
@@ -18,6 +18,23 @@ sonar.qualitygate.wait=true
 # SonarQube Exclusions (from existing Azure configuration)
 sonar.exclusions=src/Unity.GrantManager.EntityFrameworkCore/Migrations/**,modules/Unity.Payments/src/Unity.Payments.Web/Pages/BatchPayments/Index.js,src/Unity.GrantManager.EntityFrameworkCore/Scripts/**,**/bin/**,**/obj/**,**/wwwroot/lib/**,**/*.Designer.cs,**/node_modules/**
 
+# Rule exclusion: javascript:S7721 "Functions should be moved to the highest possible scope"
+# Disabled project-wide for JS. ABP renders pages by composing many independent widgets,
+# and dynamically bundles each widget's scripts together onto whatever page happens to
+# host them, at runtime. Widgets have no visibility into what else will be on the same
+# page, so the established, intentional pattern across this codebase is to nest each
+# widget's helper functions inside its own $(function(){...}) DOM-ready handler, using
+# that nesting as the widget's isolation boundary against same-named helpers in other
+# widgets (e.g. formatItems, responseCallback, updatePreview are common names reused
+# across many widgets). S7721 pushes these helpers up to module/global scope, which
+# breaks that isolation and creates real cross-widget name collisions that the rule
+# has no way to detect, since it only ever sees one file at a time. This has already
+# caused a production bug (two widgets bundled onto the same page silently overwrote
+# each other's same-named global function). Keep the nesting.
+sonar.issue.exclusions.multicriteria=e1
+sonar.issue.exclusions.multicriteria.e1.ruleKey=javascript:S7721
+sonar.issue.exclusions.multicriteria.e1.resourceKey=**/*.js
+
 # Test exclusions
 sonar.test.exclusions=**/bin/**,**/obj/**
 


### PR DESCRIPTION
ABP composes pages from many independently-authored widgets and dynamically bundles their scripts together at runtime, so widgets have no visibility into what else will share the page. This codebase relies on nesting helper functions inside each widget's own $(function(){...}) DOM-ready handler as an isolation boundary against same-named helpers in other widgets. S7721 (\"Functions should be moved to the highest possible scope\") pushes those helpers to module/global scope, which breaks that isolation and has already caused a production cross-widget name collision.