### PR TITLE
AB#34249 use concise AI form identifiers

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/ApplicationForms/Mapping/AiDraftName.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/ApplicationForms/Mapping/AiDraftName.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Linq;
+
+namespace Unity.GrantManager.ApplicationForms.Mapping;
+
+public static class AiDraftName
+{
+    public static string NormalizeTitle(string title) =>
+        string.Concat(title.Trim()
+            .Where(char.IsLetterOrDigit)
+            .Select(char.ToLowerInvariant));
+
+    public static string BuildBaseName(string title)
+    {
+        var normalizedTitle = NormalizeTitle(title);
+        return $"ai-{(string.IsNullOrEmpty(normalizedTitle) ? "draft" : normalizedTitle)}";
+    }
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/ApplicationForms/Mapping/AiScoresheetSuggestionName.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/ApplicationForms/Mapping/AiScoresheetSuggestionName.cs
@@ -4,6 +4,6 @@ namespace Unity.GrantManager.ApplicationForms.Mapping;
 
 public static class AiScoresheetSuggestionName
 {
-    public static string Build(Guid formId, Guid formVersionId) =>
-        $"ai-form-{formId}-version-{formVersionId}-scoresheet";
+    public static string Build(Guid formVersionId) =>
+        $"ai-{formVersionId:N}-scoresheet";
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/ApplicationForms/Mapping/AiWorksheetSuggestionName.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/ApplicationForms/Mapping/AiWorksheetSuggestionName.cs
@@ -4,6 +4,6 @@ namespace Unity.GrantManager.ApplicationForms.Mapping;
 
 public static class AiWorksheetSuggestionName
 {
-    public static string Build(Guid formId, Guid formVersionId) =>
-        $"ai-form-{formId}-version-{formVersionId}-worksheet";
+    public static string Build(Guid formVersionId) =>
+        $"ai-{formVersionId:N}-worksheet";
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormVersionAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/ApplicationForms/ApplicationFormVersionAppService.cs
@@ -604,6 +604,10 @@ namespace Unity.GrantManager.ApplicationForms
             {
                 throw new UserFriendlyException(localizer[AILocalizationKeys.WorksheetTitleRequired]);
             }
+            if (string.IsNullOrEmpty(AiDraftName.NormalizeTitle(title)))
+            {
+                throw new UserFriendlyException(localizer[AILocalizationKeys.WorksheetTitleRequired]);
+            }
 
             var selectedFieldIds = input.SelectedFieldIds?.ToHashSet() ?? [];
             if (selectedFieldIds.Count == 0)
@@ -620,6 +624,7 @@ namespace Unity.GrantManager.ApplicationForms
 
             var draftName = await GetNextAiWorksheetDraftNameAsync(title);
             var draft = new Worksheet(GuidGenerator.Create(), draftName, title);
+            draft.SetVersion(ParseDraftVersion(draftName));
 
             var draftSection = new WorksheetSection(GuidGenerator.Create(), "Suggested Fields")
             {
@@ -712,7 +717,7 @@ namespace Unity.GrantManager.ApplicationForms
 
             var formVersion = await formVersionRepository.GetAsync(formVersionId);
             var scoresheet = await scoresheetRepository.GetByNameAsync(
-                AiScoresheetSuggestionName.Build(formVersion.ApplicationFormId, formVersion.Id), true);
+                AiScoresheetSuggestionName.Build(formVersion.Id), true);
             return scoresheet?.Published == false ? MapAiScoresheetReview(scoresheet) : null;
         }
 
@@ -732,6 +737,10 @@ namespace Unity.GrantManager.ApplicationForms
             {
                 throw new UserFriendlyException(localizer[AILocalizationKeys.FormScoresheetTitleRequired]);
             }
+            if (string.IsNullOrEmpty(AiDraftName.NormalizeTitle(title)))
+            {
+                throw new UserFriendlyException(localizer[AILocalizationKeys.FormScoresheetTitleRequired]);
+            }
 
             var selectedIds = input.SelectedQuestionIds?.ToHashSet() ?? [];
             if (selectedIds.Count == 0)
@@ -747,6 +756,7 @@ namespace Unity.GrantManager.ApplicationForms
 
             var draftName = await GetNextAiScoresheetDraftNameAsync(title);
             var draft = new Scoresheet(GuidGenerator.Create(), title, draftName);
+            draft.Version = ParseDraftVersion(draftName);
             foreach (var sourceSection in suggestion.Sections.OrderBy(section => section.Order))
             {
                 var selectedQuestions = sourceSection.Fields
@@ -836,7 +846,7 @@ namespace Unity.GrantManager.ApplicationForms
 
             var formVersion = await formVersionRepository.GetAsync(formVersionId);
             var scoresheet = await scoresheetRepository.GetByNameAsync(
-                AiScoresheetSuggestionName.Build(formVersion.ApplicationFormId, formVersion.Id), true);
+                AiScoresheetSuggestionName.Build(formVersion.Id), true);
             return scoresheet?.Published == false ? scoresheet : null;
         }
 
@@ -920,7 +930,7 @@ namespace Unity.GrantManager.ApplicationForms
         private async Task<Worksheet?> GetAiSuggestionWorksheetAsync(ApplicationFormVersion formVersion)
         {
             return await worksheetRepository.GetByNameAsync(
-                AiWorksheetSuggestionName.Build(formVersion.ApplicationFormId, formVersion.Id), true);
+                AiWorksheetSuggestionName.Build(formVersion.Id), true);
         }
 
         private static AiWorksheetReviewDto MapAiWorksheetReview(Worksheet worksheet) => new()
@@ -1178,14 +1188,13 @@ namespace Unity.GrantManager.ApplicationForms
 
         private async Task<string> GetNextAiWorksheetDraftNameAsync(string title)
         {
-            var titlePart = Regex.Replace(title.Trim().ToLowerInvariant(), "[^a-z0-9]+", "-").Trim('-');
-            var baseName = $"ai-{(string.IsNullOrEmpty(titlePart) ? "worksheet" : titlePart)}";
-            var candidate = baseName;
-            var suffix = 2;
+            var baseName = AiDraftName.BuildBaseName(title);
+            var version = 1;
+            var candidate = $"{baseName}-v{version}";
 
             while (await worksheetRepository.GetByNameAsync(candidate, false) != null)
             {
-                candidate = $"{baseName}-{suffix++}";
+                candidate = $"{baseName}-v{++version}";
             }
 
             return candidate;
@@ -1193,18 +1202,20 @@ namespace Unity.GrantManager.ApplicationForms
 
         private async Task<string> GetNextAiScoresheetDraftNameAsync(string title)
         {
-            var titlePart = Regex.Replace(title.Trim().ToLowerInvariant(), "[^a-z0-9]+", "-").Trim('-');
-            var baseName = $"ai-{(string.IsNullOrEmpty(titlePart) ? "scoresheet" : titlePart)}";
-            var candidate = baseName;
-            var suffix = 2;
+            var baseName = AiDraftName.BuildBaseName(title);
+            var version = 1;
+            var candidate = $"{baseName}-v{version}";
 
             while (await scoresheetRepository.GetByNameAsync(candidate, false) != null)
             {
-                candidate = $"{baseName}-{suffix++}";
+                candidate = $"{baseName}-v{++version}";
             }
 
             return candidate;
         }
+
+        private static uint ParseDraftVersion(string name) =>
+            uint.Parse(name[(name.LastIndexOf("-v", StringComparison.Ordinal) + 2)..]);
 
         private static string NormalizeCustomFieldDefinition(string definition)
         {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/Operations/FormScoresheet/FormScoresheetOperationExecutor.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/Operations/FormScoresheet/FormScoresheetOperationExecutor.cs
@@ -49,7 +49,7 @@ public sealed class FormScoresheetOperationExecutor(
             ?? throw new InvalidOperationException(localizer[AILocalizationKeys.ScoresheetGenerationRequiresFormVersion]);
         var formVersion = await applicationFormVersionRepository.GetAsync(applicationFormVersionId);
         var applicationForm = await applicationFormRepository.GetAsync(formVersion.ApplicationFormId);
-        var scoresheetName = AiScoresheetSuggestionName.Build(applicationForm.Id, formVersion.Id);
+        var scoresheetName = AiScoresheetSuggestionName.Build(formVersion.Id);
         var existingScoresheet = await scoresheetRepository.GetByNameAsync(scoresheetName, true);
         var review = await generationReviewRepository.FindLatestByOperationAndFormVersionAsync(
             AIGenerationOperations.FormScoresheet,

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/Operations/FormWorksheet/FormWorksheetOperationExecutor.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/Automation/Operations/FormWorksheet/FormWorksheetOperationExecutor.cs
@@ -49,7 +49,7 @@ public sealed class FormWorksheetOperationExecutor(
             ?? throw new InvalidOperationException("Form worksheet generation requires an application form version.");
         var formVersion = await applicationFormVersionRepository.GetAsync(applicationFormVersionId);
         var applicationForm = await applicationFormRepository.GetAsync(formVersion.ApplicationFormId);
-        var baseWorksheetName = AiWorksheetSuggestionName.Build(applicationForm.Id, formVersion.Id);
+        var baseWorksheetName = AiWorksheetSuggestionName.Build(formVersion.Id);
         var review = await generationReviewRepository.FindLatestByOperationAndFormVersionAsync(
             AIGenerationOperations.FormWorksheet,
             applicationFormVersionId);

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/CustomFields/CustomFieldsViewComponent.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/CustomFields/CustomFieldsViewComponent.cs
@@ -50,7 +50,7 @@ namespace Unity.GrantManager.Web.Views.Shared.Components.CustomFields
 
             var aiSuggestionWorksheetName = formVersion == null
                 ? string.Empty
-                : AiWorksheetSuggestionName.Build(formVersion.ApplicationFormId, formVersion.Id);
+                : AiWorksheetSuggestionName.Build(formVersion.Id);
             var worksheets = await worksheetListAppService.GetListAsync();
             model.HasPendingAiWorksheet = worksheets
                 .Any(worksheet => !worksheet.Published && worksheet.Name == aiSuggestionWorksheetName);

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/ApplicationForms/ApplicationFormVersionAppServiceTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/ApplicationForms/ApplicationFormVersionAppServiceTests.cs
@@ -218,7 +218,7 @@ public class ApplicationFormVersionAppServiceTests(ITestOutputHelper outputHelpe
         });
 
         createdDraft.ShouldNotBeNull();
-        createdDraft!.Name.ShouldBe("ai-risk-review");
+        createdDraft!.Name.ShouldBe("ai-riskreview-v1");
         createdDraft.Title.ShouldBe("Risk Review");
         createdDraft.Published.ShouldBeFalse();
         createdDraft.Links.ShouldBeEmpty();
@@ -248,8 +248,8 @@ public class ApplicationFormVersionAppServiceTests(ITestOutputHelper outputHelpe
         var customFieldRepository = Substitute.For<IRepository<CustomField, Guid>>();
         var reviewRepository = CreateActiveWorksheetReviewRepository(formVersionId);
         Worksheet? createdDraft = null;
-        worksheetRepository.GetByNameAsync("ai-risk-review", false).Returns(new Worksheet(Guid.NewGuid(), "ai-risk-review", "Existing"));
-        worksheetRepository.GetByNameAsync("ai-risk-review-2", false).Returns((Worksheet?)null);
+        worksheetRepository.GetByNameAsync("ai-riskreview-v1", false).Returns(new Worksheet(Guid.NewGuid(), "ai-riskreview-v1", "Existing"));
+        worksheetRepository.GetByNameAsync("ai-riskreview-v2", false).Returns((Worksheet?)null);
         worksheetRepository.InsertAsync(Arg.Do<Worksheet>(worksheet => createdDraft = worksheet), true)
             .Returns(Task.FromResult<Worksheet>(null!));
 
@@ -269,7 +269,7 @@ public class ApplicationFormVersionAppServiceTests(ITestOutputHelper outputHelpe
             SelectedFieldIds = worksheet.Sections.Single().Fields.Select(field => field.Id).ToList()
         });
 
-        createdDraft!.Name.ShouldBe("ai-risk-review-2");
+        createdDraft!.Name.ShouldBe("ai-riskreview-v2");
         createdDraft.Published.ShouldBeFalse();
         await customFieldRepository.Received(2).DeleteAsync(Arg.Any<Guid>());
         await worksheetRepository.Received(1).DeleteAsync(worksheet, true);
@@ -282,7 +282,7 @@ public class ApplicationFormVersionAppServiceTests(ITestOutputHelper outputHelpe
         var formId = Guid.NewGuid();
         var formVersionRepository = Substitute.For<IApplicationFormVersionRepository>();
         formVersionRepository.GetAsync(formVersionId).Returns(new ApplicationFormVersion { ApplicationFormId = formId });
-        var scoresheet = new Scoresheet(Guid.NewGuid(), "AI Scoresheet", $"ai-form-{formId}-version-{formVersionId}-scoresheet");
+        var scoresheet = new Scoresheet(Guid.NewGuid(), "AI Scoresheet", AiScoresheetSuggestionName.Build(formVersionId));
         scoresheet.Instances.Add(new Unity.Flex.Domain.ScoresheetInstances.ScoresheetInstance(Guid.NewGuid(), scoresheet.Id, Guid.NewGuid(), "FormVersion"));
         var scoresheetRepository = Substitute.For<IScoresheetRepository>();
         scoresheetRepository.GetByNameAsync(Arg.Any<string>(), true).Returns(scoresheet);
@@ -333,7 +333,7 @@ public class ApplicationFormVersionAppServiceTests(ITestOutputHelper outputHelpe
     {
         var worksheet = new Worksheet(
             Guid.NewGuid(),
-            AiWorksheetSuggestionName.Build(formId, formVersionId),
+            AiWorksheetSuggestionName.Build(formVersionId),
             "AI Worksheet");
         worksheet.SetPublished(published);
 

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/ApplicationForms/Mapping/AiDraftNameTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/ApplicationForms/Mapping/AiDraftNameTests.cs
@@ -1,0 +1,39 @@
+using Shouldly;
+using Xunit;
+
+namespace Unity.GrantManager.ApplicationForms.Mapping;
+
+public class AiDraftNameTests
+{
+    [Theory]
+    [InlineData("Risk Review", "riskreview")]
+    [InlineData("  RISK---Review!  ", "riskreview")]
+    [InlineData("École Grant", "écolegrant")]
+    public void NormalizeTitle_Should_Remove_Whitespace_And_Punctuation(string title, string expected)
+    {
+        AiDraftName.NormalizeTitle(title).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void BuildBaseName_Should_Prefix_Normalized_Title()
+    {
+        AiDraftName.BuildBaseName("Risk Review").ShouldBe("ai-riskreview");
+    }
+
+    [Fact]
+    public void BuildBaseName_Should_Use_Draft_When_Title_Has_No_Alphanumeric_Characters()
+    {
+        AiDraftName.BuildBaseName("!!!").ShouldBe("ai-draft");
+    }
+
+    [Fact]
+    public void Suggestion_Names_Should_Use_Only_Form_Version_Id()
+    {
+        var formVersionId = new System.Guid("11111111-2222-3333-4444-555555555555");
+
+        AiWorksheetSuggestionName.Build(formVersionId)
+            .ShouldBe("ai-11111111222233334444555555555555-worksheet");
+        AiScoresheetSuggestionName.Build(formVersionId)
+            .ShouldBe("ai-11111111222233334444555555555555-scoresheet");
+    }
+}


### PR DESCRIPTION
## Summary
- shorten internal AI worksheet and scoresheet suggestion identifiers
- name saved AI drafts with normalized titles and incrementing `-vN` versions
- preserve the existing subset review lifecycle and update related consumers/tests

## Validation
- Focused `ApplicationFormVersionAppServiceTests` and `AiDraftNameTests` passed (20 tests).