### PR TITLE
bugfix/AB#34096 - Fix ApplicationFormVersion update function

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormVersionAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormVersionAppService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using System;
@@ -7,12 +8,8 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Unity.AI.Features;
 using Unity.AI.Generation;
-using Unity.AI.Operations;
 using Unity.AI.Permissions;
-using Unity.AI.Requests;
-using Unity.AI.Runtime.Execution;
 using Unity.Flex.Domain.Worksheets;
 using Unity.GrantManager.ApplicationForms.Mapping;
 using Unity.GrantManager.Applications;
@@ -57,7 +54,7 @@ namespace Unity.GrantManager.ApplicationForms
         public override async Task<ApplicationFormVersionDto> CreateAsync(CreateUpdateApplicationFormVersionDto input) =>
             await base.CreateAsync(input);
 
-        [RemoteService(false)]
+        [Authorize]
         public override async Task<ApplicationFormVersionDto> UpdateAsync(Guid id, CreateUpdateApplicationFormVersionDto input) =>
             await base.UpdateAsync(id, input);
 


### PR DESCRIPTION
## Pull request overview

This PR adjusts `ApplicationFormVersionAppService` to allow updating `ApplicationFormVersion` records by replacing a non-remote `UpdateAsync` implementation with an authorized one, aligning the update flow with authenticated access.

**Changes:**
- Added ASP.NET Core authorization support to the service.
- Replaced `[RemoteService(false)]` on `UpdateAsync` with an authorization attribute to enable secured remote updates.
- Cleaned up unused Unity.AI-related `using` directives.