### PR TITLE
Feature/ab#34202 ai form configuration bug

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/DataSeed/AIPromptDataSeeder.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/DataSeed/AIPromptDataSeeder.cs
@@ -129,7 +129,7 @@ public class AIPromptDataSeeder(
 
     private async Task SeedFormScoresheetPromptAsync()
     {
-        await EnsurePromptAsync(AIPromptTypes.FormScoresheet, 2, FormScoresheetSystemV2, FormScoresheetUserV2, FormScoresheetMetadataV2);
+        await EnsurePromptAsync(AIPromptTypes.FormScoresheet, 3, FormScoresheetSystemV3, FormScoresheetUserV3, FormScoresheetMetadataV3);
     }
 
     // ─── HELPERS ──────────────────────────────────────────────────────────────
@@ -832,6 +832,9 @@ public class AIPromptDataSeeder(
         - Preserve every existing non-empty mapping exactly as provided; do not replace or remove it.
         - Only fill blank existing mappings or add new mappings when supported by the available fields.
         - Only include mappings that are clearly semantically equivalent or strongly related by label, name, type, and purpose.
+        - Down-weight CHEFS fields when the CHEFS label contains the substring "Extract"; prefer a comparably suitable alternative instead.
+        - Up-weight CHEFS fields whose type is "hidden", especially when the CHEFS label or API property name contains the substring "hidden".
+        - If a field is both hidden and contains "Extract", prefer the hidden-field signal over the Extract down-weight.
         - Do not force one-to-one coverage. Omit Unity fields when no CHEFS field is a sensible match.
         - Omit CHEFS fields that do not clearly map to a Unity target field.
         - Do not map platform/system identifiers such as SubmissionId, SubmissionDate, or ConfirmationId; they are managed by Unity and should be omitted if present.
@@ -897,8 +900,8 @@ public class AIPromptDataSeeder(
         Return only valid JSON.
         """;
 
-    // ── v2/form-scoresheet.user.txt ──────────────────────────────────────────
-    private const string FormScoresheetUserV2 = """
+    // ── v3/form-scoresheet.user.txt ──────────────────────────────────────────
+    private const string FormScoresheetUserV3 = """
         SCORESHEET CONTEXT:
         {{DATA}}
 
@@ -935,6 +938,12 @@ public class AIPromptDataSeeder(
         - Return one scoresheet definition JSON object only.
         - Title and Name must be non-empty strings; Sections must contain at least one section and every section must contain at least one field.
         - Every field Name and Label must be non-empty, Order and Type must be non-negative integers, and Definition must be a valid JSON object encoded as a string.
+        - Use only these QuestionType values: Number 1, Text 2, YesNo 6, SelectList 12, and TextArea 14.
+        - Number definitions must include integer "min" and "max" values with min less than or equal to max.
+        - Text definitions must include non-negative integer "minLength" and "maxLength" values with minLength less than or equal to maxLength.
+        - TextArea definitions must include the Text definition values and a positive integer "rows" value.
+        - YesNo definitions must include integer "yes_value" and "no_value" values.
+        - SelectList definitions must include a non-empty "options" array. Each option must include non-empty string "key" and "value" values and an integer "numeric_value".
         - The context contains CHEFS form fields, allowed Unity Flex question types, and a scoresheet template.
         - Fill out the scoresheet template to generate the rubric assessors use to score submitted applications.
         - Use CHEFS form fields as evidence for assessment criteria, but do not create one question per form field.
@@ -946,7 +955,9 @@ public class AIPromptDataSeeder(
         - Return valid plain JSON only.
         """;
 
-    private const string FormScoresheetMetadataV2 = """
+    private const string FormScoresheetSystemV3 = FormScoresheetSystemV2;
+
+    private const string FormScoresheetMetadataV3 = """
         {
           "DATA": "Serialized JSON payload containing the form name, form version, CHEFS fields, allowed question types, and the scoresheet template to fill out."
         }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/DataSeed/AIPromptDataSeeder.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/DataSeed/AIPromptDataSeeder.cs
@@ -129,7 +129,7 @@ public class AIPromptDataSeeder(
 
     private async Task SeedFormScoresheetPromptAsync()
     {
-        await EnsurePromptAsync(AIPromptTypes.FormScoresheet, 3, FormScoresheetSystemV3, FormScoresheetUserV3, FormScoresheetMetadataV3);
+        await EnsurePromptAsync(AIPromptTypes.FormScoresheet, 2, FormScoresheetSystemV2, FormScoresheetUserV2, FormScoresheetMetadataV2);
     }
 
     // ─── HELPERS ──────────────────────────────────────────────────────────────
@@ -900,8 +900,8 @@ public class AIPromptDataSeeder(
         Return only valid JSON.
         """;
 
-    // ── v3/form-scoresheet.user.txt ──────────────────────────────────────────
-    private const string FormScoresheetUserV3 = """
+    // ── v2/form-scoresheet.user.txt ──────────────────────────────────────────
+    private const string FormScoresheetUserV2 = """
         SCORESHEET CONTEXT:
         {{DATA}}
 
@@ -955,9 +955,7 @@ public class AIPromptDataSeeder(
         - Return valid plain JSON only.
         """;
 
-    private const string FormScoresheetSystemV3 = FormScoresheetSystemV2;
-
-    private const string FormScoresheetMetadataV3 = """
+    private const string FormScoresheetMetadataV2 = """
         {
           "DATA": "Serialized JSON payload containing the form name, form version, CHEFS fields, allowed question types, and the scoresheet template to fill out."
         }

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Runtime/Execution/AIProviderPayloadValidator.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Runtime/Execution/AIProviderPayloadValidator.cs
@@ -377,7 +377,7 @@ namespace Unity.AI.Runtime.Execution
 
         private static AIResponseValidationResult ValidateSelectListDefinition(JsonElement definition, string responseName)
         {
-            if (!TryGetProperty(definition, "options", out var options)
+            if (!TryGetDefinitionProperty(definition, "options", out var options)
                 || options.ValueKind != JsonValueKind.Array
                 || options.GetArrayLength() == 0)
             {
@@ -400,7 +400,7 @@ namespace Unity.AI.Runtime.Execution
 
         private static bool HasNonEmptyStringProperty(JsonElement element, string propertyName)
         {
-            return TryGetProperty(element, propertyName, out var property)
+            return TryGetDefinitionProperty(element, propertyName, out var property)
                 && property.ValueKind == JsonValueKind.String
                 && !string.IsNullOrWhiteSpace(property.GetString());
         }
@@ -408,7 +408,7 @@ namespace Unity.AI.Runtime.Execution
         private static bool TryGetInt64Property(JsonElement element, string propertyName, out long value)
         {
             value = default;
-            return TryGetProperty(element, propertyName, out var property)
+            return TryGetDefinitionProperty(element, propertyName, out var property)
                 && property.ValueKind == JsonValueKind.Number
                 && property.TryGetInt64(out value);
         }
@@ -416,7 +416,7 @@ namespace Unity.AI.Runtime.Execution
         private static bool TryGetUInt32Property(JsonElement element, string propertyName, out uint value)
         {
             value = default;
-            return TryGetProperty(element, propertyName, out var property)
+            return TryGetDefinitionProperty(element, propertyName, out var property)
                 && property.ValueKind == JsonValueKind.Number
                 && property.TryGetUInt32(out value);
         }
@@ -477,6 +477,13 @@ namespace Unity.AI.Runtime.Execution
 
             property = default;
             return false;
+        }
+
+        private static bool TryGetDefinitionProperty(JsonElement element, string propertyName, out JsonElement property)
+        {
+            property = default;
+            return element.ValueKind == JsonValueKind.Object
+                && element.TryGetProperty(propertyName, out property);
         }
         private static HashSet<string> ExtractQuestionIds(string sectionJson)
         {

--- a/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Runtime/Execution/AIProviderPayloadValidator.cs
+++ b/applications/Unity.GrantManager/modules/Unity.AI/src/Unity.AI.Application/Runtime/Execution/AIProviderPayloadValidator.cs
@@ -263,16 +263,22 @@ namespace Unity.AI.Runtime.Execution
                 }
             }
 
-            foreach (var propertyName in new[] { "Order", "Type" })
+            var orderResult = ValidateRequiredUIntProperty(field, "Order", $"{responseName} field");
+            if (!orderResult.IsValid)
             {
-                var result = ValidateRequiredUIntProperty(field, propertyName, $"{responseName} field");
-                if (!result.IsValid)
-                {
-                    return result;
-                }
+                return orderResult;
             }
 
-            var definitionResult = ValidateDefinitionProperty(field, responseName);
+            if (!TryGetProperty(field, "Type", out var type)
+                || type.ValueKind != JsonValueKind.Number
+                || !type.TryGetUInt32(out var typeValue)
+                || typeValue is not (1 or 2 or 6 or 12 or 14))
+            {
+                return AIResponseValidationResult.Invalid(
+                    $"{responseName} response field Type is unsupported (expected 1, 2, 6, 12, or 14).");
+            }
+
+            var definitionResult = ValidateDefinitionProperty(field, responseName, typeValue);
             if (!definitionResult.IsValid)
             {
                 return definitionResult;
@@ -281,7 +287,7 @@ namespace Unity.AI.Runtime.Execution
             return AIResponseValidationResult.Success();
         }
 
-        private static AIResponseValidationResult ValidateDefinitionProperty(JsonElement field, string responseName)
+        private static AIResponseValidationResult ValidateDefinitionProperty(JsonElement field, string responseName, uint type)
         {
             if (!TryGetProperty(field, "Definition", out var definition) || definition.ValueKind == JsonValueKind.Null)
             {
@@ -302,17 +308,117 @@ namespace Unity.AI.Runtime.Execution
             try
             {
                 using var definitionDocument = JsonDocument.Parse(definitionText);
-                if (definitionDocument.RootElement.ValueKind != JsonValueKind.Object)
+                var parsedDefinition = definitionDocument.RootElement;
+                if (parsedDefinition.ValueKind != JsonValueKind.Object)
                 {
                     return AIResponseValidationResult.Invalid($"{responseName} response field Definition must contain a JSON object.");
                 }
+
+                return type switch
+                {
+                    1 => ValidateIntegerRangeDefinition(parsedDefinition, responseName, "min", "max"),
+                    2 => ValidateUnsignedRangeDefinition(parsedDefinition, responseName, "minLength", "maxLength"),
+                    6 => ValidateRequiredInt64Properties(parsedDefinition, responseName, "yes_value", "no_value"),
+                    12 => ValidateSelectListDefinition(parsedDefinition, responseName),
+                    14 => ValidateTextAreaDefinition(parsedDefinition, responseName),
+                    _ => AIResponseValidationResult.Success()
+                };
             }
             catch (JsonException)
             {
                 return AIResponseValidationResult.Invalid($"{responseName} response field Definition must contain valid JSON.");
             }
+        }
+
+        private static AIResponseValidationResult ValidateIntegerRangeDefinition(JsonElement definition, string responseName, string minName, string maxName)
+        {
+            if (!TryGetInt64Property(definition, minName, out var min)
+                || !TryGetInt64Property(definition, maxName, out var max)
+                || min > max)
+            {
+                return AIResponseValidationResult.Invalid($"{responseName} response field Definition must contain integer '{minName}' and '{maxName}' values where {minName} is less than or equal to {maxName}.");
+            }
 
             return AIResponseValidationResult.Success();
+        }
+
+        private static AIResponseValidationResult ValidateUnsignedRangeDefinition(JsonElement definition, string responseName, string minName, string maxName)
+        {
+            if (!TryGetUInt32Property(definition, minName, out var min)
+                || !TryGetUInt32Property(definition, maxName, out var max)
+                || min > max)
+            {
+                return AIResponseValidationResult.Invalid($"{responseName} response field Definition must contain non-negative integer '{minName}' and '{maxName}' values where {minName} is less than or equal to {maxName}.");
+            }
+
+            return AIResponseValidationResult.Success();
+        }
+
+        private static AIResponseValidationResult ValidateTextAreaDefinition(JsonElement definition, string responseName)
+        {
+            var rangeResult = ValidateUnsignedRangeDefinition(definition, responseName, "minLength", "maxLength");
+            if (!rangeResult.IsValid)
+            {
+                return rangeResult;
+            }
+
+            return TryGetUInt32Property(definition, "rows", out var rows) && rows > 0
+                ? AIResponseValidationResult.Success()
+                : AIResponseValidationResult.Invalid($"{responseName} response field Definition must contain a positive integer 'rows' value.");
+        }
+
+        private static AIResponseValidationResult ValidateRequiredInt64Properties(JsonElement definition, string responseName, string firstName, string secondName)
+        {
+            return TryGetInt64Property(definition, firstName, out _)
+                && TryGetInt64Property(definition, secondName, out _)
+                ? AIResponseValidationResult.Success()
+                : AIResponseValidationResult.Invalid($"{responseName} response field Definition must contain integer '{firstName}' and '{secondName}' values.");
+        }
+
+        private static AIResponseValidationResult ValidateSelectListDefinition(JsonElement definition, string responseName)
+        {
+            if (!TryGetProperty(definition, "options", out var options)
+                || options.ValueKind != JsonValueKind.Array
+                || options.GetArrayLength() == 0)
+            {
+                return AIResponseValidationResult.Invalid($"{responseName} response field Definition must contain a non-empty 'options' array.");
+            }
+
+            foreach (var option in options.EnumerateArray())
+            {
+                if (option.ValueKind != JsonValueKind.Object
+                    || !HasNonEmptyStringProperty(option, "key")
+                    || !HasNonEmptyStringProperty(option, "value")
+                    || !TryGetInt64Property(option, "numeric_value", out _))
+                {
+                    return AIResponseValidationResult.Invalid($"{responseName} response field Definition contains an invalid select-list option.");
+                }
+            }
+
+            return AIResponseValidationResult.Success();
+        }
+
+        private static bool HasNonEmptyStringProperty(JsonElement element, string propertyName)
+        {
+            return TryGetProperty(element, propertyName, out var property)
+                && property.ValueKind == JsonValueKind.String
+                && !string.IsNullOrWhiteSpace(property.GetString());
+        }
+
+        private static bool TryGetInt64Property(JsonElement element, string propertyName, out long value)
+        {
+            value = default;
+            return TryGetProperty(element, propertyName, out var property)
+                && property.ValueKind == JsonValueKind.Number
+                && property.TryGetInt64(out value);
+        }
+
+        private static bool TryGetUInt32Property(JsonElement element, string propertyName, out uint value)
+        {
+            value = default;
+            return TryGetProperty(element, propertyName, out var property)
+                && property.ValueKind == JsonValueKind.Number
+                && property.TryGetUInt32(out value);
         }
 
         private static AIResponseValidationResult ValidateRequiredStringProperty(JsonElement element, string propertyName, string sourceName, bool allowEmpty = false)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormVersionAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormVersionAppService.cs
@@ -565,7 +565,7 @@ namespace Unity.GrantManager.ApplicationForms
                 worksheetReview == null ||
                 worksheetReview.Status == GenerationReviewStatus.Active ||
                 GetWorksheetReviewPayload(worksheetReview).NoSuggestionsGenerated ||
-                !await HasNoRemainingDraftsOrAssignedDraftAsync(worksheetReview))
+                !await HasPublishedAndAssignedDraftAsync(worksheetReview))
             {
                 throw new UserFriendlyException(localizer[AILocalizationKeys.WorksheetDraftsMustBePublished]);
             }
@@ -868,8 +868,7 @@ namespace Unity.GrantManager.ApplicationForms
         private async Task DeleteAiWorksheetSuggestionAsync(Worksheet worksheet, Guid formVersionId)
         {
             var links = await worksheetLinkRepository.GetListByWorksheetAsync(worksheet.Id, CorrelationConsts.FormVersion) ?? [];
-            if (worksheet.Published ||
-                links.Any(link => link.CorrelationId != formVersionId) ||
+            if (links.Any(link => link.CorrelationId != formVersionId) ||
                 await worksheetInstanceRepository.AnyByWorksheetAndFormVersionAsync(worksheet.Id, formVersionId))
             {
                 throw new UserFriendlyException(localizer[AILocalizationKeys.FormWorksheetDeleteProtected]);
@@ -1048,31 +1047,35 @@ namespace Unity.GrantManager.ApplicationForms
                     true);
             }
 
-            if (worksheetReview.Status == GenerationReviewStatus.Discarded)
+            var worksheetDraftState = await GetWorksheetDraftStateAsync(worksheetReview);
+            if (worksheetDraftState.HasPublishedAndAssignedDraft)
             {
                 return FormWorkflowResult.Single(
-                    FormGenerationWorkflowState.Completed,
-                    FormGenerationWorkflowAction.GenerateMapping,
+                    FormGenerationWorkflowState.GenerateFinalMapping,
+                    FormGenerationWorkflowAction.GenerateFinalMapping,
                     true);
             }
 
-            return await HasNoRemainingDraftsOrAssignedDraftAsync(worksheetReview)
+            return worksheetDraftState.HasDraft
                 ? FormWorkflowResult.Single(
-                    FormGenerationWorkflowState.GenerateFinalMapping,
-                    FormGenerationWorkflowAction.GenerateFinalMapping,
-                    true)
-                : FormWorkflowResult.Single(
                     FormGenerationWorkflowState.PublishAndAssignWorksheets,
                     FormGenerationWorkflowAction.PublishAndAssignWorksheets,
-                    false);
+                    false)
+                : FormWorkflowResult.Single(
+                    FormGenerationWorkflowState.Completed,
+                    FormGenerationWorkflowAction.GenerateMapping,
+                    true);
         }
 
-        private async Task<bool> HasNoRemainingDraftsOrAssignedDraftAsync(GenerationReview review)
+        private async Task<bool> HasPublishedAndAssignedDraftAsync(GenerationReview review) =>
+            (await GetWorksheetDraftStateAsync(review)).HasPublishedAndAssignedDraft;
+
+        private async Task<WorksheetDraftState> GetWorksheetDraftStateAsync(GenerationReview review)
         {
             var draftWorksheetIds = GetWorksheetReviewPayload(review).DraftWorksheetIds;
             if (draftWorksheetIds.Count == 0)
             {
-                return true;
+                return new WorksheetDraftState(false, false);
             }
 
             var linkedWorksheetIds = (await worksheetLinkRepository.GetListByCorrelationAsync(
@@ -1081,7 +1084,7 @@ namespace Unity.GrantManager.ApplicationForms
                 .Select(link => link.WorksheetId)
                 .ToHashSet();
 
-            var hasRemainingDraft = false;
+            var hasDraft = false;
 
             foreach (var worksheetId in draftWorksheetIds)
             {
@@ -1091,14 +1094,14 @@ namespace Unity.GrantManager.ApplicationForms
                     continue;
                 }
 
-                hasRemainingDraft = true;
+                hasDraft = true;
                 if (worksheet.Published && linkedWorksheetIds.Contains(worksheetId))
                 {
-                    return true;
+                    return new WorksheetDraftState(true, true);
                 }
             }
 
-            return !hasRemainingDraft;
+            return new WorksheetDraftState(hasDraft, false);
         }
 
         private static FormMappingReviewPhase GetLegacyPhase(FormGenerationWorkflowState state) =>
@@ -1153,6 +1156,8 @@ namespace Unity.GrantManager.ApplicationForms
                 bool enabled) =>
                 new(state, action, enabled, [action]);
         }
+
+        private sealed record WorksheetDraftState(bool HasDraft, bool HasPublishedAndAssignedDraft);
 
         private static FormMappingReviewPayload GetMappingReviewPayload(GenerationReview review) =>
             string.IsNullOrWhiteSpace(review.ReviewData)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Mapping.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Mapping.cshtml
@@ -256,17 +256,6 @@
                             </span>
                         </button>
                     }
-                    @if (canGenerateFormMapping && canGenerateFormWorksheet)
-                    {
-                        <button type="button" id="btn-restart-ai-flow" class="btn unt-btn-outline-primary btn-outline-primary ai-generate-btn ai-workflow-action d-none"
-                                data-ai-review-action="true"
-                                title="Delete AI workflow progress, AI worksheets, and saved mappings for this form version">
-                            <span class="ai-button-content">
-                                <i class="unt-icon-sm fa-solid fa-wand-magic-sparkles"></i>
-                                <span>Restart AI Flow</span>
-                            </span>
-                        </button>
-                    }
                     <abp-button id="btn-save" text="Save" icon-type="Other" icon="fl fl-save"
                                 class="btn unt-btn-primary btn-primary"
                                 style="pointer-events: all;"

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Mapping.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Mapping.js
@@ -72,7 +72,6 @@ $(function () {
         btnPublishAssignWorksheets: $('#btn-publish-assign-worksheets'),
         btnGenerateFinalMapping: $('#btn-generate-final-mapping'),
         btnReviewFinalMapping: $('#btn-review-final-mapping'),
-        btnRestartAiFlow: $('#btn-restart-ai-flow'),
         worksheetReviewModal: $('#aiWorksheetReviewModal'),
         mappingReviewModal: $('#aiMappingReviewModal'),
         mappingReviewFields: $('#aiMappingReviewFields'),
@@ -277,7 +276,6 @@ $(function () {
         });
         UIElements.btnGenerateWorksheet.on('click', queueFormWorksheet);
         UIElements.btnGenerateFinalMapping.on('click', finalizeMappingReview);
-        UIElements.btnRestartAiFlow.on('click', restartAiFlow);
         UIElements.btnGenerateScoresheet.on('click', function () {
             queueFormScoresheet(this);
         });
@@ -1092,7 +1090,6 @@ $(function () {
         UIElements.btnPublishAssignWorksheets.toggleClass('d-none', !isPublishAssign);
         UIElements.btnGenerateFinalMapping.toggleClass('d-none', !isFinalMapping);
         UIElements.btnReviewFinalMapping.toggleClass('d-none', !isFinalReview);
-        UIElements.btnRestartAiFlow.toggleClass('d-none', !isCompleted);
         UIElements.btnGenerate.prop('disabled', !review?.actionEnabled && isInitial);
         UIElements.btnGenerateFinalMapping.prop('disabled', !review?.actionEnabled);
 
@@ -1284,31 +1281,6 @@ $(function () {
                     .fail(function () {
                         abp.notify.error('', 'Unable to discard the mapping suggestions.');
                     });
-            });
-    }
-
-    function restartAiFlow() {
-        const formVersion = String(document.getElementById('formVersionId')?.value ?? '').trim();
-        if (!validateGuid(formVersion)) {
-            return;
-        }
-
-        abp.message.confirm(
-            'This permanently deletes AI workflow progress, AI-created worksheets and assignments, and all saved mappings for this form version.',
-            'Restart AI Flow?')
-            .then(function (confirmed) {
-                if (!confirmed) {
-                    return;
-                }
-
-                UIElements.btnRestartAiFlow.prop('disabled', true);
-                return globalThis.AIFormWorkflowApi.resetAiFlow(formVersion).done(function () {
-                    globalThis.location.reload();
-                }).fail(function (error) {
-                    abp.notify.error('', error?.responseJSON?.error?.message || 'Unable to restart the AI flow.');
-                }).always(function () {
-                    UIElements.btnRestartAiFlow.prop('disabled', false);
-                });
             });
     }
 

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Mapping.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Mapping.js
@@ -1081,7 +1081,6 @@ $(function () {
         const isPublishAssign = action === 'PublishAndAssignWorksheets';
         const isFinalMapping = action === 'GenerateFinalMapping';
         const isFinalReview = action === 'ReviewFinalMapping';
-        const isCompleted = state === 'Completed';
 
         UIElements.btnGenerate.toggleClass('d-none', !isInitial);
         UIElements.btnReviewMapping.toggleClass('d-none', !isInitialReview);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Mapping.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Pages/ApplicationForms/Mapping.js
@@ -1073,7 +1073,6 @@ $(function () {
 
     function updateWorkflowActions(review) {
         const action = getWorkflowAction(review);
-        const state = getWorkflowState(review);
         const isInitial = action === 'GenerateInitialMapping';
         const isInitialReview = action === 'ReviewInitialMapping';
         const isGenerateWorksheets = action === 'GenerateWorksheets';

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/DataSeed/AIPromptDataSeederTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/DataSeed/AIPromptDataSeederTests.cs
@@ -47,7 +47,7 @@ public class AIPromptDataSeederTests
         AssertVersions(insertedPrompts, AIPromptTypes.ApplicationScoring, 0, 1, 2);
         AssertVersions(insertedPrompts, AIPromptTypes.FormMapping, 2);
         AssertVersions(insertedPrompts, AIPromptTypes.FormWorksheet, 2);
-        AssertVersions(insertedPrompts, AIPromptTypes.FormScoresheet, 3);
+        AssertVersions(insertedPrompts, AIPromptTypes.FormScoresheet, 2);
         insertedPrompts.All(prompt =>
             prompt.TenantId is null &&
             prompt.IsActive &&

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/DataSeed/AIPromptDataSeederTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/AI/DataSeed/AIPromptDataSeederTests.cs
@@ -47,7 +47,7 @@ public class AIPromptDataSeederTests
         AssertVersions(insertedPrompts, AIPromptTypes.ApplicationScoring, 0, 1, 2);
         AssertVersions(insertedPrompts, AIPromptTypes.FormMapping, 2);
         AssertVersions(insertedPrompts, AIPromptTypes.FormWorksheet, 2);
-        AssertVersions(insertedPrompts, AIPromptTypes.FormScoresheet, 2);
+        AssertVersions(insertedPrompts, AIPromptTypes.FormScoresheet, 3);
         insertedPrompts.All(prompt =>
             prompt.TenantId is null &&
             prompt.IsActive &&
@@ -57,6 +57,14 @@ public class AIPromptDataSeederTests
         var worksheetPrompt = insertedPrompts.Single(prompt => prompt.Name == AIPromptTypes.FormWorksheet);
         worksheetPrompt.UserPrompt.ShouldContain("all applicable field suggestions");
         worksheetPrompt.UserPrompt.ShouldContain("empty fields array");
+        var scoresheetPrompt = insertedPrompts.Single(prompt => prompt.Name == AIPromptTypes.FormScoresheet);
+        scoresheetPrompt.UserPrompt.ShouldContain("min");
+        scoresheetPrompt.UserPrompt.ShouldContain("max");
+        var mappingPrompt = insertedPrompts.Single(prompt => prompt.Name == AIPromptTypes.FormMapping);
+        mappingPrompt.VersionNumber.ShouldBe(2);
+        mappingPrompt.UserPrompt.ShouldContain("Down-weight CHEFS fields");
+        mappingPrompt.UserPrompt.ShouldContain("Up-weight CHEFS fields");
+        mappingPrompt.UserPrompt.ShouldContain("prefer the hidden-field signal");
     }
 
 

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/ApplicationForms/ApplicationFormVersionAppServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/ApplicationForms/ApplicationFormVersionAppServiceTests.cs
@@ -196,6 +196,8 @@ public class ApplicationFormVersionAppServiceTests(ITestOutputHelper outputHelpe
 
         var formVersionRepository = Substitute.For<IApplicationFormVersionRepository>();
         formVersionRepository.GetAsync(formVersionId).Returns(formVersion);
+        var repository = Substitute.For<IRepository<ApplicationFormVersion, Guid>>();
+        repository.GetAsync(formVersionId).Returns(formVersion);
         var worksheetRepository = Substitute.For<IWorksheetRepository>();
         worksheetRepository.GetByNameAsync(Arg.Any<string>(), true).Returns(worksheet);
         worksheetRepository.FindAsync(worksheet.Id).Returns(worksheet);
@@ -213,7 +215,7 @@ public class ApplicationFormVersionAppServiceTests(ITestOutputHelper outputHelpe
             .Returns([worksheetReview]);
 
         var service = CreateService(
-            Substitute.For<IRepository<ApplicationFormVersion, Guid>>(),
+            repository,
             Substitute.For<IAIGenerationAppService>(),
             formVersionRepository,
             worksheetRepository,

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/ApplicationForms/ApplicationFormVersionAppServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/ApplicationForms/ApplicationFormVersionAppServiceTests.cs
@@ -179,6 +179,152 @@ public class ApplicationFormVersionAppServiceTests(ITestOutputHelper outputHelpe
     }
 
     [Fact]
+    public async Task ResetAiFlowAsync_Should_UnlinkAndDelete_PublishedWorksheetForTheCurrentForm()
+    {
+        var formVersionId = Guid.NewGuid();
+        var formId = Guid.NewGuid();
+        var formVersion = new ApplicationFormVersion { ApplicationFormId = formId };
+        var worksheet = BuildAiWorksheet(formId, formVersionId, published: true);
+        var worksheetReview = new GenerationReview(
+            Guid.NewGuid(),
+            AIGenerationOperations.FormWorksheet,
+            formVersionId);
+        worksheetReview.SetReviewData(JsonSerializer.Serialize(new FormWorksheetReviewPayload
+        {
+            DraftWorksheetIds = [worksheet.Id]
+        }));
+
+        var formVersionRepository = Substitute.For<IApplicationFormVersionRepository>();
+        formVersionRepository.GetAsync(formVersionId).Returns(formVersion);
+        var worksheetRepository = Substitute.For<IWorksheetRepository>();
+        worksheetRepository.GetByNameAsync(Arg.Any<string>(), true).Returns(worksheet);
+        worksheetRepository.FindAsync(worksheet.Id).Returns(worksheet);
+        var worksheetLinkRepository = Substitute.For<Unity.Flex.Domain.WorksheetLinks.IWorksheetLinkRepository>();
+        var link = new Unity.Flex.Domain.WorksheetLinks.WorksheetLink(
+            Guid.NewGuid(), worksheet.Id, formVersionId, Unity.Modules.Shared.Correlation.CorrelationConsts.FormVersion, string.Empty);
+        worksheetLinkRepository.GetListByWorksheetAsync(worksheet.Id, Unity.Modules.Shared.Correlation.CorrelationConsts.FormVersion)
+            .Returns([link]);
+        var worksheetInstanceRepository = Substitute.For<Unity.Flex.Domain.WorksheetInstances.IWorksheetInstanceRepository>();
+        worksheetInstanceRepository.AnyByWorksheetAndFormVersionAsync(worksheet.Id, formVersionId).Returns(false);
+        var reviewRepository = Substitute.For<IGenerationReviewRepository>();
+        reviewRepository.GetListByOperationAndFormVersionAsync(AIGenerationOperations.FormMapping, formVersionId)
+            .Returns([]);
+        reviewRepository.GetListByOperationAndFormVersionAsync(AIGenerationOperations.FormWorksheet, formVersionId)
+            .Returns([worksheetReview]);
+
+        var service = CreateService(
+            Substitute.For<IRepository<ApplicationFormVersion, Guid>>(),
+            Substitute.For<IAIGenerationAppService>(),
+            formVersionRepository,
+            worksheetRepository,
+            generationReviewRepository: reviewRepository,
+            worksheetLinkRepository: worksheetLinkRepository,
+            worksheetInstanceRepository: worksheetInstanceRepository);
+        service.LazyServiceProvider = GetRequiredService<IAbpLazyServiceProvider>();
+
+        await service.ResetAiFlowAsync(formVersionId);
+
+        await worksheetLinkRepository.Received(1).DeleteAsync(link, true);
+        await worksheetRepository.Received(1).DeleteAsync(worksheet, true);
+        formVersion.SubmissionHeaderMapping.ShouldBe("{}");
+    }
+
+    [Fact]
+    public async Task ResetAiFlowAsync_Should_Delete_Draft_From_Discarded_Worksheet_Review()
+    {
+        var formVersionId = Guid.NewGuid();
+        var formId = Guid.NewGuid();
+        var formVersion = new ApplicationFormVersion { ApplicationFormId = formId };
+        var worksheet = BuildAiWorksheet(formId, formVersionId, published: false);
+        var worksheetReview = new GenerationReview(Guid.NewGuid(), AIGenerationOperations.FormWorksheet, formVersionId);
+        worksheetReview.SetReviewData(JsonSerializer.Serialize(new FormWorksheetReviewPayload
+        {
+            DraftWorksheetIds = [worksheet.Id]
+        }));
+        worksheetReview.Discard();
+
+        var repository = Substitute.For<IRepository<ApplicationFormVersion, Guid>>();
+        repository.GetAsync(formVersionId).Returns(formVersion);
+        var formVersionRepository = Substitute.For<IApplicationFormVersionRepository>();
+        formVersionRepository.GetAsync(formVersionId).Returns(formVersion);
+        var worksheetRepository = Substitute.For<IWorksheetRepository>();
+        worksheetRepository.GetByNameAsync(Arg.Any<string>(), true).Returns((Worksheet?)null);
+        worksheetRepository.FindAsync(worksheet.Id).Returns(worksheet);
+        var reviewRepository = Substitute.For<IGenerationReviewRepository>();
+        reviewRepository.GetListByOperationAndFormVersionAsync(AIGenerationOperations.FormMapping, formVersionId).Returns([]);
+        reviewRepository.GetListByOperationAndFormVersionAsync(AIGenerationOperations.FormWorksheet, formVersionId).Returns([worksheetReview]);
+
+        var service = CreateService(repository, Substitute.For<IAIGenerationAppService>(), formVersionRepository, worksheetRepository,
+            generationReviewRepository: reviewRepository);
+        service.LazyServiceProvider = GetRequiredService<IAbpLazyServiceProvider>();
+
+        await service.ResetAiFlowAsync(formVersionId);
+
+        await worksheetRepository.Received(1).DeleteAsync(worksheet, true);
+        await reviewRepository.Received(1).DeleteManyAsync(
+            Arg.Is<IEnumerable<GenerationReview>>(reviews => reviews.Single() == worksheetReview), true);
+        formVersion.SubmissionHeaderMapping.ShouldBe("{}");
+    }
+
+    [Fact]
+    public async Task GetMappingReviewAsync_Should_Show_Publish_And_Assign_For_Draft_From_Discarded_Worksheet_Review()
+    {
+        var formVersionId = Guid.NewGuid();
+        var formId = Guid.NewGuid();
+        var worksheet = BuildAiWorksheet(formId, formVersionId, published: false);
+        var mappingReview = new GenerationReview(Guid.NewGuid(), AIGenerationOperations.FormMapping, formVersionId);
+        mappingReview.Complete();
+        var worksheetReview = new GenerationReview(Guid.NewGuid(), AIGenerationOperations.FormWorksheet, formVersionId);
+        worksheetReview.SetReviewData(JsonSerializer.Serialize(new FormWorksheetReviewPayload
+        {
+            DraftWorksheetIds = [worksheet.Id]
+        }));
+        worksheetReview.Discard();
+
+        var worksheetRepository = Substitute.For<IWorksheetRepository>();
+        worksheetRepository.FindAsync(worksheet.Id).Returns(worksheet);
+        var worksheetLinkRepository = Substitute.For<Unity.Flex.Domain.WorksheetLinks.IWorksheetLinkRepository>();
+        worksheetLinkRepository.GetListByCorrelationAsync(formVersionId, Unity.Modules.Shared.Correlation.CorrelationConsts.FormVersion).Returns([]);
+        var reviewRepository = Substitute.For<IGenerationReviewRepository>();
+        reviewRepository.FindLatestByOperationAndFormVersionAsync(AIGenerationOperations.FormMapping, formVersionId).Returns(mappingReview);
+        reviewRepository.FindLatestByOperationAndFormVersionAsync(AIGenerationOperations.FormWorksheet, formVersionId).Returns(worksheetReview);
+
+        var service = CreateService(Substitute.For<IRepository<ApplicationFormVersion, Guid>>(), Substitute.For<IAIGenerationAppService>(),
+            worksheetRepository: worksheetRepository, generationReviewRepository: reviewRepository, worksheetLinkRepository: worksheetLinkRepository);
+        service.LazyServiceProvider = GetRequiredService<IAbpLazyServiceProvider>();
+
+        var result = await service.GetMappingReviewAsync(formVersionId);
+
+        result.WorkflowState.ShouldBe(FormGenerationWorkflowState.PublishAndAssignWorksheets);
+        result.WorkflowAction.ShouldBe(FormGenerationWorkflowAction.PublishAndAssignWorksheets);
+        result.ActionEnabled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetMappingReviewAsync_Should_Skip_Final_Mapping_When_No_Draft_Was_Created()
+    {
+        var formVersionId = Guid.NewGuid();
+        var mappingReview = new GenerationReview(Guid.NewGuid(), AIGenerationOperations.FormMapping, formVersionId);
+        mappingReview.Complete();
+        var worksheetReview = new GenerationReview(Guid.NewGuid(), AIGenerationOperations.FormWorksheet, formVersionId);
+        worksheetReview.SetReviewData(JsonSerializer.Serialize(new FormWorksheetReviewPayload()));
+        worksheetReview.Discard();
+
+        var reviewRepository = Substitute.For<IGenerationReviewRepository>();
+        reviewRepository.FindLatestByOperationAndFormVersionAsync(AIGenerationOperations.FormMapping, formVersionId).Returns(mappingReview);
+        reviewRepository.FindLatestByOperationAndFormVersionAsync(AIGenerationOperations.FormWorksheet, formVersionId).Returns(worksheetReview);
+
+        var service = CreateService(Substitute.For<IRepository<ApplicationFormVersion, Guid>>(), Substitute.For<IAIGenerationAppService>(),
+            generationReviewRepository: reviewRepository);
+        service.LazyServiceProvider = GetRequiredService<IAbpLazyServiceProvider>();
+
+        var result = await service.GetMappingReviewAsync(formVersionId);
+
+        result.WorkflowState.ShouldBe(FormGenerationWorkflowState.Completed);
+        result.CanGenerateFinalMapping.ShouldBeFalse();
+    }
+
+    [Fact]
     public async Task CreateAiWorksheetDraftAsync_Should_Create_Unlinked_Unpublished_Draft_And_Keep_Remaining_Suggestions()
     {
         var formVersionId = Guid.NewGuid();
@@ -425,7 +571,9 @@ public class ApplicationFormVersionAppServiceTests(ITestOutputHelper outputHelpe
         IRepository<CustomField, Guid>? customFieldRepository = null,
         IGenerationReviewRepository? generationReviewRepository = null,
         IScoresheetRepository? scoresheetRepository = null,
-        Unity.Flex.Domain.ScoresheetInstances.IScoresheetInstanceRepository? scoresheetInstanceRepository = null)
+        Unity.Flex.Domain.ScoresheetInstances.IScoresheetInstanceRepository? scoresheetInstanceRepository = null,
+        Unity.Flex.Domain.WorksheetLinks.IWorksheetLinkRepository? worksheetLinkRepository = null,
+        Unity.Flex.Domain.WorksheetInstances.IWorksheetInstanceRepository? worksheetInstanceRepository = null)
     {
         var featureChecker = Substitute.For<IFeatureChecker>();
         featureChecker.IsEnabledAsync(Arg.Any<string>()).Returns(true);
@@ -445,9 +593,9 @@ public class ApplicationFormVersionAppServiceTests(ITestOutputHelper outputHelpe
             worksheetRepository ?? Substitute.For<IWorksheetRepository>(),
             customFieldRepository ?? Substitute.For<IRepository<CustomField, Guid>>(),
             generationReviewRepository ?? Substitute.For<IGenerationReviewRepository>(),
-            Substitute.For<Unity.Flex.Domain.WorksheetLinks.IWorksheetLinkRepository>(),
+            worksheetLinkRepository ?? Substitute.For<Unity.Flex.Domain.WorksheetLinks.IWorksheetLinkRepository>(),
             scoresheetRepository ?? Substitute.For<IScoresheetRepository>(),
-            Substitute.For<Unity.Flex.Domain.WorksheetInstances.IWorksheetInstanceRepository>(),
+            worksheetInstanceRepository ?? Substitute.For<Unity.Flex.Domain.WorksheetInstances.IWorksheetInstanceRepository>(),
             scoresheetInstanceRepository ?? Substitute.For<Unity.Flex.Domain.ScoresheetInstances.IScoresheetInstanceRepository>());
         return service;
     }

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/Runtime/Execution/AIProviderPayloadValidatorTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/Runtime/Execution/AIProviderPayloadValidatorTests.cs
@@ -228,11 +228,28 @@ public class PromptResponseValidatorTests
     }
 
     [Theory]
-    [InlineData("{\"min\":0}")]
-    [InlineData("{\"min\":10,\"max\":1}")]
-    [InlineData("{\"minLength\":0,\"maxLength\":-1}")]
-    [InlineData("{\"minLength\":0,\"maxLength\":10,\"rows\":0}")]
-    public void ValidateFormScoresheetJson_Should_Return_InvalidOutput_For_Invalid_Number_Definition(string definition)
+    [InlineData(1, "{\"min\":0}")]
+    [InlineData(1, "{\"min\":10,\"max\":1}")]
+    [InlineData(2, "{\"minLength\":0,\"maxLength\":-1}")]
+    [InlineData(14, "{\"minLength\":0,\"maxLength\":10,\"rows\":0}")]
+    [InlineData(6, "{\"yes_value\":1}")]
+    [InlineData(12, "{\"options\":[]}")]
+    public void ValidateFormScoresheetJson_Should_Return_InvalidOutput_For_Invalid_Field_Definition(int type, string definition)
+    {
+        var response = ValidFormScoresheetJson
+            .Replace("\"Type\": 1", $"\"Type\": {type}", StringComparison.Ordinal)
+            .Replace("\"Definition\": \"{\\\"min\\\": 0, \\\"max\\\": 10}\"", $"\"Definition\": \"{definition.Replace("\"", "\\\"", StringComparison.Ordinal)}\"", StringComparison.Ordinal);
+
+        var result = AIProviderPayloadValidator.ValidateFormScoresheetJson(response);
+
+        result.IsValid.ShouldBeFalse();
+        result.FailureCategory.ShouldBe(AIFailureCategory.InvalidOutput);
+    }
+
+    [Theory]
+    [InlineData("{\"Min\":0,\"Max\":10}")]
+    [InlineData("{\"min\":0,\"Max\":10}")]
+    public void ValidateFormScoresheetJson_Should_Reject_Incorrectly_Cased_Definition_Properties(string definition)
     {
         var response = ValidFormScoresheetJson
             .Replace("\"Definition\": \"{\\\"min\\\": 0, \\\"max\\\": 10}\"", $"\"Definition\": \"{definition.Replace("\"", "\\\"", StringComparison.Ordinal)}\"", StringComparison.Ordinal);

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/Runtime/Execution/AIProviderPayloadValidatorTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/Runtime/Execution/AIProviderPayloadValidatorTests.cs
@@ -210,6 +210,39 @@ public class PromptResponseValidatorTests
         result.IsValid.ShouldBeTrue();
     }
 
+    [Theory]
+    [InlineData(1, "{\"min\":0,\"max\":10}")]
+    [InlineData(2, "{\"minLength\":0,\"maxLength\":100}")]
+    [InlineData(6, "{\"yes_value\":1,\"no_value\":0}")]
+    [InlineData(12, "{\"options\":[{\"key\":\"yes\",\"value\":\"Yes\",\"numeric_value\":1}]}")]
+    [InlineData(14, "{\"minLength\":0,\"maxLength\":100,\"rows\":3}")]
+    public void ValidateFormScoresheetJson_Should_Return_Success_For_Valid_Field_Definitions(int type, string definition)
+    {
+        var response = ValidFormScoresheetJson
+            .Replace("\"Type\": 1", $"\"Type\": {type}", StringComparison.Ordinal)
+            .Replace("\"Definition\": \"{\\\"min\\\": 0, \\\"max\\\": 10}\"", $"\"Definition\": \"{definition.Replace("\"", "\\\"", StringComparison.Ordinal)}\"", StringComparison.Ordinal);
+
+        var result = AIProviderPayloadValidator.ValidateFormScoresheetJson(response);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("{\"min\":0}")]
+    [InlineData("{\"min\":10,\"max\":1}")]
+    [InlineData("{\"minLength\":0,\"maxLength\":-1}")]
+    [InlineData("{\"minLength\":0,\"maxLength\":10,\"rows\":0}")]
+    public void ValidateFormScoresheetJson_Should_Return_InvalidOutput_For_Invalid_Number_Definition(string definition)
+    {
+        var response = ValidFormScoresheetJson
+            .Replace("\"Definition\": \"{\\\"min\\\": 0, \\\"max\\\": 10}\"", $"\"Definition\": \"{definition.Replace("\"", "\\\"", StringComparison.Ordinal)}\"", StringComparison.Ordinal);
+
+        var result = AIProviderPayloadValidator.ValidateFormScoresheetJson(response);
+
+        result.IsValid.ShouldBeFalse();
+        result.FailureCategory.ShouldBe(AIFailureCategory.InvalidOutput);
+    }
+
     [Fact]
     public void ValidateFormScoresheetJson_Should_Allow_Empty_Optional_Reporting_Fields()
     {
@@ -250,7 +283,7 @@ public class PromptResponseValidatorTests
     [InlineData("\"Title\": \"Generated scoresheet\"", "\"Title\": \"\"")]
     [InlineData("\"Version\": 1", "\"Version\": \"1\"")]
     [InlineData("\"Published\": true", "\"Published\": \"true\"")]
-    [InlineData("\"Definition\": \"{}\"", "\"Definition\": \"not-json\"")]
+    [InlineData("\"Definition\": \"{\\\"min\\\": 0, \\\"max\\\": 10}\"", "\"Definition\": \"not-json\"")]
     public void ValidateFormScoresheetJson_Should_Return_InvalidOutput_For_Invalid_Required_Value(string validValue, string invalidValue)
     {
         var result = AIProviderPayloadValidator.ValidateFormScoresheetJson(ValidFormScoresheetJson.Replace(validValue, invalidValue, StringComparison.Ordinal));
@@ -264,7 +297,7 @@ public class PromptResponseValidatorTests
     {
         var response = ValidFormScoresheetJson.Replace(
             "\"Fields\": [",
-            "\"Fields\": [{ \"Name\": \"project_score\", \"Label\": \"Duplicate\", \"Order\": 1, \"Type\": 1, \"Definition\": \"{}\" },",
+            "\"Fields\": [{ \"Name\": \"project_score\", \"Label\": \"Duplicate\", \"Order\": 1, \"Type\": 1, \"Definition\": \"{\\\"min\\\":0,\\\"max\\\":10}\" },",
             StringComparison.Ordinal);
 
         var result = AIProviderPayloadValidator.ValidateFormScoresheetJson(response);
@@ -278,7 +311,7 @@ public class PromptResponseValidatorTests
     {
         var response = ValidFormScoresheetJson.Replace(
             "\"Sections\": [",
-            "\"Sections\": [{ \"Name\": \"Review\", \"Order\": 1, \"Fields\": [{ \"Name\": \"second_score\", \"Label\": \"Second score\", \"Order\": 0, \"Type\": 1, \"Definition\": \"{}\" }] },",
+            "\"Sections\": [{ \"Name\": \"Review\", \"Order\": 1, \"Fields\": [{ \"Name\": \"second_score\", \"Label\": \"Second score\", \"Order\": 0, \"Type\": 1, \"Definition\": \"{\\\"min\\\":0,\\\"max\\\":10}\" }] },",
             StringComparison.Ordinal);
 
         var result = AIProviderPayloadValidator.ValidateFormScoresheetJson(response);
@@ -307,7 +340,7 @@ public class PromptResponseValidatorTests
                   "Label": "Project score",
                   "Order": 0,
                   "Type": 1,
-                  "Definition": "{}"
+                  "Definition": "{\"min\": 0, \"max\": 10}"
                 }
               ]
             }


### PR DESCRIPTION
## Summary

- Remove the obsolete Restart AI Flow control from the application form mapping page.
- Update AI mapping guidance to down-weight CHEFS labels containing "Extract".
- Prefer CHEFS fields with type "hidden", especially when the label or API property name contains "hidden".
- Validate AI-generated scoresheet definitions for Number, Text, Text Area, Yes/No, and Select List question types before persistence.
- Add focused tests covering the updated AI mapping prompt and scoresheet validation.

## Validation

- Targeted AI Application Tests passed.
