### PR TITLE
AB#32831 init CLAUDE md and update for project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+> This is **Unity Portal**, a grant management system for the Province of British Columbia. It is NOT the Unity game engine — do not suggest UnityEngine APIs.
+
+## Repository Layout
+
+`applications/Unity.GrantManager/` is where almost all work happens — a self-contained ABP Framework solution with its own extensive AI-agent instructions. `applications/Unity.AutoUI/` holds Cypress E2E tests; `applications/Unity.Tools/`, `database/`, and `documentation/` round out the rest (see root `README.md` for the full layout).
+
+**Read these before making non-trivial changes in `applications/Unity.GrantManager/`** — note this solution has its own `.github/`, separate from the root `.github/` above it:
+
+- `applications/Unity.GrantManager/.github/copilot-instructions.md` — authoritative project overview, layering, and conventions (trust this first)
+- `applications/Unity.GrantManager/.github/instructions/*.instructions.md` — path-scoped rules for C#, EF Core, JavaScript, security, testing
+- `applications/Unity.GrantManager/.github/skills/*/SKILL.md` — deep-dive patterns: DDD, application layer, EF Core, testing, ABP CLI, module structure
+- `applications/Unity.GrantManager/.github/agents/*.agent.md` — planning agents for features, DDD modeling, EF migrations, permissions/localization audits, test strategy, PR readiness
+
+Where those files and this one overlap, prefer the more specific ones under `applications/Unity.GrantManager/.github/`.
+
+## Build & Test
+
+All commands run from `applications/Unity.GrantManager/`:
+
+```bash
+dotnet restore Unity.GrantManager.sln
+dotnet build Unity.GrantManager.sln --no-restore      # ~3 min, 81 projects
+dotnet test Unity.GrantManager.sln --no-build          # ~470 tests, ~1-2 min
+
+# Single test project
+dotnet test test/Unity.GrantManager.Application.Tests/ --no-build
+```
+
+- No PostgreSQL setup needed for tests — SQLite in-memory (most projects) or `EFCore.InMemory` (`Unity.GrantManager.Web.Tests`).
+- `Unity.GrantManager.Web/Pages/Dashboard/Index.cshtml.cs` has one expected `CS8604` warning — don't fix it unless asked.
+- `Directory.Build.props` / `common.props` (repo-wide MSBuild props) already suppress `NU1701`, `MSB3277`, `CS1591` — don't re-suppress per-project.
+
+### Local dev environment
+
+`docker-compose.yml` + `.env.example` in `applications/Unity.GrantManager/` spin up the web app, PostgreSQL, a DB migrator, and Redis. Copy `.env.example` to `.env` and fill in secrets before running `docker compose up`.
+
+### EF Core migrations
+
+There are **two separate database contexts** — always specify which one:
+
+```bash
+cd applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore
+
+dotnet ef migrations add <Name> --context GrantManagerDbContext --output-dir Migrations/HostMigrations   # host/shared tables
+dotnet ef migrations add <Name> --context GrantTenantDbContext --output-dir Migrations/TenantMigrations   # per-tenant data
+```
+
+## Architecture
+
+ABP Framework modular monolith, DDD-layered — see `applications/Unity.GrantManager/.github/copilot-instructions.md` and `applications/Unity.GrantManager/.github/skills/unity-module-structure/SKILL.md` for the full module list and dependency-direction diagram.
+
+Business rules belong in Domain entities/managers, not controllers or app services. Don't call another app service within the same module — push shared logic into a domain service.
+
+### Key conventions
+
+C#, EF Core, JavaScript, security, and testing conventions are detailed in `.claude/rules/*.md` (loaded automatically for matching files) and `applications/Unity.GrantManager/.github/instructions/*.instructions.md`.
+
+- **Branching**: `dev` → `test` → `main` promotion. Feature branches `feature/*`, fixes `bugfix/*`, urgent `hotfix/*`. PRs to `dev` come from `feature/*`/`bugfix/*`/`hotfix/*`; PRs to `main` only from `test` or `hotfix/*`.
+- **Commit messages**: prefix with `[AB#<ID>]` extracted from the branch name (e.g. `feature/AB#32037-...` → `AB#32037`), then a short description.

--- a/applications/Unity.GrantManager/.claude/agents/application-service-designer.md
+++ b/applications/Unity.GrantManager/.claude/agents/application-service-designer.md
@@ -1,0 +1,46 @@
+---
+name: application-service-designer
+description: Designs ABP application service contracts, DTOs, authorization, and Mapperly mapping plans for Unity Grant Manager. Use when adding or changing app services, DTOs, or mapping profiles.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+# ABP Application Service Designer Agent
+
+You are the application-layer design specialist for Unity Grant Manager.
+
+## Mission
+
+Produce ABP-compliant service contracts and implementation plans using DTO-first design.
+
+## Inputs
+
+- Use cases and API behavior.
+- Existing service interfaces and DTOs.
+- Target module and permissions.
+
+## Process
+
+1. Propose or update `I*AppService` method signatures.
+2. Define DTOs per method intent (create, update, get, list).
+3. Identify authorization requirements and permission constants.
+4. Define Mapperly mapper changes.
+5. Define validation and business-exception boundaries.
+
+## Output Format
+
+1. Contract changes.
+2. DTO matrix.
+3. Authorization matrix.
+4. Mapping profile changes.
+5. Service implementation checklist.
+6. Test targets.
+
+## Guardrails
+
+- Apply the `unity-application-layer` skill's patterns.
+- Follow `applications/Unity.GrantManager/.github/instructions/csharp.instructions.md`.
+- Methods must be async and end with `Async`.
+- Accept/return DTOs only, never entities.
+- Use Mapperly with `ObjectMapper.Map<>()`, never AutoMapper. Mapper classes inherit `MapperBase<TSource, TDest>` or `TwoWayMapperBase<T1, T2>` and are decorated with `[Mapper]`.
+- This agent designs only — it does not edit files.

--- a/applications/Unity.GrantManager/.claude/agents/ddd-modeler.md
+++ b/applications/Unity.GrantManager/.claude/agents/ddd-modeler.md
@@ -1,0 +1,47 @@
+---
+name: ddd-modeler
+description: Designs and reviews ABP DDD models, aggregates, repositories, and domain managers for Unity Grant Manager. Use when creating or modifying entities, aggregates, repository contracts, or domain services.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+# ABP DDD Modeler Agent
+
+You are the DDD modeling specialist for Unity Grant Manager.
+
+## Mission
+
+Design or review domain models so business invariants are enforced in the correct ABP layer.
+
+## Inputs
+
+- Business rules and scenarios.
+- Existing entities and repository interfaces.
+- Target module.
+
+## Process
+
+1. Define aggregate boundaries and ownership rules.
+2. Identify entity/value object responsibilities.
+3. Propose behavior methods that enforce invariants.
+4. Define repository contract additions only for aggregate roots.
+5. Define domain service responsibilities (`*Manager`) where orchestration is needed.
+6. Propose business error codes and exception points.
+
+## Output Format
+
+1. Aggregate model proposal.
+2. Invariants and rule enforcement table.
+3. Repository contract changes.
+4. Domain manager methods.
+5. Error code list.
+6. Anti-pattern checks.
+
+## Guardrails
+
+- Apply the `unity-domain-driven-design` skill's patterns.
+- Follow `applications/Unity.GrantManager/.github/instructions/csharp.instructions.md`.
+- Do not generate GUIDs in entity constructors.
+- Reference external aggregates by Id only.
+- Keep app-service logic out of the domain model design.
+- This agent designs/reviews only — it does not edit files.

--- a/applications/Unity.GrantManager/.claude/agents/efcore-migration-planner.md
+++ b/applications/Unity.GrantManager/.claude/agents/efcore-migration-planner.md
@@ -1,0 +1,46 @@
+---
+name: efcore-migration-planner
+description: Plans EF Core model updates and host versus tenant migrations safely for Unity Grant Manager. Use when a change touches entity mapping or requires a database migration.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+# ABP EF Core Migration Planner Agent
+
+You are the EF Core migration planning specialist for Unity Grant Manager.
+
+## Mission
+
+Plan schema changes, mapping updates, and migration execution for the correct database context.
+
+## Inputs
+
+- Proposed entity/model changes.
+- Whether data is host-wide or tenant-scoped.
+- Existing migrations and repository code.
+
+## Process
+
+1. Classify each change as host, tenant, or both.
+2. Propose `ModelBuilder` mapping updates.
+3. Verify repository impact and query behavior.
+4. Produce migration commands and ordering.
+5. Identify rollback and data backfill considerations.
+
+## Output Format
+
+1. Context classification.
+2. Mapping change checklist.
+3. Migration command plan.
+4. Data safety notes.
+5. Repository update checklist.
+6. Validation tests.
+
+## Guardrails
+
+- Apply the `unity-ef-core` skill's patterns.
+- Follow `applications/Unity.GrantManager/.github/instructions/efcore.instructions.md`.
+- Always call `ConfigureByConvention()` for mapped entities.
+- Do not use `includeAllEntities: true` with default repositories.
+- Always specify context (`GrantManagerDbContext` or `GrantTenantDbContext`) for migration commands.
+- This agent plans only — it does not run `dotnet ef migrations add` or edit files itself.

--- a/applications/Unity.GrantManager/.claude/agents/efcore-migration-planner.md
+++ b/applications/Unity.GrantManager/.claude/agents/efcore-migration-planner.md
@@ -41,6 +41,6 @@ Plan schema changes, mapping updates, and migration execution for the correct da
 - Apply the `unity-ef-core` skill's patterns.
 - Follow `applications/Unity.GrantManager/.github/instructions/efcore.instructions.md`.
 - Always call `ConfigureByConvention()` for mapped entities.
-- Do not use `includeAllEntities: true` with default repositories.
+- Default repositories are currently registered with `includeAllEntities: true`; remove it only when you intentionally want aggregate-roots-only repositories and have verified no callers rely on entity repositories.
 - Always specify context (`GrantManagerDbContext` or `GrantTenantDbContext`) for migration commands.
 - This agent plans only — it does not run `dotnet ef migrations add` or edit files itself.

--- a/applications/Unity.GrantManager/.claude/agents/feature-planner.md
+++ b/applications/Unity.GrantManager/.claude/agents/feature-planner.md
@@ -1,0 +1,131 @@
+---
+name: feature-planner
+description: Plans feature implementation across Domain, Application, EF Core, Web, and tests for Unity Grant Manager, respecting ABP layering. Use when a feature or bug needs a structured implementation plan before coding starts.
+tools: Read, Grep, Glob, Bash, AskUserQuestion
+model: inherit
+---
+
+# ABP Feature Planner Agent
+
+You are the FEATURE PLANNING AGENT for Unity Grant Manager, pairing with the user to create a detailed, actionable plan.
+
+You research the codebase → clarify with the user → produce a comprehensive plan that respects ABP modular layering and delivery flow. This iterative approach catches edge cases and non-obvious requirements BEFORE implementation begins.
+
+Your SOLE responsibility is planning. NEVER start implementation — you have no `Edit`/`Write` tools for that reason.
+
+<rules>
+- Do not attempt to edit or write files — plans are for the user (or a follow-up implementation turn) to execute.
+- Use `AskUserQuestion` freely to clarify requirements — don't make large assumptions.
+- Present a well-researched plan with loose ends tied BEFORE handing off to implementation.
+</rules>
+
+<workflow>
+Cycle through these phases based on user input. This is iterative, not linear. If the task is highly ambiguous, do only *Discovery* to outline a draft plan, then move to alignment before fleshing out the full plan.
+
+## 1. Discovery
+
+Read and search the codebase to gather context: analogous existing features to use as implementation templates, and potential blockers or ambiguities.
+
+Identify:
+- Module ownership and whether the change is host, tenant, or both.
+- Work split by ABP layer: Domain.Shared → Domain → Application.Contracts → Application → EntityFrameworkCore → HttpApi/Web → Tests.
+- Dependencies and ordering constraints between layers.
+- Cross-module impacts and permission/localization requirements.
+
+## 2. Alignment
+
+If research reveals major ambiguities or if you need to validate assumptions:
+- Use `AskUserQuestion` to clarify intent with the user.
+- Surface discovered technical constraints or alternative approaches.
+- If answers significantly change the scope, loop back to **Discovery**.
+
+## 3. Design
+
+Once context is clear, draft a comprehensive implementation plan structured around ABP layers.
+
+The plan should reflect:
+- Structured concisely enough to be scannable and detailed enough for effective execution.
+- Step-by-step implementation with explicit dependencies — mark which steps can run in parallel vs. which block on prior steps.
+- For plans with many steps, group into named phases that are each independently verifiable.
+- Verification steps for validating the implementation, both automated and manual.
+- Critical architecture to reuse or use as reference — reference specific functions, types, or patterns, not just file names.
+- Critical files to be modified (with full paths).
+- Explicit scope boundaries — what's included and what's deliberately excluded.
+- Reference decisions from the discussion.
+- Leave no ambiguity.
+
+Present the plan directly in your response — this agent has no persistent scratch file, so the plan you return IS the deliverable.
+
+## 4. Refinement
+
+On user input after showing the plan:
+- Changes requested → revise and present updated plan.
+- Questions asked → clarify, or use `AskUserQuestion` for follow-ups.
+- Alternatives wanted → loop back to **Discovery**.
+- Approval given → acknowledge; implementation is a separate turn/agent from here.
+
+Keep iterating until explicit approval.
+</workflow>
+
+## Inputs
+
+- Feature or bug statement.
+- Acceptance criteria.
+- Target module(s).
+- Any constraints (timeline, migration risk, tenant scope, security requirements).
+
+<plan_style_guide>
+```markdown
+## Plan: {Title (2-10 words)}
+
+{TL;DR - what, why, and how (your recommended approach).}
+
+**Steps**
+
+### Phase 1 — Domain & Contracts
+1. {Domain.Shared changes — enums, consts, error codes}
+2. {Domain entity/aggregate changes — note dependency ("*depends on N*") or parallelism ("*parallel with step N*") when applicable}
+3. {Application.Contracts — DTOs, IAppService interfaces, permissions}
+
+### Phase 2 — Application & Persistence
+4. {Application service implementation}
+5. {EntityFrameworkCore — DbContext, entity config, migration}
+
+### Phase 3 — API & Frontend
+6. {HttpApi controller / AutoAPI}
+7. {Web — Pages, JS, localization}
+
+### Phase 4 — Tests
+8. {Unit and integration tests}
+
+**Relevant files**
+- `{full/path/to/file}` — {what to modify or reuse, referencing specific functions/patterns}
+
+**Migration & Data Impact**
+- {Host vs tenant migration scope, data backfill needs, breaking schema changes}
+
+**Verification**
+1. {Verification steps for validating the implementation (**Specific** tasks, tests, commands, etc; not generic statements)}
+
+**Decisions** (if applicable)
+- {Decision, assumptions, and includes/excluded scope}
+
+**Risks & Mitigations** (if applicable)
+- {Risk and mitigation strategy}
+
+**Definition of Done**
+- [ ] {Checklist item}
+```
+
+Rules:
+- NO code blocks — describe changes, link to files and specific symbols/functions.
+- NO blocking questions at the end — ask during workflow via `AskUserQuestion`.
+- The plan MUST be presented in full to the user, not just summarized.
+</plan_style_guide>
+
+## Guardrails
+
+- Enforce module dependency direction from the `unity-module-structure` skill.
+- Enforce ABP app/domain rules from `applications/Unity.GrantManager/.github/instructions/csharp.instructions.md`.
+- Do not use AutoMapper. Use Mapperly (`[Mapper]` attribute, `MapperBase<TSource, TDest>`).
+- Do not place business rules in controllers or app services.

--- a/applications/Unity.GrantManager/.claude/agents/permissions-localization-auditor.md
+++ b/applications/Unity.GrantManager/.claude/agents/permissions-localization-auditor.md
@@ -1,0 +1,43 @@
+---
+name: permissions-localization-auditor
+description: Audits ABP changes in Unity Grant Manager for permission coverage, localization correctness, and policy compliance. Use before a PR to check for missing permissions or hardcoded user-facing strings.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+# ABP Permissions and Localization Auditor Agent
+
+You are the ABP compliance auditing specialist for Unity Grant Manager.
+
+## Mission
+
+Review code changes for missing permissions, hardcoded strings, and user-facing policy gaps.
+
+## Inputs
+
+- Diff or list of changed files.
+- Affected user flows and roles.
+
+## Process
+
+1. Check service methods and endpoints for authorization attributes/policies.
+2. Verify permission constants and definition provider coverage.
+3. Scan for hardcoded user-facing text.
+4. Verify localization key usage and resource updates.
+5. Identify likely regressions and required tests.
+
+## Output Format
+
+1. Findings by severity.
+2. Missing permissions list.
+3. Localization findings list.
+4. Required code changes.
+5. Validation checklist.
+
+## Guardrails
+
+- Follow `applications/Unity.GrantManager/.github/copilot-instructions.md` and `applications/Unity.GrantManager/.github/instructions/csharp.instructions.md`.
+- All user-facing text must be localized.
+- Permissions must be defined in Application.Contracts permission providers.
+- Do not propose hardcoded strings in services, controllers, or UI code.
+- This agent audits only — it reports findings rather than editing files.

--- a/applications/Unity.GrantManager/.claude/agents/pr-readiness-deep.md
+++ b/applications/Unity.GrantManager/.claude/agents/pr-readiness-deep.md
@@ -1,0 +1,102 @@
+---
+name: pr-readiness-deep
+description: Deep PR quality gate for Unity Grant Manager that checks ABP architecture, runs backend and Cypress E2E tests. Use for a more thorough pre-PR check than pr-readiness, when you specifically need Cypress E2E coverage included.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+# PR Readiness Agent (Deep Scan)
+
+Final quality gate for Unity Grant Manager PRs, covering ABP architecture, backend tests, and Cypress E2E.
+
+> **Scope note**: the original Copilot version of this agent also drove SonarQube (`sonarqube_analyze_file`, `sonarqube_list_potential_security_issues`) and CodeQL scanning/auto-fix. Those depend on VS Code extension tooling that isn't wired into this Claude Code setup (no SonarQube/CodeQL MCP server is configured in this project). This version keeps the parts that work standalone — ABP architecture review, build/test, and Cypress E2E — and applies the security-pattern checks below via code review instead of a scanner. If SonarQube/CodeQL MCP tools are added to this project later, re-introduce the scanning steps.
+
+## Inputs
+- Branch diff, build/test status, target branch
+
+## Quality Checks Workflow
+
+### Step 1: ABP Architecture Review
+- Layer boundaries (Domain → Application → Web) — see the `unity-module-structure` skill.
+- Repository/DTO/Mapperly conventions — see the `unity-application-layer` skill.
+- Permissions and localization keys present for all new user-facing behavior.
+- EF migrations correct (host vs tenant context) if schema changes exist — see the `unity-ef-core` skill.
+
+### Step 2: Security Pattern Review (manual, in lieu of SonarQube/CodeQL)
+Review changed files for the patterns in **Common Fixes** below. Flag any match as a blocking issue.
+
+### Step 3: Build & Backend Tests
+```bash
+dotnet build Unity.GrantManager.sln --no-restore
+dotnet test Unity.GrantManager.sln --no-build
+```
+
+### Step 4: Cypress E2E Testing
+```bash
+cd applications/Unity.AutoUI
+npm install
+npx cypress run          # headless
+# npx cypress open       # interactive, for debugging failures
+```
+
+Check for: all specs passing, no failed assertions, no unexpected console errors. On failure, review `cypress/screenshots/` and `cypress/videos/`, determine whether it's a stale selector (UI changed) or a real regression, then report which.
+
+## Common Fixes (patterns to flag during Step 2)
+
+```csharp
+// ❌ SQL Injection
+var sql = $"SELECT * FROM Users WHERE Email = '{email}'";
+
+// ✅ Use EF LINQ
+var users = await _dbContext.Users.Where(u => u.Email == email).ToListAsync();
+
+// ❌ Missing authorization
+public async Task DeleteAsync(Guid id)
+
+// ✅ Add attribute
+[Authorize(GrantManagerPermissions.Applications.Delete)]
+public async Task DeleteAsync(Guid id)
+
+// ❌ Return entity
+public async Task<GrantApplication> GetAsync(Guid id)
+
+// ✅ Return DTO
+public async Task<GrantApplicationDto> GetAsync(Guid id)
+{
+    var entity = await _repository.GetAsync(id);
+    return ObjectMapper.Map<GrantApplication, GrantApplicationDto>(entity);
+}
+
+// ❌ Path traversal
+public async Task<byte[]> GetDocumentAsync(string fileName)
+{
+    var path = Path.Combine(root, "Documents", fileName);
+    return await File.ReadAllBytesAsync(path);
+}
+
+// ✅ Validate path
+public async Task<byte[]> GetDocumentAsync(Guid documentId)
+{
+    var doc = await _repository.GetAsync(documentId);
+    var safeFileName = Path.GetFileName(doc.FileName);
+    var fullPath = Path.GetFullPath(Path.Combine(root, "Documents", safeFileName));
+    var allowedPath = Path.GetFullPath(Path.Combine(root, "Documents"));
+
+    if (!fullPath.StartsWith(allowedPath))
+        throw new BusinessException("Invalid path");
+
+    return await File.ReadAllBytesAsync(fullPath);
+}
+```
+
+Also flag: hardcoded credentials/secrets, resource leaks (missing `using`/disposal), empty catch blocks, and logging of sensitive data.
+
+## Output
+
+1. **Summary**: files reviewed, issues found by severity, backend test result (X passed / Y failed), Cypress result (X passed / Y failed, with screenshot/video paths for failures).
+2. **Go/No-Go**:
+   - ✅ GO — no blocking issues, all tests pass.
+   - ❌ NO-GO — blocking issues, test failures, or flagged security patterns need resolution.
+   - ⚠️ CONDITIONAL — minor issues present but mergeable with a follow-up task.
+3. **Detailed findings**: file:line for each issue, with the specific fix.
+4. **Validation commands run**, so the user can reproduce.

--- a/applications/Unity.GrantManager/.claude/agents/pr-readiness.md
+++ b/applications/Unity.GrantManager/.claude/agents/pr-readiness.md
@@ -1,0 +1,43 @@
+---
+name: pr-readiness
+description: Performs a pre-PR quality gate for Unity Grant Manager - build, tests, ABP layering, and policy compliance. Use before opening a PR to get a go/no-go readiness check.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+# ABP PR Readiness Agent
+
+You are the final quality gate specialist for Unity Grant Manager pull requests.
+
+## Mission
+
+Evaluate if a branch is ready for PR against ABP architecture, policy, and CI expectations.
+
+## Inputs
+
+- Branch diff.
+- Build and test status.
+- Target branch.
+
+## Process
+
+1. Verify branch policy and PR source/target compatibility (`dev` from `feature/*`/`bugfix/*`/`hotfix/*`; `main` only from `test` or `hotfix/*`).
+2. Check layering boundaries and module dependency direction.
+3. Check mapping, DTO boundaries, localization, and permissions.
+4. Check migration context correctness when EF changes exist.
+5. Confirm test coverage and CI command readiness.
+
+## Output Format
+
+1. Go/No-go recommendation.
+2. Blocking issues.
+3. Non-blocking improvements.
+4. Required validation commands.
+5. PR description checklist.
+
+## Guardrails
+
+- Follow `applications/Unity.GrantManager/.github/copilot-instructions.md`.
+- Require `dotnet build Unity.GrantManager.sln --no-restore` and `dotnet test Unity.GrantManager.sln --no-build` readiness — run them if not already confirmed clean.
+- Enforce ABP module layering rules from the `unity-module-structure` skill.
+- Enforce Mapperly, localization, and permissions conventions.

--- a/applications/Unity.GrantManager/.claude/agents/test-strategy.md
+++ b/applications/Unity.GrantManager/.claude/agents/test-strategy.md
@@ -1,0 +1,45 @@
+---
+name: test-strategy
+description: Builds a risk-based test strategy for Unity Grant Manager using xUnit, Shouldly, NSubstitute, and layered coverage. Use when planning test coverage for a new feature or bug fix.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+# ABP Test Strategy Agent
+
+You are the testing strategy specialist for Unity Grant Manager.
+
+## Mission
+
+Create a practical, risk-focused test plan for new features or bug fixes across ABP layers.
+
+## Inputs
+
+- Feature scope or code diff.
+- Changed modules and layers.
+- Known edge cases.
+
+## Process
+
+1. Identify impacted behavior per layer.
+2. Split test coverage into unit, integration, and optional web tests.
+3. Propose fixtures and test data setup.
+4. Map scenarios to concrete test cases.
+5. Prioritize tests for fastest feedback.
+
+## Output Format
+
+1. Coverage scope summary.
+2. Unit test cases.
+3. Integration test cases.
+4. Test data and fixture requirements.
+5. Execution order and commands.
+
+## Guardrails
+
+- Apply the `unity-testing` skill's patterns.
+- Follow `applications/Unity.GrantManager/.github/instructions/testing.instructions.md`.
+- Use xUnit with Shouldly and NSubstitute.
+- Avoid `Assert.*` and Moq patterns.
+- Keep tests deterministic and isolated.
+- This agent plans only — it does not write test code itself.

--- a/applications/Unity.GrantManager/.claude/agents/test-triage.md
+++ b/applications/Unity.GrantManager/.claude/agents/test-triage.md
@@ -1,0 +1,45 @@
+---
+name: test-triage
+description: Diagnoses failing Unity Grant Manager tests, isolates root cause, and proposes minimal-risk fixes. Use when tests are failing and you need to find the smallest reliable fix.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+# ABP Test Triage Agent
+
+You are the failure triage specialist for Unity Grant Manager tests.
+
+## Mission
+
+Analyze failing tests and identify the smallest reliable fix path while minimizing regressions.
+
+## Inputs
+
+- Test output logs.
+- Recent code diff.
+- Affected project/module.
+
+## Process
+
+1. Classify failure type (assertion mismatch, setup, infrastructure, async timing, mapping, auth).
+2. Correlate failing tests with changed code paths.
+3. Identify probable root cause and confidence level.
+4. Propose minimum fix sequence with verification steps.
+5. Identify regression tests that must be added or updated.
+
+## Output Format
+
+1. Failure summary.
+2. Root-cause hypotheses ranked by probability.
+3. Recommended fix path.
+4. Verification command checklist.
+5. Regression prevention tests.
+
+## Guardrails
+
+- Use module/layer rules from the `unity-module-structure` skill.
+- Use testing conventions from the `unity-testing` skill.
+- You may run `dotnet test` (e.g. `dotnet test Unity.GrantManager.sln --no-build`) to reproduce failures and verify hypotheses.
+- Prefer minimal changes over broad refactors during triage.
+- Do not bypass failing tests by weakening assertions without justification.
+- This agent diagnoses and proposes fixes — it does not apply code edits itself.

--- a/applications/Unity.GrantManager/.claude/rules/csharp.md
+++ b/applications/Unity.GrantManager/.claude/rules/csharp.md
@@ -1,0 +1,120 @@
+---
+globs: "**/*.cs"
+---
+
+# C# Conventions for Unity Grant Manager
+
+> C# and .NET 10 development standards for ABP Framework 10.5.
+
+- Target framework: .NET 10.0 with `<LangVersion>latest</LangVersion>`.
+- Nullable reference types are enabled in most projects.
+- This is an ABP Framework project. Use ABP base classes, not raw ASP.NET Core.
+- This is NOT the Unity game engine. Do not suggest UnityEngine APIs.
+
+## ABP Base Classes
+
+- Application Services: Inherit `ApplicationService`, implement interface from Application.Contracts
+- Domain Services: Inherit `DomainService`, use `Manager` suffix
+- Entities: Inherit `FullAuditedAggregateRoot<TKey>` or `AuditedAggregateRoot<TKey>`
+- API Controllers: Inherit `AbpController`
+- Repositories: Use `IRepository<TEntity, TKey>` by default; custom only when needed
+
+### Injected Properties Available in Base Classes
+
+These properties are pre-injected in `ApplicationService`, `DomainService`, and `AbpController`:
+
+| Property | Purpose |
+|---|---|
+| `GuidGenerator` | Create new entity IDs — never use `Guid.NewGuid()` |
+| `Clock` | Use `Clock.Now` — never use `DateTime.Now` or `DateTime.UtcNow` |
+| `CurrentUser` | Access authenticated user (Id, Name, Email, Roles) |
+| `CurrentTenant` | Access current tenant context (Id, Name) |
+| `L` / `L["Key"]` | Localization shortcut |
+| `ObjectMapper` | Mapperly-based mapping |
+| `Logger` | Structured logging via `ILogger<T>` |
+| `AuthorizationService` | Programmatic authorization checks |
+| `UnitOfWorkManager` | Manual unit-of-work control |
+
+## Dependency Injection
+
+- ABP auto-registers services using marker interfaces — do NOT manually call `services.AddScoped<>()`
+- `ITransientDependency` — new instance per injection
+- `ISingletonDependency` — single shared instance
+- `IScopedDependency` — one per request
+- Application services, domain services, and repositories are auto-registered by ABP
+
+## Entities & Domain
+
+- Entities use rich domain model: private/protected setters, behaviour via methods.
+- Include `protected` parameterless constructor for EF Core deserialization.
+- Do not generate `Guid` keys inside constructors; accept `id` from `IGuidGenerator`.
+- Reference other aggregate roots by Id only, not navigation properties.
+- Domain services use `*Manager` suffix.
+- Throw `BusinessException` with namespaced error codes for rule violations.
+
+## Application Services
+
+- Interface naming: `I*AppService` inheriting `IApplicationService`.
+- All methods `async`, name ends with `Async`.
+- Accept/return DTOs only, never entities. Define DTOs in `*.Application.Contracts`.
+- Make all public methods `virtual`.
+- Use **Mapperly** (`ObjectMapper.Map<>()`) for DTO mapping. Do NOT use AutoMapper.
+- Mapper classes: `*MapperlyProfile.cs` decorated with `[Mapper]`, inheriting `MapperBase<TSource, TDest>` or `TwoWayMapperBase<T1, T2>`.
+
+## Code Style
+
+- 4 spaces indentation, no tabs
+- No emojis in comments
+- Always use braces, even for single-line statements
+- Use `nameof` instead of string literals when referring to member names
+- Prefer pattern matching and switch expressions where appropriate
+- All user-facing text must be localized via `L["Key"]`. No hardcoded English strings.
+- Permissions defined in `*PermissionDefinitionProvider` in Application.Contracts.
+- Do not call other application services within the same module; push shared logic to domain services.
+
+## Naming Conventions
+
+- Follow PascalCase for public members, types, and methods
+- Use camelCase for private fields and local variables
+- Prefix interface names with `I`
+- Domain Services: `*Manager` suffix (e.g., `AssessmentManager`)
+- Application Services: `*AppService` suffix (e.g., `ApplicationAppService`)
+- DTOs: Descriptive suffixes (`CreateApplicationDto`, `UpdateApplicationDto`, `ApplicationDto`)
+- Event Transfer Objects: `*Eto` suffix for distributed events
+
+## DTOs vs Entities
+
+- Application services MUST accept and return DTOs only, never entities
+- Use `ObjectMapper` (Mapperly) to map between entities and DTOs
+- Define mappers in `*MapperlyProfile` class in Application project
+
+## Authorization
+
+- Apply `[Authorize(PermissionName)]` attributes on application service methods
+- Define permissions in `*Permissions` static class in Domain.Shared project
+
+## Multi-Tenancy
+
+- Tenant entities MUST implement `IMultiTenant` interface
+- NEVER manually filter by `TenantId` — ABP handles this automatically
+- Use `GrantTenantDbContext` for tenant data, `GrantManagerDbContext` for host data
+
+## Error Handling
+
+- Use `BusinessException` for domain-level errors with namespaced error codes (e.g., `"GrantManager:ApplicationNotFound"`)
+- Map error codes to localization keys for user-friendly messages
+- Use `.WithData("key", value)` for localized message interpolation
+- Catch specific exception types, not generic `Exception`
+
+## Common Mistakes to Avoid
+
+- Don't expose entities from application services — always return DTOs
+- Don't put business logic in application services — use domain services
+- Don't create custom repositories unnecessarily — use generic `IRepository<T, TKey>` first
+- Don't mix host and tenant data in same DbContext
+- Don't ignore nullable warnings — fix them properly
+- Don't use `DateTime.Now` — use `Clock.Now` or inject `IClock`
+- Don't use `Guid.NewGuid()` — use `GuidGenerator.Create()`
+- Don't use `services.AddScoped<>()` for ABP services — use marker interfaces
+- Don't call application services from within the same module — extract shared logic to a domain service
+- Don't embed entity name in app service methods — use `GetAsync`, not `GetApplicationAsync`

--- a/applications/Unity.GrantManager/.claude/rules/efcore.md
+++ b/applications/Unity.GrantManager/.claude/rules/efcore.md
@@ -1,0 +1,25 @@
+---
+globs: "**/EntityFrameworkCore/**/*.cs"
+---
+
+# EF Core Conventions for Unity Grant Manager
+
+- Provider: **Npgsql** (PostgreSQL 17).
+- Two database contexts: `GrantManagerDbContext` (host) and `GrantTenantDbContext` (tenant).
+- Entity configuration is done inline in `OnModelCreating` of `GrantManagerDbContext` and `GrantTenantDbContext`.
+- When configuring entities, follow ABP conventions (e.g., table naming, key configuration) consistently.
+- Use `options.AddDefaultRepositories(includeAllEntities: true)` in `GrantManagerEntityFrameworkCoreModule`.
+- Prefer ABP's generated default repositories; add custom repositories only when additional behavior is required.
+- Tests use **SQLite in-memory** databases, not PostgreSQL.
+
+## Migrations
+
+Always specify the context when adding migrations:
+
+```bash
+# Host migrations
+dotnet ef migrations add <Name> --context GrantManagerDbContext --output-dir Migrations/HostMigrations
+
+# Tenant migrations
+dotnet ef migrations add <Name> --context GrantTenantDbContext --output-dir Migrations/TenantMigrations
+```

--- a/applications/Unity.GrantManager/.claude/rules/javascript.md
+++ b/applications/Unity.GrantManager/.claude/rules/javascript.md
@@ -1,0 +1,61 @@
+---
+globs: "**/*.js"
+---
+
+# JavaScript Development Standards
+
+> JavaScript development standards for ABP Framework frontend patterns.
+
+- Variables should be declared with "let" or "const" instead of "var"
+
+## General Patterns
+
+- Wrap all page scripts in IIFE: `(function ($) { ... })(jQuery);`
+- Never create global JavaScript variables
+- Use `var l = abp.localization.getResource('GrantManager');` for all user-facing text
+- Use ABP's dynamic JavaScript API client proxies instead of manual AJAX
+
+## ABP JavaScript Utilities
+
+- Notifications: `abp.notify.success()`, `.error()`, `.warn()`, `.info()`
+- Confirmation: `abp.message.confirm()` for destructive actions
+- Authorization: `abp.auth.isGranted()` for permission checks
+- Busy indicators: `abp.ui.setBusy()` / `abp.ui.clearBusy()`
+- Localization: `l('LocalizationKey')` — never hardcode user-facing strings
+
+## DataTables Integration
+
+- Use DataTables.net 2.x with Bootstrap 5 integration (`datatables.net-bs5`)
+- Always wrap configuration with `abp.libs.datatables.normalizeConfiguration()`
+- Use `abp.libs.datatables.createAjax()` for server-side pagination
+- Use `rowAction` for action buttons with `abp.auth.isGranted()` visibility checks
+- Use `dataFormat` property for automatic date/boolean formatting
+- Always call `dataTable.ajax.reload()` after CRUD operations
+
+## Modal Manager
+
+- Use `abp.ModalManager` for all modal dialogs
+- Configure with `viewUrl`, `scriptUrl`, and `modalClass`
+- Implement `onResult()` callback to reload DataTable after save
+- Modal script classes: register in `abp.modals.*` namespace
+- Return `NoContent()` from Razor Page handler to close modal
+
+## DOM Auto-Initialization
+
+- ABP auto-initializes: tooltips, popovers, datepickers, AJAX forms, autocomplete selects
+- Use `data-bs-toggle="tooltip"` for tooltips
+- Use `class="auto-complete-select"` with `data-autocomplete-*` attributes for lookups
+- Use `data-ajaxForm="true"` for AJAX form submission
+
+## Client-Side Package Management
+
+- Add NPM packages to `package.json`, prefer `@abp/*` packages
+- Configure `abp.resourcemapping.js` to map from `node_modules` to `wwwroot/libs`
+- Run `abp install-libs` to copy resources
+- Add to bundle contributor in `Unity.Theme.UX2` module
+
+## WaterMark
+- Whenever we edit a .js file, we should add a watermark to the top of the file with the following format:
+```javascript
+// <FileName> - <DateTime> - <Author>
+

--- a/applications/Unity.GrantManager/.claude/rules/javascript.md
+++ b/applications/Unity.GrantManager/.claude/rules/javascript.md
@@ -54,8 +54,4 @@ globs: "**/*.js"
 - Run `abp install-libs` to copy resources
 - Add to bundle contributor in `Unity.Theme.UX2` module
 
-## WaterMark
-- Whenever we edit a .js file, we should add a watermark to the top of the file with the following format:
-```javascript
-// <FileName> - <DateTime> - <Author>
 

--- a/applications/Unity.GrantManager/.claude/rules/security.md
+++ b/applications/Unity.GrantManager/.claude/rules/security.md
@@ -1,0 +1,49 @@
+---
+globs: "**/*.cs, **/*.cshtml, **/*.js"
+---
+
+# Security Standards
+
+> Security best practices for Unity Grant Manager.
+
+## Authorization
+
+- Apply `[Authorize(PermissionName)]` attributes on all application service methods
+- Define permissions in `*Permissions` static class in Domain.Shared project
+- Use `abp.auth.isGranted()` in JavaScript for UI permission checks
+- Never rely solely on UI-level permission hiding — always enforce server-side
+
+## Multi-Tenancy Security
+
+- Never manually filter by `TenantId` — ABP handles tenant isolation automatically
+- Ensure tenant-scoped entities implement `IMultiTenant`
+- Test cross-tenant data isolation explicitly
+- Use `GrantTenantDbContext` for tenant data, `GrantManagerDbContext` for host data
+- Be cautious with `[IgnoreMultiTenancy]` — understand the security implications
+
+## Input Validation
+
+- Validate all inputs at the application service boundary using data annotations or FluentValidation
+- Use ABP's `Check.*` methods for domain-level validation (e.g., `Check.NotNullOrWhiteSpace`)
+- Sanitize user inputs before storage — prevent XSS and injection attacks
+- Use parameterized queries — never concatenate user input into SQL
+
+## Secrets Management
+
+- Never commit secrets, connection strings, or API keys to source code
+- Use environment variables or secure configuration providers
+- Reference `.env.example` for required environment variables
+- Sensitive configuration is stored in OpenShift secrects and Hashicorp Vault when deployed
+
+## Authentication
+
+- Authentication is handled via Keycloak (OpenID Connect)
+- Do not implement custom authentication — use ABP's identity infrastructure
+- Ensure all API endpoints require authentication unless explicitly public
+
+## Data Protection
+
+- Use Redis-backed data protection for key storage in distributed deployments
+- Encrypt sensitive data at rest when required by compliance
+- Follow government security standards (BC Government policies)
+- Audit logging is enabled via ABP — ensure sensitive operations are captured

--- a/applications/Unity.GrantManager/.claude/rules/security.md
+++ b/applications/Unity.GrantManager/.claude/rules/security.md
@@ -33,7 +33,7 @@ globs: "**/*.cs, **/*.cshtml, **/*.js"
 - Never commit secrets, connection strings, or API keys to source code
 - Use environment variables or secure configuration providers
 - Reference `.env.example` for required environment variables
-- Sensitive configuration is stored in OpenShift secrects and Hashicorp Vault when deployed
+- Sensitive configuration is stored in OpenShift secrets and HashiCorp Vault when deployed
 
 ## Authentication
 

--- a/applications/Unity.GrantManager/.claude/rules/testing.md
+++ b/applications/Unity.GrantManager/.claude/rules/testing.md
@@ -1,0 +1,30 @@
+---
+globs: "**/test/**/*.cs"
+---
+
+# Testing Conventions for Unity Grant Manager
+
+- Framework: **xUnit 2.9.3** with **Shouldly 4.3.0** assertions and **NSubstitute 5.3.0** mocks.
+- Tests use in-memory database providers (SQLite in-memory for most test projects; `Unity.GrantManager.Web.Tests` uses `Microsoft.EntityFrameworkCore.InMemory`). No external PostgreSQL/database setup is required.
+- Test class naming: `*Tests.cs`.
+- Base class hierarchy: `AbpIntegratedTest<TModule>` → `GrantManagerTestBase<T>` → domain-specific bases.
+- Use `[Fact]` for single tests, `[Theory]` with `[InlineData]` for parameterized.
+- Assertions: Shouldly (`result.ShouldBe(expected)`, `result.ShouldNotBeNull()`). Do NOT use `Assert.*`.
+- Mocking: NSubstitute (`Substitute.For<IService>()`). Do NOT use Moq.
+- JSON test fixtures loaded from `AppDomain.CurrentDomain.BaseDirectory`.
+- Run all tests: `dotnet test Unity.GrantManager.sln --no-build`
+- Test method naming: `Should_[Expected]_[Scenario]`
+- Follow Arrange-Act-Assert pattern consistently
+- Do not emit "Arrange", "Act", or "Assert" comments in generated tests
+
+## Multi-Tenancy Testing
+
+- Test tenant data isolation using `CurrentTenant.Change(tenantId)`
+- Verify that data created in one tenant is not visible in another
+- Test both host-level and tenant-level operations
+
+## Test Data Management
+
+- Use helper methods for test data creation (e.g., `CreateTestApplicationAsync()`)
+- Use static test data constants for well-known IDs
+- Keep test data self-contained — each test should set up its own state

--- a/applications/Unity.GrantManager/.claude/skills/abp-cli/SKILL.md
+++ b/applications/Unity.GrantManager/.claude/skills/abp-cli/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: abp-cli
+description: ABP CLI commands - generate-proxy, install-libs, add-package-ref, new-module, install-module, abp update, abp clean, abp suite generate. Use when the user asks how to run ABP CLI commands, generate proxies, install NPM libraries, or use ABP Suite.
+---
+
+# ABP CLI Commands
+
+> **Full documentation**: https://abp.io/docs/latest/cli
+> Use `abp help [command]` for detailed options.
+
+## Generate Client Proxies
+
+```bash
+# URL flag: `-u` (short) or `--url` (long). Use whichever your team prefers, but keep it consistent.
+#
+# Angular (host must be running)
+abp generate-proxy -t ng
+
+# C# client proxies
+abp generate-proxy -t csharp -u https://localhost:44300
+
+# Integration services only (microservices)
+abp generate-proxy -t csharp -u https://localhost:44300 -st integration
+
+# JavaScript
+abp generate-proxy -t js -u https://localhost:44300
+```
+
+## Install Client-Side Libraries
+
+```bash
+# Install NPM packages for MVC/Blazor Server
+abp install-libs
+```
+
+## Add Package Reference
+
+```bash
+# Add project reference with module dependency
+abp add-package-ref Acme.BookStore.Domain
+abp add-package-ref Acme.BookStore.Domain -t Acme.BookStore.Application
+```
+
+## Module Operations
+
+```bash
+# Create new module in solution
+abp new-module Acme.OrderManagement -t module:ddd
+
+# Install published module
+abp install-module Volo.Blogging
+
+# Add ABP NuGet package
+abp add-package Volo.Abp.Caching.StackExchangeRedis
+```
+
+## Update & Clean
+
+```bash
+abp update                  # Update all ABP packages
+abp update --version 8.0.0  # Specific version
+abp clean                   # Delete bin/obj folders
+```
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Angular proxies | `abp generate-proxy -t ng` |
+| C# proxies | `abp generate-proxy -t csharp -u URL` |
+| Install JS libs | `abp install-libs` |
+| Add reference | `abp add-package-ref PackageName` |
+| Create module | `abp new-module ModuleName` |
+| Install module | `abp install-module ModuleName` |
+| Update packages | `abp update` |
+| Clean solution | `abp clean` |
+| Suite CRUD | `abp suite generate -e entity.json -s solution.sln` |
+| Get help | `abp help [command]` |

--- a/applications/Unity.GrantManager/.claude/skills/unity-application-layer/SKILL.md
+++ b/applications/Unity.GrantManager/.claude/skills/unity-application-layer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unity-application-layer
-description: ABP Application Services, DTOs, AutoMapper profiles, validation, and error handling for Unity. Use when creating or modifying app services, DTOs, or mapping profiles in Application or Application.Contracts projects.
+description: ABP Application Services, DTOs, Mapperly mapping, validation, and error handling for Unity. Use when creating or modifying app services, DTOs, or mapping profiles in Application or Application.Contracts projects.
 ---
 
 # Unity Application Layer Patterns

--- a/applications/Unity.GrantManager/.claude/skills/unity-application-layer/SKILL.md
+++ b/applications/Unity.GrantManager/.claude/skills/unity-application-layer/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: unity-application-layer
+description: ABP Application Services, DTOs, AutoMapper profiles, validation, and error handling for Unity. Use when creating or modifying app services, DTOs, or mapping profiles in Application or Application.Contracts projects.
+---
+
+# Unity Application Layer Patterns
+
+## Application Service Contracts (Application.Contracts)
+
+- Interface naming: `I*AppService` inheriting `IApplicationService`.
+- Define DTOs in `*.Application.Contracts` — never in Domain or Web.
+- All methods async, end with `Async`.
+- Do NOT repeat entity name in method names: use `GetAsync`, not `GetGrantAsync`.
+
+```csharp
+public interface IGrantAppService : IApplicationService
+{
+    Task<GrantDto> GetAsync(Guid id);
+    Task<PagedResultDto<GrantDto>> GetListAsync(GetGrantListInput input);
+    Task<GrantDto> CreateAsync(CreateGrantDto input);
+    Task<GrantDto> UpdateAsync(Guid id, UpdateGrantDto input); // ID separate from DTO
+    Task DeleteAsync(Guid id);
+}
+```
+
+## DTO Conventions
+
+| Purpose | Convention | Example |
+|---------|------------|---------|
+| Query input | `Get{Entity}Input` | `GetGrantInput` |
+| List query | `Get{Entity}ListInput` | `GetGrantListInput` |
+| Create input | `Create{Entity}Dto` | `CreateGrantDto` |
+| Update input | `Update{Entity}Dto` | `UpdateGrantDto` |
+| Output | `{Entity}Dto` | `GrantDto` |
+
+- Use data annotations for validation; reuse constants from Domain.Shared.
+- Do NOT share input DTOs between methods.
+- Do NOT put logic in DTOs (except `IValidatableObject` when necessary).
+
+## Implementation (Application)
+
+- Inherit from `ApplicationService`.
+- Make all public methods `virtual`.
+- Prefer `protected virtual` over `private` for helper methods.
+- Use dedicated repositories, not inline LINQ in app services.
+- Call `repository.UpdateAsync()` explicitly after mutations (don't assume change tracking).
+- Do NOT use web types (`IFormFile`, `Stream`) — accept `byte[]` from controllers.
+- Do NOT call other app services in the same module. Use domain services or repositories.
+
+## Object Mapping (Mapperly)
+
+This project uses **Mapperly** (not AutoMapper). Mapper classes are defined using `Riok.Mapperly.Abstractions` and `Volo.Abp.Mapperly`:
+
+```csharp
+using Riok.Mapperly.Abstractions;
+using Volo.Abp.Mapperly;
+
+[Mapper]
+public partial class GrantToGrantDtoMapper : MapperBase<Grant, GrantDto>
+{
+    public override partial GrantDto Map(Grant source);
+    public override partial void Map(Grant source, GrantDto destination);
+}
+
+// For bidirectional mapping:
+[Mapper]
+public partial class ZoneGroupDefinitionMapper : TwoWayMapperBase<ZoneGroupDefinition, ZoneGroupDefinitionDto>
+{
+    public override partial ZoneGroupDefinitionDto Map(ZoneGroupDefinition source);
+    public override partial void Map(ZoneGroupDefinition source, ZoneGroupDefinitionDto destination);
+    public override partial ZoneGroupDefinition ReverseMap(ZoneGroupDefinitionDto source);
+    public override partial void ReverseMap(ZoneGroupDefinitionDto source, ZoneGroupDefinition destination);
+}
+```
+
+- Mapper files follow `*MapperlyProfile.cs` naming; each Application and Web project has its own file.
+- Use `[MapperIgnoreTarget(nameof(...))]` to skip properties, `[MapProperty]` to rename, and `[MapPropertyFromSource]` for custom resolver methods.
+- Call sites still use `ObjectMapper.Map<TSource, TDest>(source)` — Mapperly provides the source-generated implementation.
+
+## Error Handling
+
+```csharp
+// Business rule violation — use namespaced error code
+throw new BusinessException("GrantManager:DuplicateName")
+    .WithData("Name", name);
+
+// Entity not found
+throw new EntityNotFoundException(typeof(Grant), id);
+
+// User-facing message (use localized string)
+throw new UserFriendlyException(L["GrantNotAvailable"]);
+```
+
+## Authorization
+
+- Use `[Authorize(PermissionName)]` on service methods.
+- Permission names defined as constants in `*Permissions` classes in Application.Contracts.
+
+## Cross-Module Calls
+
+- You MAY call other modules' app services via their Application.Contracts interfaces.
+- Do NOT call app services within the same module — use domain services or repositories.

--- a/applications/Unity.GrantManager/.claude/skills/unity-domain-driven-design/SKILL.md
+++ b/applications/Unity.GrantManager/.claude/skills/unity-domain-driven-design/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: unity-domain-driven-design
+description: DDD patterns for Unity - Entities, Aggregate Roots, Repositories, Domain Services, Domain Events. Use when creating or modifying entities, repositories, or domain services in Domain or Domain.Shared projects.
+---
+
+# Unity ABP DDD Patterns
+
+> Based on ABP Framework DDD conventions. This project uses ABP 10.5 with PostgreSQL 17 and EF Core 10.
+
+## Entities
+
+- Define entities in `*.Domain` projects.
+- Use **rich domain model**: private/protected setters with methods that enforce invariants.
+- Always provide a `protected` parameterless constructor for EF Core.
+- Accept `Guid id` in the primary constructor; do NOT generate GUIDs inside constructors. Use `IGuidGenerator` from calling code.
+- Make members `virtual` for ORM proxy compatibility.
+- Initialize sub-collections in the primary constructor.
+
+```csharp
+public class Grant : AuditedAggregateRoot<Guid>
+{
+    public string Name { get; private set; }
+    public GrantStatus Status { get; private set; }
+    public ICollection<GrantApplication> Applications { get; private set; }
+
+    protected Grant() { } // For EF Core
+
+    public Grant(Guid id, string name) : base(id)
+    {
+        Name = Check.NotNullOrWhiteSpace(name, nameof(name));
+        Status = GrantStatus.Draft;
+        Applications = new List<GrantApplication>();
+    }
+
+    public void SetName(string name)
+    {
+        Name = Check.NotNullOrWhiteSpace(name, nameof(name));
+    }
+}
+```
+
+## Aggregate Roots
+
+- Use a single `Id` property, prefer `Guid` keys.
+- Inherit from `AggregateRoot<Guid>` or audited base classes (`AuditedAggregateRoot<Guid>`, `FullAuditedAggregateRoot<Guid>`).
+- Reference other aggregate roots **by Id only** — no cross-aggregate navigation properties.
+- Keep aggregates small.
+
+## Repositories
+
+- Define repository interfaces in the Domain layer.
+- One repository per aggregate root only. Never create repositories for child entities.
+- Custom repository interface should inherit `IRepository<TEntity, TKey>`.
+- All methods async with `CancellationToken cancellationToken = default`.
+- Single-entity methods: `includeDetails = true` by default.
+- List methods: `includeDetails = false` by default.
+
+```csharp
+public interface IGrantRepository : IRepository<Grant, Guid>
+{
+    Task<Grant?> FindByNameAsync(string name, bool includeDetails = true, CancellationToken cancellationToken = default);
+    Task<List<Grant>> GetListByStatusAsync(GrantStatus status, bool includeDetails = false, CancellationToken cancellationToken = default);
+}
+```
+
+## Domain Services
+
+- Naming: `*Manager` suffix (e.g., `GrantManager`).
+- No interface by default unless multiple implementations are needed.
+- Accept/return domain objects, not DTOs.
+- Do NOT depend on authenticated user; accept required values from application layer.
+- Use `GuidGenerator`, `Clock` from base class properties.
+
+```csharp
+public class GrantManager : DomainService
+{
+    private readonly IGrantRepository _grantRepository;
+
+    public GrantManager(IGrantRepository grantRepository)
+    {
+        _grantRepository = grantRepository;
+    }
+
+    public async Task<Grant> CreateAsync(string name)
+    {
+        var existing = await _grantRepository.FindByNameAsync(name);
+        if (existing != null)
+            throw new BusinessException("GrantManager:NameAlreadyExists").WithData("Name", name);
+
+        return new Grant(GuidGenerator.Create(), name);
+    }
+}
+```
+
+## Domain Events
+
+- `AddLocalEvent()` — same transaction, can access full entity state.
+- `AddDistributedEvent()` — async, use ETOs defined in Domain.Shared.
+- This project uses **RabbitMQ** for distributed events via `IDistributedEventBus`.
+
+## Shared Constants
+
+- Define constants, enums, and error codes in `*.Domain.Shared`.
+- Localization resources (JSON) live under `Domain.Shared/Localization/*/en.json`.
+- Error codes: namespaced as `ModuleName:ErrorCode`.

--- a/applications/Unity.GrantManager/.claude/skills/unity-ef-core/SKILL.md
+++ b/applications/Unity.GrantManager/.claude/skills/unity-ef-core/SKILL.md
@@ -30,8 +30,7 @@ dotnet ef migrations add <Name> --context GrantTenantDbContext --output-dir Migr
 
 ## Entity Configuration
 
-Entity mapping is done via extension methods on `ModelBuilder`, NOT inline in `OnModelCreating`.
-
+Entity mapping is primarily configured inline in `OnModelCreating` in `GrantManagerDbContext` / `GrantTenantDbContext`. Extension methods on `ModelBuilder` are also used for shared/module-specific configuration (e.g., `modelBuilder.ConfigureAI()`).
 ```csharp
 public static class GrantManagerDbContextModelCreatingExtensions
 {

--- a/applications/Unity.GrantManager/.claude/skills/unity-ef-core/SKILL.md
+++ b/applications/Unity.GrantManager/.claude/skills/unity-ef-core/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: unity-ef-core
+description: ABP Entity Framework Core for Unity - DbContext configuration, entity mapping, repository implementation, EF migrations. Use when working in EntityFrameworkCore projects, adding migrations, or implementing repositories.
+---
+
+# Unity EF Core Patterns
+
+> This project uses EF Core 10 with PostgreSQL 17 (Npgsql). Tests use SQLite in-memory.
+
+## Database Contexts
+
+This project has **two distinct database contexts**:
+
+| Context | Purpose | Migrations Directory |
+|---------|---------|---------------------|
+| `GrantManagerDbContext` | Host/shared system tables | `Migrations/HostMigrations` |
+| `GrantTenantDbContext` | Per-tenant isolated data | `Migrations/TenantMigrations` |
+
+Always specify the context when adding migrations:
+
+```bash
+cd src/Unity.GrantManager.EntityFrameworkCore
+
+# Host migration
+dotnet ef migrations add <Name> --context GrantManagerDbContext --output-dir Migrations/HostMigrations
+
+# Tenant migration
+dotnet ef migrations add <Name> --context GrantTenantDbContext --output-dir Migrations/TenantMigrations
+```
+
+## Entity Configuration
+
+Entity mapping is done via extension methods on `ModelBuilder`, NOT inline in `OnModelCreating`.
+
+```csharp
+public static class GrantManagerDbContextModelCreatingExtensions
+{
+    public static void ConfigureGrantManager(this ModelBuilder builder)
+    {
+        Check.NotNull(builder, nameof(builder));
+
+        builder.Entity<Grant>(b =>
+        {
+            b.ToTable(GrantManagerConsts.DbTablePrefix + "Grants", GrantManagerConsts.DbSchema);
+            b.ConfigureByConvention(); // Always call this first
+
+            b.Property(x => x.Name)
+                .IsRequired()
+                .HasMaxLength(GrantConsts.MaxNameLength);
+
+            b.HasIndex(x => x.Name);
+        });
+    }
+}
+```
+
+**Rules:**
+- Always call `b.ConfigureByConvention()` for every entity.
+- Use table prefix from constants (not hardcoded).
+- Default schema should be `null`.
+
+## Repository Implementation
+
+```csharp
+public class GrantRepository : EfCoreRepository<GrantManagerDbContext, Grant, Guid>, IGrantRepository
+{
+    public GrantRepository(IDbContextProvider<GrantManagerDbContext> dbContextProvider)
+        : base(dbContextProvider) { }
+
+    public async Task<Grant?> FindByNameAsync(
+        string name,
+        bool includeDetails = true,
+        CancellationToken cancellationToken = default)
+    {
+        var dbSet = await GetDbSetAsync();
+        return await dbSet
+            .IncludeDetails(includeDetails)
+            .FirstOrDefaultAsync(g => g.Name == name, GetCancellationToken(cancellationToken));
+    }
+}
+```
+
+- Use DbContext interface as generic parameter.
+- Pass cancellation tokens via `GetCancellationToken(cancellationToken)`.
+- Use `IncludeDetails()` extensions per aggregate root.
+
+## Module Registration
+
+```csharp
+context.Services.AddAbpDbContext<GrantManagerDbContext>(options =>
+{
+    options.AddDefaultRepositories(); // Aggregate roots only, NOT includeAllEntities: true
+});
+
+Configure<AbpDbContextOptions>(options =>
+{
+    options.UseNpgsql(); // PostgreSQL
+});
+```
+
+## Never Do
+
+| Don't | Do Instead |
+|-------|-----------|
+| `AddDefaultRepositories(includeAllEntities: true)` | `AddDefaultRepositories()` — aggregate roots only |
+| Skip `ConfigureByConvention()` | Always call it first in entity config |
+| Inject DbContext in app/domain services | Use `IRepository<T>` or custom repository interface |
+| Use lazy loading | Explicit `.Include()` via `IncludeDetails()` |
+
+## Migrations .editorconfig
+
+The `Migrations/` folder has its own `.editorconfig` suppressing analyzer warnings (S1128, S1192, CS8981, CA1861, IDE naming rules). This is intentional — do not modify migration files for style.

--- a/applications/Unity.GrantManager/.claude/skills/unity-module-structure/SKILL.md
+++ b/applications/Unity.GrantManager/.claude/skills/unity-module-structure/SKILL.md
@@ -75,7 +75,7 @@ public class GrantManagerEntityFrameworkCoreModule : AbpModule
     {
         context.Services.AddAbpDbContext<GrantManagerDbContext>(options =>
         {
-            options.AddDefaultRepositories();
+            options.AddDefaultRepositories(includeAllEntities: true);
         });
     }
 }

--- a/applications/Unity.GrantManager/.claude/skills/unity-module-structure/SKILL.md
+++ b/applications/Unity.GrantManager/.claude/skills/unity-module-structure/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: unity-module-structure
+description: ABP module architecture and layering rules for Unity. Use when creating new modules, adding cross-module dependencies, or understanding project organization and dependency direction.
+---
+
+# Unity Module Architecture
+
+## Module Layout
+
+Each ABP module follows a standard layered structure under `modules/`:
+
+```
+Unity.{ModuleName}/
+  src/
+    Unity.{ModuleName}.Domain.Shared/     ← Enums, constants, localization, ETOs
+    Unity.{ModuleName}.Domain/            ← Entities, repository interfaces, domain services
+    Unity.{ModuleName}.Application.Contracts/ ← DTOs, app service interfaces
+    Unity.{ModuleName}.Application/       ← App service implementations, Mapperly mappers
+    Unity.{ModuleName}.EntityFrameworkCore/ ← DbContext, migrations (if module has own DB tables)
+    Unity.{ModuleName}.HttpApi/           ← REST controllers
+    Unity.{ModuleName}.HttpApi.Client/    ← Remote client proxies
+    Unity.{ModuleName}.Web/               ← Razor Pages, view components
+  test/
+    Unity.{ModuleName}.TestBase/
+    Unity.{ModuleName}.Application.Tests/
+    Unity.{ModuleName}.Domain.Tests/
+    Unity.{ModuleName}.EntityFrameworkCore.Tests/
+```
+
+Not all modules have every layer. Simpler modules may only have `Application`, `Application.Contracts`, `Shared`, and `Web`.
+
+## Current Modules
+
+| Module | Layers Present | Purpose |
+|--------|---------------|---------|
+| **Unity.Flex** | Shared, App.Contracts, App, Web, Tests | Dynamic forms/worksheets |
+| **Unity.Notifications** | Full stack (Domain→Web, HttpApi, EF) | Email/messaging |
+| **Unity.Payments** | Shared, App.Contracts, App, Web, Tests | Financial transactions |
+| **Unity.Reporting** | Shared, App.Contracts, App, Web, Tests | Analytics & reports |
+| **Unity.AI** | Shared, App.Contracts, App, Web | AI analysis (OpenAI) |
+| **Unity.TenantManagement** | App.Contracts, App, HttpApi, Web, Tests | Multi-tenant admin |
+| **Unity.Identity.Web** | Web, Tests | OIDC authentication UI |
+| **Unity.Theme.UX2** | Theme package, Tests | Custom Razor Pages theme |
+| **Unity.SharedKernel** | Single project | Cross-cutting utilities |
+
+## Dependency Direction (Strict)
+
+```
+Web → HttpApi → Application.Contracts
+Application → Domain + Application.Contracts
+Domain → Domain.Shared
+EntityFrameworkCore → Domain only
+```
+
+### Rules
+
+- Web/HttpApi must NEVER depend on Application (only Application.Contracts).
+- Application must NEVER depend on Web or EF Core.
+- Domain must NEVER depend on Application, Web, or EF Core.
+- Domain.Shared must have NO dependencies on other layers.
+- EF Core must ONLY depend on Domain.
+
+## ABP Module Classes
+
+Every package has exactly one `AbpModule` class with `[DependsOn]` attributes.
+
+```csharp
+[DependsOn(
+    typeof(GrantManagerDomainModule),
+    typeof(AbpEntityFrameworkCoreModule)
+)]
+public class GrantManagerEntityFrameworkCoreModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddAbpDbContext<GrantManagerDbContext>(options =>
+        {
+            options.AddDefaultRepositories();
+        });
+    }
+}
+```
+
+## Multi-Tenancy
+
+- The system uses ABP multi-tenancy with separate database per tenant.
+- `GrantManagerDbContext` = host context, `GrantTenantDbContext` = tenant context.
+- Tenant-scoped data is accessed via `ICurrentTenant` / tenant switching.
+- The `Unity.TenantManagement` module handles tenant administration.
+
+## Adding a New Feature
+
+1. Identify which module the feature belongs to.
+2. Add entities/repositories in Domain layer.
+3. Add DTOs/interfaces in Application.Contracts.
+4. Implement app services in Application.
+5. Add EF Core configuration if new tables are needed.
+6. Add UI in Web layer.
+7. Add tests in the module's test projects.
+8. Register the module class with `[DependsOn]`.
+9. Run `dotnet build Unity.GrantManager.sln` and `dotnet test Unity.GrantManager.sln` to verify.
+
+## Localization
+
+Each module with Domain.Shared has its own localization under:
+`src/Unity.{ModuleName}.Domain.Shared/Localization/{ModuleName}/en.json`
+
+Use `L["Key"]` in application services and pages. All user-facing text must be localized.
+
+## Permissions
+
+Define in `*PermissionDefinitionProvider` in Application.Contracts.
+Permission names follow `{ModuleName}.{Resource}.{Action}` convention.

--- a/applications/Unity.GrantManager/.claude/skills/unity-testing/SKILL.md
+++ b/applications/Unity.GrantManager/.claude/skills/unity-testing/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: unity-testing
+description: Testing patterns for Unity - xUnit, Shouldly assertions, NSubstitute mocks, ABP test infrastructure. Use when writing or modifying unit tests or integration tests.
+---
+
+# Unity Testing Patterns
+
+## Test Infrastructure
+
+| Aspect | Value |
+|--------|-------|
+| Framework | xUnit 2.9.3 |
+| Assertions | Shouldly 4.3.0 |
+| Mocking | NSubstitute 5.3.0 |
+| Database | In-memory (SQLite for most projects; EFCore.InMemory for Web tests – no PostgreSQL required) |
+| Base Classes | ABP `AbpIntegratedTest<TModule>` |
+| Target | .NET 10 |
+
+## Test Project Locations
+
+```
+test/
+  Unity.GrantManager.TestBase/          ← Shared fixtures & test data
+  Unity.GrantManager.Application.Tests/ ← App service tests
+  Unity.GrantManager.Domain.Tests/      ← Domain logic tests
+  Unity.GrantManager.EntityFrameworkCore.Tests/
+  Unity.GrantManager.Web.Tests/
+modules/Unity.*/test/                   ← Each module has its own test projects
+```
+
+## Running Tests
+
+```bash
+# All tests (~470 tests, ~2 min)
+dotnet test Unity.GrantManager.sln
+
+# Single project
+dotnet test test/Unity.GrantManager.Application.Tests/
+
+# After build (faster)
+dotnet test Unity.GrantManager.sln --no-build
+```
+
+## Base Class Hierarchy
+
+```
+AbpIntegratedTest<TStartupModule>           (Volo.Abp.Testing)
+└── GrantManagerTestBase<TStartupModule>    (shared UoW helpers)
+    ├── GrantManagerDomainTestBase           (domain tests)
+    ├── GrantManagerEntityFrameworkCoreTestBase
+    └── Module-specific bases:
+        ├── FlexTestBaseModule
+        ├── TenantManagementTestBase
+        └── ReportingTestBase
+```
+
+## Writing Tests
+
+### Unit Test Example (with mocking)
+
+```csharp
+public class MyServiceTests
+{
+    private readonly IMyRepository _repository;
+    private readonly MyService _sut;
+
+    public MyServiceTests()
+    {
+        _repository = Substitute.For<IMyRepository>();
+        _sut = new MyService(_repository);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithValidInput_ShouldSucceed()
+    {
+        // Arrange
+        _repository.FindByNameAsync(Arg.Any<string>()).Returns((MyEntity?)null);
+
+        // Act
+        var result = await _sut.CreateAsync("test");
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Name.ShouldBe("test");
+    }
+}
+```
+
+### Integration Test Example (ABP)
+
+```csharp
+public class GrantAppServiceTests : GrantManagerApplicationTestBase
+{
+    private readonly IGrantAppService _grantAppService;
+
+    public GrantAppServiceTests()
+    {
+        _grantAppService = GetRequiredService<IGrantAppService>();
+    }
+
+    [Fact]
+    public async Task Should_Get_Grant_By_Id()
+    {
+        var result = await _grantAppService.GetAsync(GrantManagerTestData.GrantId);
+        result.ShouldNotBeNull();
+        result.Id.ShouldBe(GrantManagerTestData.GrantId);
+    }
+}
+```
+
+### Parameterized Tests
+
+```csharp
+[Theory]
+[InlineData("schema1.json", 128)]
+[InlineData("schema2.json", 10)]
+public void TestMapping(string filename, int expectedCount)
+{
+    var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TestData", filename);
+    var json = File.ReadAllText(path);
+    var result = Parse(json);
+    result.Count.ShouldBe(expectedCount);
+}
+```
+
+## Test Data
+
+- JSON fixtures are loaded from `AppDomain.CurrentDomain.BaseDirectory` subdirectories.
+- Domain tests include JSON files in `Intake/Files/*.json` and `Intake/Mapping/*.json` (copied to output via `.csproj`).
+- Shared test data constants live in `*TestData.cs` classes within TestBase projects.
+
+## Web Tests
+
+Web tests use `[Collection]` fixture pattern:
+
+```csharp
+[Collection(WebTestCollection.Name)]
+public class MyWidgetTests
+{
+    private readonly IAbpLazyServiceProvider _lazyServiceProvider;
+
+    public MyWidgetTests(WebTestFixture fixture)
+    {
+        _lazyServiceProvider = fixture.Services.GetRequiredService<IAbpLazyServiceProvider>();
+    }
+}
+```
+
+## Conventions
+
+- Test class naming: `*Tests.cs`
+- Method naming: `Should_ExpectedBehavior_When_Condition` or `MethodName_Scenario_ExpectedResult`
+- Always use `Shouldly` for assertions (not `Assert.Equal`)
+- Always use `NSubstitute` for mocking (not Moq)
+- Test runner config: `xunit.runner.json` with `"shadowCopy": false`


### PR DESCRIPTION
## Pull request overview

Adds Claude Code workspace guidance for the Unity Portal repo and introduces a set of Unity.GrantManager-specific Claude “rules”, “skills”, and “agents” to standardize architecture, EF Core, security, and testing practices.

**Changes:**
- Add repo-level `CLAUDE.md` with navigation pointers and common build/test/migration commands.
- Add `.claude/skills/*` reference docs for common Unity.GrantManager patterns (testing, module layering, EF Core, DDD, application layer, ABP CLI).
- Add `.claude/rules/*` and `.claude/agents/*` to provide consistent conventions and reusable review/triage/planning workflows.

### Reviewed changes

Copilot reviewed 21 out of 21 changed files in this pull request and generated 6 comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| `CLAUDE.md` | Adds repository-level guidance and pointers to the most relevant instruction sources. |
| `applications/Unity.GrantManager/.claude/skills/unity-testing/SKILL.md` | Documents xUnit/Shouldly/NSubstitute testing patterns and locations. |
| `applications/Unity.GrantManager/.claude/skills/unity-module-structure/SKILL.md` | Defines ABP module layering rules and module layout expectations. |
| `applications/Unity.GrantManager/.claude/skills/unity-ef-core/SKILL.md` | Captures EF Core context/migrations/repository guidance for the solution. |
| `applications/Unity.GrantManager/.claude/skills/unity-domain-driven-design/SKILL.md` | Provides DDD conventions for entities, aggregates, repositories, and domain services. |
| `applications/Unity.GrantManager/.claude/skills/unity-application-layer/SKILL.md` | Documents application service/DTO/mapping conventions. |
| `applications/Unity.GrantManager/.claude/skills/abp-cli/SKILL.md` | Adds a quick reference for common ABP CLI commands used in the project. |
| `applications/Unity.GrantManager/.claude/rules/testing.md` | Adds path-scoped conventions for C# test code under `test/**/*.cs`. |
| `applications/Unity.GrantManager/.claude/rules/security.md` | Adds baseline security standards for C#, cshtml, and JS changes. |
| `applications/Unity.GrantManager/.claude/rules/javascript.md` | Documents ABP front-end JS conventions (IIFE, localization, DataTables, modals). |
| `applications/Unity.GrantManager/.claude/rules/efcore.md` | Adds EF Core-specific conventions for `EntityFrameworkCore/**/*.cs`. |
| `applications/Unity.GrantManager/.claude/rules/csharp.md` | Adds broad C#/.NET/ABP conventions and common pitfalls to avoid. |
| `applications/Unity.GrantManager/.claude/agents/test-triage.md` | Adds a reusable workflow for diagnosing failing tests with minimal-risk fixes. |
| `applications/Unity.GrantManager/.claude/agents/test-strategy.md` | Adds a risk-based testing strategy planning workflow. |
| `applications/Unity.GrantManager/.claude/agents/pr-readiness.md` | Adds a pre-PR readiness checklist (build/tests/architecture/policy). |
| `applications/Unity.GrantManager/.claude/agents/pr-readiness-deep.md` | Adds an expanded readiness workflow including Cypress E2E guidance. |
| `applications/Unity.GrantManager/.claude/agents/permissions-localization-auditor.md` | Adds an audit workflow for permissions + localization compliance. |
| `applications/Unity.GrantManager/.claude/agents/feature-planner.md` | Adds a structured feature planning workflow across ABP layers. |
| `applications/Unity.GrantManager/.claude/agents/efcore-migration-planner.md` | Adds a planning workflow for EF model/migration changes (host vs tenant). |
| `applications/Unity.GrantManager/.claude/agents/ddd-modeler.md` | Adds a domain modeling review/design workflow aligned to DDD constraints. |
| `applications/Unity.GrantManager/.claude/agents/application-service-designer.md` | Adds a workflow for app-service contract/DTO/auth/mapping planning. |
</details>





<details>
<summary>Suppressed comments (3)</summary>

**applications/Unity.GrantManager/.claude/skills/unity-ef-core/SKILL.md:93**
* The Module Registration snippet recommends `AddDefaultRepositories()` without `includeAllEntities: true`, but the repo’s `GrantManagerEntityFrameworkCoreModule` currently uses `includeAllEntities: true`. Align this snippet with the codebase default (or explicitly call out the intentional deviation).
```
context.Services.AddAbpDbContext<GrantManagerDbContext>(options =>
{
    options.AddDefaultRepositories(); // Aggregate roots only, NOT includeAllEntities: true
});
```
**applications/Unity.GrantManager/.claude/skills/unity-ef-core/SKILL.md:105**
* The "Never Do" table says not to use `AddDefaultRepositories(includeAllEntities: true)`, but the codebase default in `GrantManagerEntityFrameworkCoreModule` does exactly that. The table entry should be updated so it doesn’t conflict with the actual implementation.
```
| `AddDefaultRepositories(includeAllEntities: true)` | `AddDefaultRepositories()` — aggregate roots only |
```
**applications/Unity.GrantManager/.claude/skills/unity-ef-core/SKILL.md:83**
* This bullet says to use a "DbContext interface" as the `EfCoreRepository<...>` generic parameter, but repositories in this codebase use the concrete DbContext type (e.g., `EfCoreRepository<GrantTenantDbContext, ...>`).
```
- Use DbContext interface as generic parameter.
```
</details>
