### PR TITLE
bugfix/AB#33566 - Fix Save Applicant Info when Project Summary zone disabled

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ProjectInfo/Default.js
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/ProjectInfo/Default.js
@@ -298,10 +298,15 @@ $(function () {
 });
 
 function calculatePercentage() {
+    const percentageElement = document.getElementById("ProjectInfo_PercentageTotalProjectBudget");
+    // The Project Summary zone can be hidden, in which case these fields are not rendered.
+    if (!percentageElement) {
+        return;
+    }
     const requestedAmount = Number.parseFloat(document.getElementById("RequestedAmountInputPI")?.value.replaceAll(',', ''));
     const totalProjectBudget = Number.parseFloat(document.getElementById("TotalBudgetInputPI")?.value.replaceAll(',', ''));
     if (Number.isNaN(requestedAmount) || Number.isNaN(totalProjectBudget) || totalProjectBudget == 0) {
-        document.getElementById("ProjectInfo_PercentageTotalProjectBudget").value = 0;
+        percentageElement.value = 0;
         return;
     }
     const percentage = ((requestedAmount / totalProjectBudget) * 100.00).toFixed(2);


### PR DESCRIPTION
This pull request updates `calculatePercentage` function in the `ProjectInfo` component's JavaScript. The change ensures that the function safely handles cases where the percentage field is not present in the DOM, preventing potential JavaScript errors when the Project Summary zone is hidden.

* Added a check to ensure the `ProjectInfo_PercentageTotalProjectBudget` element exists before attempting to use it, which prevents errors if the field is not rendered.