### PR TITLE
bugfix/AB#33914 - Application History and Various Bugfixes

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/unity-styles.css
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/unity-styles.css
@@ -920,5 +920,5 @@ table.dataTable th.dt-type-numeric div.dt-column-header,
 table.dataTable th.dt-type-date div.dt-column-header, 
 table.dataTable td.dt-type-numeric div.dt-column-header, 
 table.dataTable td.dt-type-date div.dt-column-header {
-    flex-direction: row;
+    flex-direction: row !important;
 }

--- a/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/unity-styles.css
+++ b/applications/Unity.GrantManager/modules/Unity.Theme.UX2/src/Unity.Theme.UX2/wwwroot/themes/ux2/unity-styles.css
@@ -915,3 +915,10 @@ div.dt-container div.dt-search {
 .filter-search-action-bar_search-wrapper {
     flex: 1;
 }
+
+table.dataTable th.dt-type-numeric div.dt-column-header, 
+table.dataTable th.dt-type-date div.dt-column-header, 
+table.dataTable td.dt-type-numeric div.dt-column-header, 
+table.dataTable td.dt-type-date div.dt-column-header {
+    flex-direction: row;
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantManagerFeaturesDefinitionProvider.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantManagerFeaturesDefinitionProvider.cs
@@ -13,7 +13,7 @@ namespace Unity.GrantManager
     {
         public override void Define(IFeatureDefinitionContext context)
         {
-            var myGroup = context.AddGroup("GrantManager");
+            var myGroup = context.AddGroup("GrantManager", displayName: LocalizableString.Create<GrantManagerResource>("Grant Manager"));
             var defaultValue = "false";
 
             myGroup.AddFeature("Unity.Payments",

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/HistoryWidget/HistoryWidgetViewComponent.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/HistoryWidget/HistoryWidgetViewComponent.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.History;
@@ -26,14 +27,21 @@ public class HistoryWidgetViewComponent(
         string? entityId = applicationId.ToString();
         Dictionary<string, string> applicationStatusDict = await GetApplicationStatusDict();
 
-        HistoryWidgetViewModel model = new()
-        {
-            ApplicationStatusHistoryList = await historyAppService.GetEntityPropertyChangesAsync(
+        var historyList = await historyAppService.GetEntityPropertyChangesAsync(
             new GetEntityPropertyChangesInput
             {
                 EntityId = entityId,
                 PropertyNames = [Property_ApplicationStatusId, Property_ExternalStatusVisibility],
-            }, applicationStatusDict),
+            }, applicationStatusDict);
+
+        // Suppress the automatic initial Unpublished entry created on new entities (no prior value)
+        historyList = historyList
+            .Where(h => !(h.PropertyName == Property_ExternalStatusVisibility && string.IsNullOrEmpty(h.OriginalValue)))
+            .ToList();
+
+        HistoryWidgetViewModel model = new()
+        {
+            ApplicationStatusHistoryList = historyList,
         };
 
         return View(model);


### PR DESCRIPTION
This PR includes:
- [AB#33914] Audit history widget should exclude initial published values
- [AB#33886] Bugfix for sort button layout on numeric and date type columns
- [AB#33565] Tenant configuration localization for Grant Manager group
## Pull request overview

This PR updates the Unity Grant Manager portal to refine the application audit/history display, improve DataTables sort-icon layout for numeric/date columns, and introduce a localized display name for the “GrantManager” feature group used in tenant configuration.

**Changes:**
- Filter the History widget to suppress the initial audit entry for `ExternalStatusVisibility` when there is no prior value.
- Add a localized display name for the `GrantManager` feature group definition.
- Adjust UX2 theme CSS to keep DataTables header content (title + sort control) laid out horizontally for numeric/date columns.

### Reviewed changes

Copilot reviewed 3 out of 3 changed files in this pull request and generated 2 comments.

| File | Description |
| ---- | ----------- |
| HistoryWidgetViewComponent.cs | Filters out the initial `ExternalStatusVisibility` audit entry (no prior value) before rendering the widget. |
| GrantManagerFeaturesDefinitionProvider.cs | Adds a `displayName` for the `GrantManager` feature group using `LocalizableString`. |
| unity-styles.css | Forces DataTables numeric/date column headers to use `flex-direction: row` to correct sort button layout. |