### PR TITLE
feature/AB#33783 - Reduce CRUD AppService Exposure - Simplified

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Prompts/AIPromptAppService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Prompts/AIPromptAppService.cs
@@ -6,12 +6,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using Unity.AI.Domain;
 using Unity.Modules.Shared.Permissions;
-using Volo.Abp.Data;
+using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
+using Volo.Abp.Data;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.MultiTenancy;
-using Volo.Abp;
 
 namespace Unity.AI.Prompts;
 
@@ -132,7 +132,7 @@ public class AIPromptAppService :
         }
     }
 
-    [HttpDelete("{id}")]
+    [RemoteService(false)]
     public override async Task DeleteAsync(Guid id)
     {
         using (_multiTenantDataFilter.Disable())

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormAppService.cs
@@ -222,7 +222,7 @@ public class ApplicationFormAppService
                     throw new BusinessException(GrantManagerDomainErrorCodes.ChildFormCannotReferenceSelf);
                 }
 
-                var parentForm = await Repository.FindAsync(dto.ParentFormId.Value) ?? throw new BusinessException(GrantManagerDomainErrorCodes.ChildFormRequiresParentForm);
+                _ = await Repository.FindAsync(dto.ParentFormId.Value) ?? throw new BusinessException(GrantManagerDomainErrorCodes.ChildFormRequiresParentForm);
             }
         }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormAppService.cs
@@ -9,8 +9,8 @@ using Unity.GrantManager.Forms;
 using Unity.GrantManager.GrantApplications;
 using Unity.GrantManager.Integrations.Chefs;
 using Unity.GrantManager.Permissions;
-using Unity.Payments.Permissions;
 using Unity.Payments.Enums;
+using Unity.Payments.Permissions;
 using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
@@ -52,6 +52,8 @@ public class ApplicationFormAppService
         _applicationService = applicationService;
         _applicationFormSubmissionRepository = applicationFormSubmissionRepository;
         _formsApiService = formsApiService;
+
+        DeletePolicyName = GrantManagerPermissions.ApplicationForms.Default;
     }
 
     [Authorize(GrantManagerPermissions.ApplicationForms.Default)]
@@ -307,4 +309,8 @@ public class ApplicationFormAppService
             ApplicationFormVersion = formDetails.ApplicationFormVersion
         };
     }
+
+    [RemoteService(false)]
+    public override Task DeleteAsync(Guid id)
+        => base.DeleteAsync(id);
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormVersionAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormVersionAppService.cs
@@ -1,35 +1,33 @@
-﻿using Microsoft.Extensions.Logging;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Text.Json;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Unity.GrantManager.Applications;
 using Unity.AI.Cooldown;
 using Unity.AI.Features;
-using Unity.AI.Permissions;
 using Unity.AI.Operations;
+using Unity.AI.Permissions;
 using Unity.AI.Requests;
-using Unity.AI.Responses;
-using Unity.AI.Runtime;
+using Unity.Flex.Domain.Worksheets;
+using Unity.GrantManager.ApplicationForms.Mapping;
+using Unity.GrantManager.Applications;
 using Unity.GrantManager.Forms;
 using Unity.GrantManager.Intakes;
+using Unity.GrantManager.Intakes.Mapping;
 using Unity.GrantManager.Integrations.Chefs;
-using Unity.GrantManager.ApplicationForms.Mapping;
 using Unity.GrantManager.Reporting.FieldGenerators;
 using Unity.Modules.Shared.Features;
+using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Entities;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Features;
-using Volo.Abp;
 using Volo.Abp.Uow;
-using Unity.GrantManager.Intakes.Mapping;
-using Unity.Flex.Domain.Worksheets;
 
 namespace Unity.GrantManager.ApplicationForms
 {
@@ -62,11 +60,16 @@ namespace Unity.GrantManager.ApplicationForms
         public override async Task<ApplicationFormVersionDto> CreateAsync(CreateUpdateApplicationFormVersionDto input) =>
             await base.CreateAsync(input);
 
+        [RemoteService(false)]
         public override async Task<ApplicationFormVersionDto> UpdateAsync(Guid id, CreateUpdateApplicationFormVersionDto input) =>
             await base.UpdateAsync(id, input);
 
         public override async Task<ApplicationFormVersionDto> GetAsync(Guid id) =>
             await base.GetAsync(id);
+
+        [RemoteService(false)]
+        public override Task DeleteAsync(Guid id)
+            => base.DeleteAsync(id);
 
         public async Task<bool> InitializePublishedFormVersion(dynamic chefsForm, Guid applicationFormId, bool initializePublishedOnly)
         {
@@ -348,9 +351,9 @@ namespace Unity.GrantManager.ApplicationForms
                 Data = FormMappingPromptDataBuilder.Build(readModel)
             });
             var submissionHeaderMapping = FormMappingResponseMapper.BuildSubmissionHeaderMapping(response);
-            var applicationFormVersion = await repository.GetAsync(id);
+            var applicationFormVersion = await Repository.GetAsync(id);
             applicationFormVersion.SubmissionHeaderMapping = submissionHeaderMapping;
-            await repository.UpdateAsync(applicationFormVersion, true);
+            await Repository.UpdateAsync(applicationFormVersion, true);
 
             return new ApplicationFormMappingDto
             {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/ApplicationLinksAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/ApplicationLinksAppService.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Unity.GrantManager.ApplicationForms;
 using Unity.GrantManager.Applications;
+using Volo.Abp;
 using Volo.Abp.Application.Services;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Repositories;
@@ -444,6 +445,16 @@ public class ApplicationLinksAppService(IRepository<ApplicationLink, Guid> repos
             };
         }
     }
+
+    /// <summary>
+    /// Updates the intake with the specified <paramref name="id"/> using the provided <paramref name="input"/>.
+    /// </summary>
+    /// <remarks>Use <see cref="UpdateLinkTypeAsync"/> to update the link type instead of deleting.</remarks>
+    /// <param name="id"></param>
+    /// <param name="input"></param>
+    /// <returns></returns>
+    [RemoteService(false)]
+    public override Task<ApplicationLinksDto> UpdateAsync(Guid id, ApplicationLinksDto input) => base.UpdateAsync(id, input);
 
     public async Task UpdateLinkTypeAsync(Guid applicationLinkId, ApplicationLinkType newLinkType)
     {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/ApplicationLinksAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/ApplicationLinksAppService.cs
@@ -447,12 +447,12 @@ public class ApplicationLinksAppService(IRepository<ApplicationLink, Guid> repos
     }
 
     /// <summary>
-    /// Updates the intake with the specified <paramref name="id"/> using the provided <paramref name="input"/>.
+    /// Updates an application link with the specified <paramref name="id"/> using the provided <paramref name="input"/>.
     /// </summary>
-    /// <remarks>Use <see cref="UpdateLinkTypeAsync"/> to update the link type instead of deleting.</remarks>
-    /// <param name="id"></param>
-    /// <param name="input"></param>
-    /// <returns></returns>
+    /// <remarks>Remote updates are disabled; use <see cref="UpdateLinkTypeAsync"/> to change the link type.</remarks>
+     /// <param name="id">The unique identifier of the application link to update.</param>
+     /// <param name="input">The updated application link data.</param>
+     /// <returns>The updated application link.</returns>
     [RemoteService(false)]
     public override Task<ApplicationLinksDto> UpdateAsync(Guid id, ApplicationLinksDto input) => base.UpdateAsync(id, input);
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/IntakeAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/IntakeAppService.cs
@@ -1,25 +1,36 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using System;
+using System.Threading.Tasks;
 using Unity.GrantManager.Permissions;
+using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
 
-namespace Unity.GrantManager.Intakes
+namespace Unity.GrantManager.Intakes;
+
+[Authorize(GrantManagerPermissions.Intakes.Default)]
+public class IntakeAppService :
+        CrudAppService<
+        Intake,
+        IntakeDto,
+        Guid,
+        PagedAndSortedResultRequestDto,
+        CreateUpdateIntakeDto>,
+        IIntakeAppService
 {
-    [Authorize(GrantManagerPermissions.Intakes.Default)]
-    public class IntakeAppService :
-            CrudAppService<
-            Intake,
-            IntakeDto,
-            Guid,
-            PagedAndSortedResultRequestDto,
-            CreateUpdateIntakeDto>,
-            IIntakeAppService
+    public IntakeAppService(IRepository<Intake, Guid> repository)
+        : base(repository)
     {
-        public IntakeAppService(IRepository<Intake, Guid> repository)
-            : base(repository)
-        {
-        }
+        DeletePolicyName = GrantManagerPermissions.Intakes.Default;
     }
+
+    /// <summary>
+    /// Deletes the intake with the specified <paramref name="id"/>.
+    /// </summary>
+    /// <param name="id">The unique identifier of the intake to delete.</param>
+    /// <returns>A task that represents the asynchronous delete operation.</returns>
+    [RemoteService(false)]
+    public override Task DeleteAsync(Guid id)
+        => base.DeleteAsync(id);
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Integrations/Endpoints/EndpointManagementAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Integrations/Endpoints/EndpointManagementAppService.cs
@@ -1,9 +1,9 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Caching.Distributed;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.Extensions.Caching.Distributed;
 using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
@@ -188,5 +188,9 @@ namespace Unity.GrantManager.Integrations.Endpoints
             // Clear the key set itself
             await _cache.RemoveAsync(keySetKey);
         }
+
+        [RemoteService(false)]
+        public override Task DeleteAsync(Guid id)
+            => base.DeleteAsync(id);
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Payments/AccountCodingAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Payments/AccountCodingAppService.cs
@@ -28,18 +28,6 @@ public class AccountCodingAppService :
     /// <summary>
     /// Deletes the account coding with the specified <paramref name="id"/>.
     /// </summary>
-    /// <remarks>
-    /// <list type="number">
-    ///     <item>
-    ///         <term>API Restriction</term>
-    ///         <description>Has been removed from API registration</description>
-    ///     </item>
-    ///     <item>
-    ///         <term>Permission Policy</term>
-    ///         <description>Requires <see cref="UnitySettingManagementPermissions.ConfigurePayments" /></description>
-    ///     </item>
-    /// </list>
-    /// </remarks>
     /// <param name="id">The unique identifier of the account coding to delete.</param>
     /// <returns>A task that represents the asynchronous delete operation.</returns>
     [RemoteService(false)]

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Payments/AccountCodingAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Payments/AccountCodingAppService.cs
@@ -1,20 +1,48 @@
+using Microsoft.AspNetCore.Authorization;
 using System;
+using System.Threading.Tasks;
+using Unity.GrantManager.Permissions;
 using Unity.Payments.Domain.AccountCodings;
 using Unity.Payments.PaymentRequests;
+using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
 
-namespace Unity.GrantManager.Payments
-{    
-    public class AccountCodingAppService(
-        IRepository<AccountCoding, Guid> repository
-    ) : CrudAppService<
-            AccountCoding,
-            AccountCodingDto,
-            Guid,
-            PagedAndSortedResultRequestDto,
-            CreateUpdateAccountCodingDto>(repository), IAccountCodingAppService
+namespace Unity.GrantManager.Payments;
+
+[Authorize]
+public class AccountCodingAppService :
+    CrudAppService<
+        AccountCoding,
+        AccountCodingDto,
+        Guid,
+        PagedAndSortedResultRequestDto,
+        CreateUpdateAccountCodingDto>, IAccountCodingAppService
+{
+    public AccountCodingAppService(IRepository<AccountCoding, Guid> repository) : base(repository)
     {
+        DeletePolicyName = UnitySettingManagementPermissions.ConfigurePayments;
     }
+
+    /// <summary>
+    /// Deletes the account coding with the specified <paramref name="id"/>.
+    /// </summary>
+    /// <remarks>
+    /// <list type="number">
+    ///     <item>
+    ///         <term>API Restriction</term>
+    ///         <description>Has been removed from API registration</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>Permission Policy</term>
+    ///         <description>Requires <see cref="UnitySettingManagementPermissions.ConfigurePayments" /></description>
+    ///     </item>
+    /// </list>
+    /// </remarks>
+    /// <param name="id">The unique identifier of the account coding to delete.</param>
+    /// <returns>A task that represents the asynchronous delete operation.</returns>
+    [RemoteService(false)]
+    public override Task DeleteAsync(Guid id)
+        => base.DeleteAsync(id);
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Payments/PaymentThresholdAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Payments/PaymentThresholdAppService.cs
@@ -24,7 +24,6 @@ public class PaymentThresholdAppService :
         : base(repository)
     {
         CreatePolicyName = UnitySettingManagementPermissions.ConfigurePayments;
-        UpdatePolicyName = UnitySettingManagementPermissions.ConfigurePayments;
         DeletePolicyName = UnitySettingManagementPermissions.ConfigurePayments;
     }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Payments/PaymentThresholdAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Payments/PaymentThresholdAppService.cs
@@ -1,23 +1,38 @@
+using Microsoft.AspNetCore.Authorization;
 using System;
+using System.Threading.Tasks;
+using Unity.GrantManager.Permissions;
 using Unity.Payments.Domain.PaymentThresholds;
 using Unity.Payments.PaymentThresholds;
+using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
 
-namespace Unity.GrantManager.Payments
-{    
-    public class PaymentThresholdAppService :
-            CrudAppService<
-            PaymentThreshold,
-            PaymentThresholdDto,
-            Guid,
-            PagedAndSortedResultRequestDto,
-            UpdatePaymentThresholdDto>, IPaymentThresholdAppService
+namespace Unity.GrantManager.Payments;
+
+[Authorize]
+public class PaymentThresholdAppService :
+    CrudAppService<
+        PaymentThreshold,
+        PaymentThresholdDto,
+        Guid,
+        PagedAndSortedResultRequestDto,
+        UpdatePaymentThresholdDto>, IPaymentThresholdAppService
+{
+    public PaymentThresholdAppService(IRepository<PaymentThreshold, Guid> repository)
+        : base(repository)
     {
-        public PaymentThresholdAppService(IRepository<PaymentThreshold, Guid> repository)
-            : base(repository)
-        {
-        }
+        CreatePolicyName = UnitySettingManagementPermissions.ConfigurePayments;
+        UpdatePolicyName = UnitySettingManagementPermissions.ConfigurePayments;
+        DeletePolicyName = UnitySettingManagementPermissions.ConfigurePayments;
     }
+
+    [RemoteService(false)]
+    public override Task<PaymentThresholdDto> CreateAsync(UpdatePaymentThresholdDto input)
+        => base.CreateAsync(input);
+
+    [RemoteService(false)]
+    public override Task DeleteAsync(Guid id)
+        => base.DeleteAsync(id);
 }


### PR DESCRIPTION
## Pull request overview

This PR reduces the externally exposed ABP `CrudAppService` API surface across several Application-layer services by disabling selected remote CRUD methods (via `[RemoteService(false)]`) and tightening authorization configuration through `[Authorize]` and ABP policy name properties.

**Changes:**
- Disabled remote exposure for selected CRUD methods (notably `DeleteAsync`, and in some cases `CreateAsync`/`UpdateAsync`) to shrink the public API surface.
- Added/adjusted authorization configuration (class-level `[Authorize]` and CRUD policy name properties) for payment/configuration-related services.
- Minor refactors/cleanups (file-scoped namespaces, using reorder, repository property usage).

### Reviewed changes

Copilot reviewed 8 out of 8 changed files in this pull request and generated 3 comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| applications/Unity.GrantManager/src/Unity.GrantManager.Application/Payments/PaymentThresholdAppService.cs | Adds `[Authorize]`, sets some CRUD policy names, disables remote Create/Delete. |
| applications/Unity.GrantManager/src/Unity.GrantManager.Application/Payments/AccountCodingAppService.cs | Adds `[Authorize]`, sets Delete policy name, disables remote Delete. |
| applications/Unity.GrantManager/src/Unity.GrantManager.Application/Integrations/Endpoints/EndpointManagementAppService.cs | Reorders usings and disables remote Delete. |
| applications/Unity.GrantManager/src/Unity.GrantManager.Application/Intakes/IntakeAppService.cs | Converts to file-scoped namespace, sets Delete policy name, disables remote Delete. |
| applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/ApplicationLinksAppService.cs | Disables remote Update and adds XML docs for the override. |
| applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormVersionAppService.cs | Disables remote Update/Delete and switches to `Repository` property usage in one method. |
| applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormAppService.cs | Sets `DeletePolicyName`, disables remote Delete, minor cleanup. |
| applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Prompts/AIPromptAppService.cs | Disables remote Delete (replacing explicit `[HttpDelete]`). |
</details>






