### PR TITLE
bugfix/AB#34303 - Published Status Visibility in Applicant List

### DIFF
--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/ApplicationRepository.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/ApplicationRepository.cs
@@ -512,9 +512,10 @@ public class ApplicationRepository
                     Status = a.Status,
                     ExternalStatusVisibility = a.ExternalStatusVisibility,
                     ExternalStatus = a.ExternalStatus,
+                    // For presentation, render as empty if unpublished
                     PublishedStatus = a.ExternalStatusVisibility
                         ? a.NotifiedStatus ?? a.ExternalStatus
-                        : a.ExternalStatus,
+                        : null,
                     Category = a.Category,
                     ApplicantId = a.ApplicantId,
                     ApplicantName = a.ApplicantName,


### PR DESCRIPTION
Updates the GetApplicationListRecordsAsync projection used by the Unity Grant Manager application list to prevent unpublished external statuses from being surfaced via the PublishedStatus field (so the UI can render it as blank when ExternalStatusVisibility is false).

Changes:

- Adjust PublishedStatus projection to return null when ExternalStatusVisibility is false (instead of echoing ExternalStatus).