### PR TITLE
feature/AB#32293-DBMigratorUpdates-fixmapperlyOnPayments

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Domain/Services/PaymentRequestQueryManager.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/Domain/Services/PaymentRequestQueryManager.cs
@@ -152,7 +152,7 @@ namespace Unity.Payments.Domain.Services
             if (includeTags)
             {
                 paymentsQueryable = paymentsQueryable
-                    .Include(pr => pr.PaymentTags)
+                    .Include(pr => pr.PaymentTags!)
                     .ThenInclude(pt => pt.Tag);
             }
 
@@ -161,9 +161,7 @@ namespace Unity.Payments.Domain.Services
                 paymentsQueryable = paymentsQueryable.Include(pr => pr.ExpenseApprovals);
             }
 
-#pragma warning disable CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
             var paymentWithIncludes = await paymentsQueryable.ToListAsync();
-#pragma warning restore CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
 
             return paymentWithIncludes;
         }

--- a/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/PaymentsApplicationMapperlyProfile.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Payments/src/Unity.Payments.Application/PaymentsApplicationMapperlyProfile.cs
@@ -24,11 +24,15 @@ public partial class PaymentRequestToPaymentRequestDtoMapper : MapperBase<Paymen
     [MapperIgnoreTarget(nameof(PaymentRequestDto.ErrorSummary))]
     [MapperIgnoreTarget(nameof(PaymentRequestDto.AccountCodingDisplay))]
     [MapperIgnoreTarget(nameof(PaymentRequestDto.CreatorUser))]
+    [MapperIgnoreTarget(nameof(PaymentRequestDto.ApplicantId))]
+    [MapperIgnoreTarget(nameof(PaymentRequestDto.Category))]
     public override partial PaymentRequestDto Map(PaymentRequest source);
 
     [MapperIgnoreTarget(nameof(PaymentRequestDto.ErrorSummary))]
     [MapperIgnoreTarget(nameof(PaymentRequestDto.AccountCodingDisplay))]
     [MapperIgnoreTarget(nameof(PaymentRequestDto.CreatorUser))]
+    [MapperIgnoreTarget(nameof(PaymentRequestDto.ApplicantId))]
+    [MapperIgnoreTarget(nameof(PaymentRequestDto.Category))]
     public override partial void Map(PaymentRequest source, PaymentRequestDto destination);
 
     [MapperIgnoreTarget(nameof(ExpenseApprovalDto.DecisionUser))]


### PR DESCRIPTION
Fixes an issue with The member ApplicantId on the mapping target type Unity.Payments.PaymentRequests.PaymentRequestDto was not found on the mapping source type Unity.Payments.Domain.PaymentRequests.PaymentRequest [/src/modules/Unity.Payments/src/Unity.Payments.Application/Unity.Payments.Application.csproj]