### PR TITLE
AB#33553: Display Wrong Tenant Error Page When Displaying Page From a Different Tenant

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Notifications/src/Unity.Notifications.Application/EmailNotificaions/EmailNotificationService.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Notifications/src/Unity.Notifications.Application/EmailNotificaions/EmailNotificationService.cs
@@ -110,9 +110,17 @@ public class EmailNotificationService(
                 string commentLink = input.CommentType switch
                 {
                     Comments.CommentType.ApplicationComment or Comments.CommentType.AssessmentComment =>
-                        QueryHelpers.AddQueryString($"{baseUrl}/GrantApplications/Details", "ApplicationId", input.OwnerId),
+                        QueryHelpers.AddQueryString($"{baseUrl}/GrantApplications/Details", new Dictionary<string, string?>
+                        {
+                            ["ApplicationId"] = input.OwnerId,
+                            ["TenantId"] = CurrentTenant.Id?.ToString()
+                        }),
                     Comments.CommentType.ApplicantComment =>
-                        QueryHelpers.AddQueryString($"{baseUrl}/GrantApplicants/Details", "ApplicantId", input.OwnerId),
+                        QueryHelpers.AddQueryString($"{baseUrl}/GrantApplicants/Details", new Dictionary<string, string?>
+                        {
+                            ["ApplicantId"] = input.OwnerId,
+                            ["TenantId"] = CurrentTenant.Id?.ToString()
+                        }),
                     _ => throw new InvalidOperationException("Invalid comment type.")
                 };
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain.Shared/Localization/GrantManager/en.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain.Shared/Localization/GrantManager/en.json
@@ -616,6 +616,11 @@
     "DataTable:ContextMenu:Copy": "Copy",
     "DataTable:ContextMenu:CopiedToClipboard": "Copied to clipboard",
     "DataTable:ContextMenu:Filter": "Filter",
-    "DataTable:ContextMenu:ClearFilter": "Clear Filters"
+    "DataTable:ContextMenu:ClearFilter": "Clear Filters",
+
+    "WrongTenantError:Title": "An Error Occurred",
+    "WrongTenantError:ApplicationTenant": "This application is in Tenant: {0}",
+    "WrongTenantError:CurrentTenant": "You are currently in Tenant: {0}",
+    "WrongTenantError:Instructions": "Please click on the Profile menu at the top right of the corner, click on Switch Grant Programs, and select the correct Tenant before proceeding to view the link."
   }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Applicants/Details.cshtml.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Applicants/Details.cshtml.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Permissions;
+using Volo.Abp.TenantManagement;
 using Volo.Abp.Users;
 
 namespace Unity.GrantManager.Web.Pages.Applicants
@@ -14,12 +15,16 @@ namespace Unity.GrantManager.Web.Pages.Applicants
     {
         private readonly IApplicantRepository _applicantRepository;
         private readonly IApplicationRepository _applicationRepository;
+        private readonly ITenantRepository _tenantRepository;
 
         [BindProperty(SupportsGet = true)]
         public Guid ApplicantId { get; set; }
 
         [BindProperty(SupportsGet = true)]
         public Guid? ApplicationId { get; set; } = null;
+
+        [BindProperty(SupportsGet = true)]
+        public Guid? TenantId { get; set; }
 
         public Applicant? Applicant { get; set; }
         public bool ApplicantIsDeleted { get; set; }
@@ -34,11 +39,13 @@ namespace Unity.GrantManager.Web.Pages.Applicants
         public DetailsModel(
             IApplicantRepository applicantRepository,
             IApplicationRepository applicationRepository,
+            ITenantRepository tenantRepository,
             ICurrentUser currentUser,
             IConfiguration configuration)
         {
             _applicantRepository = applicantRepository;
             _applicationRepository = applicationRepository;
+            _tenantRepository = tenantRepository;
             CurrentUserId = currentUser.Id;
             CurrentUserName = currentUser.SurName + ", " + currentUser.Name;
             AllowedFileTypes = configuration["S3:AllowedFileTypes"] ?? "";
@@ -47,6 +54,17 @@ namespace Unity.GrantManager.Web.Pages.Applicants
 
         public async Task<IActionResult> OnGetAsync()
         {
+            if (TenantId.HasValue && TenantId.Value != CurrentTenant.Id)
+            {
+                var applicationTenant = await _tenantRepository.FindAsync(TenantId.Value);
+                return RedirectToPage("/Error", new
+                {
+                    httpStatusCode = 409,
+                    applicationTenantName = applicationTenant?.Name ?? TenantId.Value.ToString(),
+                    currentTenantName = CurrentTenant.Name ?? "Host"
+                });
+            }
+
             // Resolve ApplicantId from ApplicationId if needed
             if (ApplicantId == Guid.Empty && ApplicationId.HasValue)
             {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Error.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Error.cshtml
@@ -1,8 +1,12 @@
 @page
+@using Microsoft.Extensions.Localization
+@using Unity.GrantManager.Localization
 @model Unity.GrantManager.Web.Pages.ErrorModel
+@inject IStringLocalizer<GrantManagerResource> L
 
 @{
     var code = Model.HttpStatusCode;
+    var isWrongTenant = code == 409;
 
     string title;
     string message;
@@ -16,6 +20,10 @@
         case 403:
             title = "Access Denied";
             message = "You do not have permission to view this page.";
+            break;
+        case 409:
+            title = L["WrongTenantError:Title"].Value;
+            message = string.Empty;
             break;
         case 500:
             title = "Something Went Wrong";
@@ -31,6 +39,17 @@
 <div class="card mt-3 shadow-sm rounded">
     <div class="card-body p-5 text-center">
         <h4>@title</h4>
-        <p class="mt-3">@message</p>
+        @if (isWrongTenant)
+        {
+            <p class="mt-3">
+                @L["WrongTenantError:ApplicationTenant", Model.ApplicationTenantName]<br />
+                @L["WrongTenantError:CurrentTenant", Model.CurrentTenantName]
+            </p>
+            <p>@L["WrongTenantError:Instructions"]</p>
+        }
+        else
+        {
+            <p class="mt-3">@message</p>
+        }
     </div>
 </div>

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Error.cshtml.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Error.cshtml.cs
@@ -5,9 +5,13 @@ namespace Unity.GrantManager.Web.Pages;
 public class ErrorModel : PageModel
 {
     public int HttpStatusCode { get; private set; }
+    public string? ApplicationTenantName { get; private set; }
+    public string? CurrentTenantName { get; private set; }
 
-    public void OnGet(int httpStatusCode = 0)
+    public void OnGet(int httpStatusCode = 0, string? applicationTenantName = null, string? currentTenantName = null)
     {
         HttpStatusCode = httpStatusCode;//HTTP Status Code
+        ApplicationTenantName = applicationTenantName;
+        CurrentTenantName = currentTenantName;
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.cshtml.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.cshtml.cs
@@ -21,6 +21,7 @@ using Unity.Modules.Shared.Correlation;
 using Unity.Modules.Shared.Specializations;
 using Volo.Abp.AspNetCore.Mvc.UI.RazorPages;
 using Volo.Abp.Features;
+using Volo.Abp.TenantManagement;
 using Volo.Abp.Users;
 
 namespace Unity.GrantManager.Web.Pages.GrantApplications
@@ -33,6 +34,7 @@ namespace Unity.GrantManager.Web.Pages.GrantApplications
         private readonly IApplicationFormVersionAppService _applicationFormVersionAppService;
         private readonly IScoresheetRepository _scoresheetRepository;
         private readonly IFeatureChecker _featureChecker;
+        private readonly ITenantRepository _tenantRepository;
         protected readonly IZoneManagementAppService _zoneManagementAppService;
 
         [BindProperty(SupportsGet = true)]
@@ -47,6 +49,9 @@ namespace Unity.GrantManager.Web.Pages.GrantApplications
 
         [BindProperty(SupportsGet = true)]
         public Guid ApplicationId { get; set; }
+
+        [BindProperty(SupportsGet = true)]
+        public Guid? TenantId { get; set; }
 
         [BindProperty(SupportsGet = true)]
         public Guid ApplicationFormVersionId { get; set; }
@@ -94,6 +99,7 @@ namespace Unity.GrantManager.Web.Pages.GrantApplications
             IApplicationFormVersionAppService applicationFormVersionAppService,
             IScoresheetRepository scoresheetRepository,
             IFeatureChecker featureChecker,
+            ITenantRepository tenantRepository,
             ICurrentUser currentUser,
             IConfiguration configuration,
             IZoneManagementAppService zoneManagementAppService)
@@ -103,6 +109,7 @@ namespace Unity.GrantManager.Web.Pages.GrantApplications
             _featureChecker = featureChecker;
             _applicationFormVersionAppService = applicationFormVersionAppService;
             _scoresheetRepository = scoresheetRepository;
+            _tenantRepository = tenantRepository;
             _zoneManagementAppService = zoneManagementAppService;
 
             CurrentUserId = currentUser.Id;
@@ -113,8 +120,19 @@ namespace Unity.GrantManager.Web.Pages.GrantApplications
             TotalEmailAttachmentMaxFileSize = configuration["S3:EmailAttachmentsTotalMaxFileSize"] ?? "25";
         }
 
-        public async Task OnGetAsync()
+        public async Task<IActionResult> OnGetAsync()
         {
+            if (TenantId.HasValue && TenantId.Value != CurrentTenant.Id)
+            {
+                var applicationTenant = await _tenantRepository.FindAsync(TenantId.Value);
+                return RedirectToPage("/Error", new
+                {
+                    httpStatusCode = 409,
+                    applicationTenantName = applicationTenant?.Name ?? TenantId.Value.ToString(),
+                    currentTenantName = CurrentTenant.Name ?? "Host"
+                });
+            }
+
             if (await _featureChecker.IsEnabledAsync(SpecializationConsts.Onboarding))
             {
                 ViewData["ActiveNavHref"] = "/TenantManagement/Onboarding";
@@ -152,6 +170,8 @@ namespace Unity.GrantManager.Web.Pages.GrantApplications
             ArgumentNullException.ThrowIfNull(applicationForm);
             ApplicationScoresheetSchemaJson = await GetApplicationScoresheetSchemaJsonAsync(applicationForm);
             ApplicationFormSubmissionData = applicationFormSubmission.Submission;
+
+            return Page();
         }
 
         public async Task<IActionResult> OnPostAsync()


### PR DESCRIPTION
Clicking "View Comment" button from a comment email will now say "You are in the wrong tenant" instead of just saying "there is an error"

<img width="817" height="247" alt="image" src="https://github.com/user-attachments/assets/7c432fc5-df4b-44bb-ac5e-e449574e705a" />
