### PR TITLE
feature/AB#33783 - Reduce CRUD AppService Exposure

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Prompts/AIPromptAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Prompts/AIPromptAppService.cs
@@ -6,12 +6,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using Unity.AI.Domain;
 using Unity.Modules.Shared.Permissions;
-using Volo.Abp.Data;
+using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
+using Volo.Abp.Data;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.MultiTenancy;
-using Volo.Abp;
 
 namespace Unity.AI.Prompts;
 
@@ -132,9 +132,7 @@ public class AIPromptAppService :
         }
     }
 
-    // Not used by any client; keep the entity soft-managed via IsActive rather than exposing hard delete.
     [RemoteService(false)]
-    [HttpDelete("{id}")]
     public override async Task DeleteAsync(Guid id)
     {
         using (_multiTenantDataFilter.Disable())

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Prompts/AIPromptAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Prompts/AIPromptAppService.cs
@@ -132,6 +132,8 @@ public class AIPromptAppService :
         }
     }
 
+    // Not used by any client; keep the entity soft-managed via IsActive rather than exposing hard delete.
+    [RemoteService(false)]
     [HttpDelete("{id}")]
     public override async Task DeleteAsync(Guid id)
     {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormAppService.cs
@@ -52,10 +52,9 @@ public class ApplicationFormAppService
         _applicationService = applicationService;
         _applicationFormSubmissionRepository = applicationFormSubmissionRepository;
         _formsApiService = formsApiService;
-        GetListPolicyName = GrantManagerPermissions.ApplicationForms.Default;
+        DeletePolicyName = GrantManagerPermissions.ApplicationForms.Default;
     }
 
-    // No caller uses this endpoint; disable it to reduce surface area.
     [RemoteService(false)]
     public override Task DeleteAsync(Guid id) => base.DeleteAsync(id);
 
@@ -225,7 +224,7 @@ public class ApplicationFormAppService
                     throw new BusinessException(GrantManagerDomainErrorCodes.ChildFormCannotReferenceSelf);
                 }
 
-                var parentForm = await Repository.FindAsync(dto.ParentFormId.Value) ?? throw new BusinessException(GrantManagerDomainErrorCodes.ChildFormRequiresParentForm);
+                _ = await Repository.FindAsync(dto.ParentFormId.Value) ?? throw new BusinessException(GrantManagerDomainErrorCodes.ChildFormRequiresParentForm);
             }
         }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormAppService.cs
@@ -9,8 +9,8 @@ using Unity.GrantManager.Forms;
 using Unity.GrantManager.GrantApplications;
 using Unity.GrantManager.Integrations.Chefs;
 using Unity.GrantManager.Permissions;
-using Unity.Payments.Permissions;
 using Unity.Payments.Enums;
+using Unity.Payments.Permissions;
 using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
@@ -52,7 +52,12 @@ public class ApplicationFormAppService
         _applicationService = applicationService;
         _applicationFormSubmissionRepository = applicationFormSubmissionRepository;
         _formsApiService = formsApiService;
+        GetListPolicyName = GrantManagerPermissions.ApplicationForms.Default;
     }
+
+    // No caller uses this endpoint; disable it to reduce surface area.
+    [RemoteService(false)]
+    public override Task DeleteAsync(Guid id) => base.DeleteAsync(id);
 
     [Authorize(GrantManagerPermissions.ApplicationForms.Default)]
     public override async Task<ApplicationFormDto> CreateAsync(CreateUpdateApplicationFormDto input)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormVersionAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormVersionAppService.cs
@@ -1,35 +1,34 @@
-﻿using Microsoft.Extensions.Logging;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Text.Json;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Unity.GrantManager.Applications;
 using Unity.AI.Cooldown;
 using Unity.AI.Features;
-using Unity.AI.Permissions;
 using Unity.AI.Operations;
+using Unity.AI.Permissions;
 using Unity.AI.Requests;
-using Unity.AI.Responses;
-using Unity.AI.Runtime;
+using Unity.Flex.Domain.Worksheets;
+using Unity.GrantManager.ApplicationForms.Mapping;
+using Unity.GrantManager.Applications;
 using Unity.GrantManager.Forms;
 using Unity.GrantManager.Intakes;
+using Unity.GrantManager.Intakes.Mapping;
 using Unity.GrantManager.Integrations.Chefs;
-using Unity.GrantManager.ApplicationForms.Mapping;
+using Unity.GrantManager.Permissions;
 using Unity.GrantManager.Reporting.FieldGenerators;
 using Unity.Modules.Shared.Features;
+using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Entities;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Features;
-using Volo.Abp;
 using Volo.Abp.Uow;
-using Unity.GrantManager.Intakes.Mapping;
-using Unity.Flex.Domain.Worksheets;
 
 namespace Unity.GrantManager.ApplicationForms
 {
@@ -62,11 +61,27 @@ namespace Unity.GrantManager.ApplicationForms
         public override async Task<ApplicationFormVersionDto> CreateAsync(CreateUpdateApplicationFormVersionDto input) =>
             await base.CreateAsync(input);
 
+        // No caller uses this endpoint; disable it to reduce surface area.
+        [RemoteService(false)]
         public override async Task<ApplicationFormVersionDto> UpdateAsync(Guid id, CreateUpdateApplicationFormVersionDto input) =>
             await base.UpdateAsync(id, input);
 
         public override async Task<ApplicationFormVersionDto> GetAsync(Guid id) =>
             await base.GetAsync(id);
+
+        // No caller uses these endpoints; disable them to reduce surface area.
+        [RemoteService(false)]
+        public override Task<PagedResultDto<ApplicationFormVersionDto>> GetListAsync(PagedAndSortedResultRequestDto input) =>
+            base.GetListAsync(input);
+
+        [RemoteService(false)]
+        public override Task DeleteAsync(Guid id) => base.DeleteAsync(id);
+
+        protected override Task CheckGetPolicyAsync()
+            => CheckPolicyAsync(GrantManagerPermissions.ApplicationForms.Default);
+
+        protected override Task CheckCreatePolicyAsync()
+            => CheckPolicyAsync(GrantManagerPermissions.ApplicationForms.Default);
 
         public async Task<bool> InitializePublishedFormVersion(dynamic chefsForm, Guid applicationFormId, bool initializePublishedOnly)
         {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/ApplicationContactAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/ApplicationContactAppService.cs
@@ -36,6 +36,7 @@ public class ApplicationContactAppService : CrudAppService<
     [RemoteService(false)]
     public override Task<PagedResultDto<ApplicationContactDto>> GetListAsync(PagedAndSortedResultRequestDto input) => base.GetListAsync(input);
 
+    [Authorize(GrantApplicationPermissions.ApplicantInfo.Read)]
     public async Task<List<ApplicationContactDto>> GetListByApplicationAsync(Guid applicationId)
     {
         var contacts = await _applicationContactRepository.GetListAsync(c => c.ApplicationId == applicationId);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/ApplicationContactAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/ApplicationContactAppService.cs
@@ -4,6 +4,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Unity.GrantManager.Applications;
+using Unity.GrantManager.Permissions;
+using Volo.Abp;
+using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Repositories;
@@ -23,8 +26,16 @@ public class ApplicationContactAppService : CrudAppService<
         IApplicationContactRepository applicationContactRepository) : base(repository)
     {
         _applicationContactRepository = applicationContactRepository;
+        GetPolicyName = GrantApplicationPermissions.ApplicantInfo.Read;
+        CreatePolicyName = GrantApplicationPermissions.ApplicantInfo.AddAdditionalContact;
+        UpdatePolicyName = GrantApplicationPermissions.ApplicantInfo.UpdateAdditionalContact;
+        DeletePolicyName = GrantApplicationPermissions.ApplicantInfo.DeleteAdditionalContact;
     }
-    
+
+    // The widget lists contacts via GetListByApplicationAsync
+    [RemoteService(false)]
+    public override Task<PagedResultDto<ApplicationContactDto>> GetListAsync(PagedAndSortedResultRequestDto input) => base.GetListAsync(input);
+
     public async Task<List<ApplicationContactDto>> GetListByApplicationAsync(Guid applicationId)
     {
         var contacts = await _applicationContactRepository.GetListAsync(c => c.ApplicationId == applicationId);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/ApplicationLinksAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/ApplicationLinksAppService.cs
@@ -7,6 +7,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using Unity.GrantManager.ApplicationForms;
 using Unity.GrantManager.Applications;
+using Unity.GrantManager.Permissions;
+using Volo.Abp;
+using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Repositories;
@@ -15,10 +18,10 @@ namespace Unity.GrantManager.GrantApplications;
 
 [Authorize]
 [ExposeServices(typeof(ApplicationLinksAppService), typeof(IApplicationLinksService))]
-public class ApplicationLinksAppService(IRepository<ApplicationLink, Guid> repository) : CrudAppService<
+public class ApplicationLinksAppService : CrudAppService<
         ApplicationLink,
         ApplicationLinksDto,
-        Guid>(repository), IApplicationLinksService
+        Guid>, IApplicationLinksService
 {
     // Validation Error Messages
     private const string ERROR_MULTIPLE_PARENTS = "Error: A submission can not have two parents. Please revise the link type.";
@@ -33,6 +36,23 @@ public class ApplicationLinksAppService(IRepository<ApplicationLink, Guid> repos
     public IApplicantRepository ApplicantRepository { get; set; } = null!;
     public IApplicationFormAppService ApplicationFormAppService { get; set; } = null!;
     public IRepository<ApplicationStatus, Guid> ApplicationStatusRepository { get; set; } = null!;
+
+    public ApplicationLinksAppService(IRepository<ApplicationLink, Guid> repository)
+        : base(repository)
+    {
+        CreatePolicyName = GrantApplicationPermissions.Applications.Default;
+        DeletePolicyName = GrantApplicationPermissions.Applications.Default;
+    }
+
+    // Custom GetListByApplicationAsync/UpdateLinkTypeAsync are used instead
+    [RemoteService(false)]
+    public override Task<ApplicationLinksDto> GetAsync(Guid id) => base.GetAsync(id);
+
+    [RemoteService(false)]
+    public override Task<PagedResultDto<ApplicationLinksDto>> GetListAsync(PagedAndSortedResultRequestDto input) => base.GetListAsync(input);
+
+    [RemoteService(false)]
+    public override Task<ApplicationLinksDto> UpdateAsync(Guid id, ApplicationLinksDto input) => base.UpdateAsync(id, input);
 
     public async Task<List<ApplicationLinksInfoDto>> GetListByApplicationAsync(Guid applicationId)
     {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/IntakeAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/IntakeAppService.cs
@@ -7,24 +7,24 @@ using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
 
-namespace Unity.GrantManager.Intakes
-{
-    [Authorize(GrantManagerPermissions.Intakes.Default)]
-    public class IntakeAppService :
-            CrudAppService<
-            Intake,
-            IntakeDto,
-            Guid,
-            PagedAndSortedResultRequestDto,
-            CreateUpdateIntakeDto>,
-            IIntakeAppService
-    {
-        public IntakeAppService(IRepository<Intake, Guid> repository)
-            : base(repository)
-        {
-        }
+namespace Unity.GrantManager.Intakes;
 
-        [RemoteService(false)]
-        public override Task DeleteAsync(Guid id) => base.DeleteAsync(id);
+[Authorize(GrantManagerPermissions.Intakes.Default)]
+public class IntakeAppService :
+        CrudAppService<
+        Intake,
+        IntakeDto,
+        Guid,
+        PagedAndSortedResultRequestDto,
+        CreateUpdateIntakeDto>,
+        IIntakeAppService
+{
+    public IntakeAppService(IRepository<Intake, Guid> repository)
+        : base(repository)
+    {
+        DeletePolicyName = GrantManagerPermissions.Intakes.Default;
     }
+
+    [RemoteService(false)]
+    public override Task DeleteAsync(Guid id) => base.DeleteAsync(id);
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/IntakeAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/IntakeAppService.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using System;
+using System.Threading.Tasks;
 using Unity.GrantManager.Permissions;
+using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
@@ -21,5 +23,8 @@ namespace Unity.GrantManager.Intakes
             : base(repository)
         {
         }
+
+        [RemoteService(false)]
+        public override Task DeleteAsync(Guid id) => base.DeleteAsync(id);
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Integrations/Endpoints/EndpointManagementAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Integrations/Endpoints/EndpointManagementAppService.cs
@@ -1,9 +1,10 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Caching.Distributed;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.Extensions.Caching.Distributed;
+using Unity.GrantManager.Permissions;
 using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
@@ -12,19 +13,31 @@ using Volo.Abp.Uow;
 
 namespace Unity.GrantManager.Integrations.Endpoints
 {
-    public class EndpointManagementAppService(
-        IRepository<DynamicUrl, Guid> repository,
-        IDistributedCache cache) :
+    public class EndpointManagementAppService :
         CrudAppService<
             DynamicUrl,
             DynamicUrlDto,
             Guid,
             PagedAndSortedResultRequestDto,
-            CreateUpdateDynamicUrlDto>(repository),
+            CreateUpdateDynamicUrlDto>,
         IEndpointManagementAppService
     {
-        private readonly IDistributedCache _cache = cache;
+        private readonly IDistributedCache _cache;
         private const string CACHE_KEY_SET_PREFIX = "DynamicUrl:KeySet";
+
+        public EndpointManagementAppService(IRepository<DynamicUrl, Guid> repository, IDistributedCache cache)
+            : base(repository)
+        {
+            _cache = cache;
+            GetPolicyName = GrantManagerPermissions.Endpoints.Default;
+            GetListPolicyName = GrantManagerPermissions.Endpoints.Default;
+            CreatePolicyName = GrantManagerPermissions.Endpoints.ManageEndpoints;
+            UpdatePolicyName = GrantManagerPermissions.Endpoints.ManageEndpoints;
+        }
+
+        // No caller uses this endpoint; disable it to reduce surface area.
+        [RemoteService(false)]
+        public override Task DeleteAsync(Guid id) => base.DeleteAsync(id);
 
         private static string BuildCacheKey(string keyName, bool tenantSpecific, Guid? tenantId)
             => $"DynamicUrl:{tenantSpecific}:{tenantId ?? Guid.Empty}:{keyName}";

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Payments/AccountCodingAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Payments/AccountCodingAppService.cs
@@ -8,26 +8,24 @@ using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
 
-namespace Unity.GrantManager.Payments
-{    
-    public class AccountCodingAppService :
-        CrudAppService<
-            AccountCoding,
-            AccountCodingDto,
-            Guid,
-            PagedAndSortedResultRequestDto,
-            CreateUpdateAccountCodingDto>, IAccountCodingAppService
-    {
-        public AccountCodingAppService(IRepository<AccountCoding, Guid> repository)
-            : base(repository)
-        {
-            GetPolicyName = UnitySettingManagementPermissions.ConfigurePayments;
-            GetListPolicyName = UnitySettingManagementPermissions.ConfigurePayments;
-            CreatePolicyName = UnitySettingManagementPermissions.ConfigurePayments;
-            UpdatePolicyName = UnitySettingManagementPermissions.ConfigurePayments;
-        }
+namespace Unity.GrantManager.Payments;
 
-        [RemoteService(false)]
-        public override Task DeleteAsync(Guid id) => base.DeleteAsync(id);
+public class AccountCodingAppService :
+    CrudAppService<
+        AccountCoding,
+        AccountCodingDto,
+        Guid,
+        PagedAndSortedResultRequestDto,
+        CreateUpdateAccountCodingDto>, IAccountCodingAppService
+{
+    public AccountCodingAppService(IRepository<AccountCoding, Guid> repository)
+        : base(repository)
+    {
+        CreatePolicyName = UnitySettingManagementPermissions.ConfigurePayments;
+        UpdatePolicyName = UnitySettingManagementPermissions.ConfigurePayments;
+        DeletePolicyName = UnitySettingManagementPermissions.ConfigurePayments;
     }
+
+    [RemoteService(false)]
+    public override Task DeleteAsync(Guid id) => base.DeleteAsync(id);
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Payments/AccountCodingAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Payments/AccountCodingAppService.cs
@@ -1,20 +1,33 @@
 using System;
+using System.Threading.Tasks;
+using Unity.GrantManager.Permissions;
 using Unity.Payments.Domain.AccountCodings;
 using Unity.Payments.PaymentRequests;
+using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
 
 namespace Unity.GrantManager.Payments
 {    
-    public class AccountCodingAppService(
-        IRepository<AccountCoding, Guid> repository
-    ) : CrudAppService<
+    public class AccountCodingAppService :
+        CrudAppService<
             AccountCoding,
             AccountCodingDto,
             Guid,
             PagedAndSortedResultRequestDto,
-            CreateUpdateAccountCodingDto>(repository), IAccountCodingAppService
+            CreateUpdateAccountCodingDto>, IAccountCodingAppService
     {
+        public AccountCodingAppService(IRepository<AccountCoding, Guid> repository)
+            : base(repository)
+        {
+            GetPolicyName = UnitySettingManagementPermissions.ConfigurePayments;
+            GetListPolicyName = UnitySettingManagementPermissions.ConfigurePayments;
+            CreatePolicyName = UnitySettingManagementPermissions.ConfigurePayments;
+            UpdatePolicyName = UnitySettingManagementPermissions.ConfigurePayments;
+        }
+
+        [RemoteService(false)]
+        public override Task DeleteAsync(Guid id) => base.DeleteAsync(id);
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Payments/PaymentThresholdAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Payments/PaymentThresholdAppService.cs
@@ -23,6 +23,9 @@ public class PaymentThresholdAppService :
     public PaymentThresholdAppService(IRepository<PaymentThreshold, Guid> repository)
         : base(repository)
     {
+        CreatePolicyName = UnitySettingManagementPermissions.ConfigurePayments;
+        UpdatePolicyName = UnitySettingManagementPermissions.ConfigurePayments;
+        DeletePolicyName = UnitySettingManagementPermissions.ConfigurePayments;
     }
 
     // Listing goes through PaymentSettingsAppService.GetL2ApproversThresholds

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Payments/PaymentThresholdAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Payments/PaymentThresholdAppService.cs
@@ -1,23 +1,40 @@
+using Microsoft.AspNetCore.Authorization;
 using System;
+using System.Threading.Tasks;
+using Unity.GrantManager.Permissions;
 using Unity.Payments.Domain.PaymentThresholds;
 using Unity.Payments.PaymentThresholds;
+using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
 
-namespace Unity.GrantManager.Payments
-{    
-    public class PaymentThresholdAppService :
-            CrudAppService<
-            PaymentThreshold,
-            PaymentThresholdDto,
-            Guid,
-            PagedAndSortedResultRequestDto,
-            UpdatePaymentThresholdDto>, IPaymentThresholdAppService
+namespace Unity.GrantManager.Payments;
+
+[Authorize(UnitySettingManagementPermissions.ConfigurePayments)]
+public class PaymentThresholdAppService :
+        CrudAppService<
+        PaymentThreshold,
+        PaymentThresholdDto,
+        Guid,
+        PagedAndSortedResultRequestDto,
+        UpdatePaymentThresholdDto>, IPaymentThresholdAppService
+{
+    public PaymentThresholdAppService(IRepository<PaymentThreshold, Guid> repository)
+        : base(repository)
     {
-        public PaymentThresholdAppService(IRepository<PaymentThreshold, Guid> repository)
-            : base(repository)
-        {
-        }
     }
+
+    // Listing goes through PaymentSettingsAppService.GetL2ApproversThresholds
+    [RemoteService(false)]
+    public override Task<PagedResultDto<PaymentThresholdDto>> GetListAsync(PagedAndSortedResultRequestDto input)
+        => base.GetListAsync(input);
+
+    [RemoteService(false)]
+    public override Task<PaymentThresholdDto> CreateAsync(UpdatePaymentThresholdDto input)
+        => base.CreateAsync(input);
+
+    [RemoteService(false)]
+    public override Task DeleteAsync(Guid id) 
+        => base.DeleteAsync(id);
 }


### PR DESCRIPTION
## Pull request overview

This PR reduces the externally exposed CRUD surface area of several ABP `CrudAppService` endpoints by disabling unused remote methods and tightening authorization via ABP policy names / `[Authorize]` attributes across Payments, Intakes, Integrations, GrantApplications, ApplicationForms, and Unity.AI modules.

**Changes:**
- Disabled unused CRUD endpoints by overriding and applying `[RemoteService(false)]` (primarily `DeleteAsync`, plus additional list/create/update endpoints in select services).
- Added/standardized authorization via ABP policy names (`GetPolicyName`, `CreatePolicyName`, etc.) and/or `[Authorize(...)]` at the class level.
- Refactored some services away from primary constructors to explicit constructors to initialize policy names and other fields.