### PR TITLE
AB#33553: Error Page For Application/Applicant URL without TenantID

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain.Shared/Localization/GrantManager/en.json
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain.Shared/Localization/GrantManager/en.json
@@ -642,7 +642,10 @@
 
     "WrongTenantError:Title": "An Error Occurred",
     "WrongTenantError:ApplicationTenant": "This application is in Tenant: {0}",
+    "WrongTenantError:ApplicantTenant": "This applicant is in Tenant: {0}",
     "WrongTenantError:CurrentTenant": "You are currently in Tenant: {0}",
-    "WrongTenantError:Instructions": "Please click on the Profile menu at the top right of the corner, click on Switch Grant Programs, and select the correct Tenant before proceeding to view the link."
+    "WrongTenantError:Instructions": "Please click on the Profile menu at the top right of the corner, click on Switch Grant Programs, and select the correct Tenant before proceeding to view the link.",
+    "WrongTenantError:ApplicantNotFoundPossibleTenant": "This applicant was not found in the current Tenant and may exist in another Tenant.",
+    "WrongTenantError:ApplicationNotFoundPossibleTenant": "This application was not found in the current Tenant and may exist in another Tenant."
   }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Applicants/Details.cshtml.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Applicants/Details.cshtml.cs
@@ -60,6 +60,7 @@ namespace Unity.GrantManager.Web.Pages.Applicants
                 return RedirectToPage("/Error", new
                 {
                     httpStatusCode = 409,
+                    entityType = "Applicant",
                     applicationTenantName = applicationTenant?.Name ?? TenantId.Value.ToString(),
                     currentTenantName = CurrentTenant.Name ?? "Host"
                 });
@@ -75,7 +76,12 @@ namespace Unity.GrantManager.Web.Pages.Applicants
                 }
                 catch (Exception)
                 {
-                    return NotFound();
+                    return RedirectToPage("/Error", new
+                    {
+                        httpStatusCode = 404,
+                        entityType = "Applicant",
+                        currentTenantName = CurrentTenant.Name ?? "Host"
+                    });
                 }
             }
 
@@ -105,7 +111,12 @@ namespace Unity.GrantManager.Web.Pages.Applicants
             }
             catch (Exception)
             {
-                return NotFound();
+                return RedirectToPage("/Error", new
+                {
+                    httpStatusCode = 404,
+                    entityType = "Applicant",
+                    currentTenantName = CurrentTenant.Name ?? "Host"
+                });
             }
         }
     }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Error.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Error.cshtml
@@ -7,6 +7,8 @@
 @{
     var code = Model.HttpStatusCode;
     var isWrongTenant = code == 409;
+    var isPossibleTenantMismatch = code == 404 && !string.IsNullOrEmpty(Model.EntityType);
+    var isApplicant = string.Equals(Model.EntityType, "Applicant", StringComparison.OrdinalIgnoreCase);
 
     string title;
     string message;
@@ -14,8 +16,8 @@
     switch (code)
     {
         case 404:
-            title = "Page Not Found";
-            message = "The page you are looking for does not exist or may have been moved.";
+            title = isPossibleTenantMismatch ? L["WrongTenantError:Title"].Value : "Page Not Found";
+            message = isPossibleTenantMismatch ? string.Empty : "The page you are looking for does not exist or may have been moved.";
             break;
         case 403:
             title = "Access Denied";
@@ -42,7 +44,15 @@
         @if (isWrongTenant)
         {
             <p class="mt-3">
-                @L["WrongTenantError:ApplicationTenant", Model.ApplicationTenantName]<br />
+                @(isApplicant ? L["WrongTenantError:ApplicantTenant", Model.ApplicationTenantName] : L["WrongTenantError:ApplicationTenant", Model.ApplicationTenantName])<br />
+                @L["WrongTenantError:CurrentTenant", Model.CurrentTenantName]
+            </p>
+            <p>@L["WrongTenantError:Instructions"]</p>
+        }
+        else if (isPossibleTenantMismatch)
+        {
+            <p class="mt-3">
+                @(isApplicant ? L["WrongTenantError:ApplicantNotFoundPossibleTenant"] : L["WrongTenantError:ApplicationNotFoundPossibleTenant"])<br />
                 @L["WrongTenantError:CurrentTenant", Model.CurrentTenantName]
             </p>
             <p>@L["WrongTenantError:Instructions"]</p>

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Error.cshtml.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/Error.cshtml.cs
@@ -7,11 +7,13 @@ public class ErrorModel : PageModel
     public int HttpStatusCode { get; private set; }
     public string? ApplicationTenantName { get; private set; }
     public string? CurrentTenantName { get; private set; }
+    public string? EntityType { get; private set; }
 
-    public void OnGet(int httpStatusCode = 0, string? applicationTenantName = null, string? currentTenantName = null)
+    public void OnGet(int httpStatusCode = 0, string? applicationTenantName = null, string? currentTenantName = null, string? entityType = null)
     {
         HttpStatusCode = httpStatusCode;//HTTP Status Code
         ApplicationTenantName = applicationTenantName;
         CurrentTenantName = currentTenantName;
+        EntityType = entityType;
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.cshtml.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/GrantApplications/Details.cshtml.cs
@@ -20,6 +20,7 @@ using Unity.GrantManager.Zones;
 using Unity.Modules.Shared.Correlation;
 using Unity.Modules.Shared.Specializations;
 using Volo.Abp.AspNetCore.Mvc.UI.RazorPages;
+using Volo.Abp.Domain.Entities;
 using Volo.Abp.Features;
 using Volo.Abp.TenantManagement;
 using Volo.Abp.Users;
@@ -128,6 +129,7 @@ namespace Unity.GrantManager.Web.Pages.GrantApplications
                 return RedirectToPage("/Error", new
                 {
                     httpStatusCode = 409,
+                    entityType = "Application",
                     applicationTenantName = applicationTenant?.Name ?? TenantId.Value.ToString(),
                     currentTenantName = CurrentTenant.Name ?? "Host"
                 });
@@ -138,7 +140,20 @@ namespace Unity.GrantManager.Web.Pages.GrantApplications
                 ViewData["ActiveNavHref"] = "/TenantManagement/Onboarding";
             }
 
-            ApplicationFormSubmission applicationFormSubmission = await _grantApplicationAppService.GetFormSubmissionByApplicationId(ApplicationId);
+            ApplicationFormSubmission applicationFormSubmission;
+            try
+            {
+                applicationFormSubmission = await _grantApplicationAppService.GetFormSubmissionByApplicationId(ApplicationId);
+            }
+            catch (EntityNotFoundException)
+            {
+                return RedirectToPage("/Error", new
+                {
+                    httpStatusCode = 404,
+                    entityType = "Application",
+                    currentTenantName = CurrentTenant.Name ?? "Host"
+                });
+            }
             ZoneStateSet = await _zoneManagementAppService.GetZoneStateSetAsync(applicationFormSubmission.ApplicationFormId);
             
             var formVersion = applicationFormSubmission.ApplicationFormVersionId.HasValue


### PR DESCRIPTION
New error page for old comments email which does not have TenantID in the URL:

<img width="1108" height="315" alt="image" src="https://github.com/user-attachments/assets/20f5bc85-753b-4cb3-9011-eb8547f66c05" />
