### PR TITLE
feature/AB#33819 - Scheduled Notifications FYE Trigger

### DIFF
--- a/applications/Unity.GrantManager/modules/Unity.Notifications/src/Unity.Notifications.Domain/NotificationsDataSeedContributor.cs
+++ b/applications/Unity.GrantManager/modules/Unity.Notifications/src/Unity.Notifications.Domain/NotificationsDataSeedContributor.cs
@@ -42,6 +42,7 @@ public class NotificationsDataSeedContributor(ITemplateVariablesRepository templ
             new() { Name = "Registered Organization Name", Token = "organization_name", MapTo = "organizationName" },
             new() { Name = "Project Start Date", Token = "project_start_date", MapTo = "projectStartDate" },
             new() { Name = "Project End Date", Token = "project_end_date", MapTo = "projectEndDate" },
+            new() { Name = "Fiscal Year End", Token = "fiscal_year_end", MapTo = "applicant.fiscalYearEnd" },
             new() { Name = "Project Name", Token = "project_name", MapTo = "projectName" },
             new() { Name = "Project Summary", Token = "project_summary", MapTo = "projectSummary" },
             new() { Name = "Signing Authority Full Name", Token = "signing_authority_full_name", MapTo = "signingAuthorityFullName" },

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/GrantApplicationApplicant.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application.Contracts/GrantApplications/GrantApplicationApplicant.cs
@@ -22,5 +22,6 @@ public class GrantApplicationApplicantDto : AuditedEntityDto<Guid>
     public string UnityApplicantId { get; set; } = string.Empty;
     public string FiscalDay { get; set; } = string.Empty;
     public string FiscalMonth { get; set; } = string.Empty;
+    public DateOnly? FiscalYearEnd { get; set; }
     public string? ElectoralDistrict { get; set; }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Events/DateBasedScheduledNotificationJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Events/DateBasedScheduledNotificationJob.cs
@@ -6,8 +6,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Notifications;
-using Unity.Notifications.Emails;
+using Unity.GrantManager.Settings;
+using Unity.Modules.Shared.Utils;
 using Unity.Notifications.EmailGroups;
+using Unity.Notifications.Emails;
+using Unity.Notifications.Events;
 using Unity.Notifications.Settings;
 using Unity.Notifications.Templates;
 using Volo.Abp.BackgroundWorkers.Quartz;
@@ -17,19 +20,16 @@ using Volo.Abp.EventBus.Local;
 using Volo.Abp.Features;
 using Volo.Abp.Identity.Integration;
 using Volo.Abp.MultiTenancy;
+using Volo.Abp.SettingManagement;
 using Volo.Abp.Settings;
 using Volo.Abp.TenantManagement;
-using Unity.Notifications.Events;
-using Unity.Modules.Shared.Utils;
-using Unity.GrantManager.Settings;
-using Volo.Abp.SettingManagement;
 
 namespace Unity.GrantManager.Events
 {
     /// <summary>
     /// Quartz background job that runs nightly to process date-based scheduled notifications.
-    /// Checks if application trigger dates (DueDate, NotificationDate, ContractNotificationDate) have passed
-    /// and sends emails accordingly.
+    /// Checks if application trigger dates (DueDate, NotificationDate, ProjectStartDate, ProjectEndDate,
+    /// ContractExecutionDate, FiscalYearEnd) have passed and sends emails accordingly.
     /// </summary>
     [DisallowConcurrentExecution]
     public class DateBasedScheduledNotificationJob : QuartzBackgroundWorkerBase, ITransientDependency
@@ -203,16 +203,20 @@ namespace Unity.GrantManager.Events
                 }
 
                 var today = DateTime.UtcNow.Date;
+                var todayDateOnly = DateOnly.FromDateTime(today);
 
                 // OPTIMIZATION: Single query to get all applications for all forms with past dates
                 // Only queries applications where FormId exists in ScheduledNotifications with Date trigger type
+                // includeDetails: true is required to eager-load Applicant (needed for FiscalYearEnd matching)
                 var allApplications = (await _applicationRepository.GetListAsync(
                     a => formIds.Contains(a.ApplicationFormId)
                       && ((a.DueDate != null && a.DueDate <= today) ||
                           (a.ProjectStartDate != null && a.ProjectStartDate <= today) ||
                           (a.ProjectEndDate != null && a.ProjectEndDate <= today) ||
                           (a.NotificationDate != null && a.NotificationDate <= today) ||
-                          (a.ContractExecutionDate != null && a.ContractExecutionDate <= today))))
+                          (a.ContractExecutionDate != null && a.ContractExecutionDate <= today) ||
+                          (a.Applicant.FiscalYearEnd != null && a.Applicant.FiscalYearEnd <= todayDateOnly)),
+                    includeDetails: true))
                     .ToList();
 
                 if (allApplications.Count == 0)
@@ -349,10 +353,27 @@ namespace Unity.GrantManager.Events
                 "ProjectStartDate" => application.ProjectStartDate,
                 "ProjectEndDate" => application.ProjectEndDate,
                 "ContractExecutionDate" => application.ContractExecutionDate,
+                // The notification will not send if the FYE Date has no value
+                "FiscalYearEnd" => GetApplicantFiscalYearEnd(application) is { } fiscalYearEnd
+                    ? fiscalYearEnd.ToDateTime(TimeOnly.MinValue)
+                    : null,
                 _ => null
             };
 
             return triggerDate.HasValue && triggerDate.Value.Date <= today.Date;
+        }
+
+        // Applicant navigation throws if not eager-loaded, so guard access rather than returning null via ?.
+        private static DateOnly? GetApplicantFiscalYearEnd(Application application)
+        {
+            try
+            {
+                return application.Applicant.FiscalYearEnd;
+            }
+            catch (InvalidOperationException)
+            {
+                return null;
+            }
         }
 
         private async Task<ScheduledNotificationTracking?> ProcessApplicationForNotificationAsync(

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Events/DateBasedScheduledNotificationJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Events/DateBasedScheduledNotificationJob.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Notifications;
 using Unity.GrantManager.Settings;
+using static Unity.GrantManager.Notifications.NotificationDateFields;
 using Unity.Modules.Shared.Utils;
 using Unity.Notifications.EmailGroups;
 using Unity.Notifications.Emails;
@@ -215,7 +216,7 @@ namespace Unity.GrantManager.Events
                           (a.ProjectEndDate != null && a.ProjectEndDate <= today) ||
                           (a.NotificationDate != null && a.NotificationDate <= today) ||
                           (a.ContractExecutionDate != null && a.ContractExecutionDate <= today) ||
-                          (a.Applicant.FiscalYearEnd != null && a.Applicant.FiscalYearEnd <= todayDateOnly)),
+                          (a.Applicant != null && a.Applicant.FiscalYearEnd != null && a.Applicant.FiscalYearEnd <= todayDateOnly)),
                     includeDetails: true))
                     .ToList();
 
@@ -348,13 +349,13 @@ namespace Unity.GrantManager.Events
         {
             DateTime? triggerDate = dateField switch
             {
-                "NotificationDate" => application.NotificationDate,
-                "DueDate" => application.DueDate,
-                "ProjectStartDate" => application.ProjectStartDate,
-                "ProjectEndDate" => application.ProjectEndDate,
-                "ContractExecutionDate" => application.ContractExecutionDate,
+                NotificationDate => application.NotificationDate,
+                DueDate => application.DueDate,
+                ProjectStartDate => application.ProjectStartDate,
+                ProjectEndDate => application.ProjectEndDate,
+                ContractExecutionDate => application.ContractExecutionDate,
                 // The notification will not send if the FYE Date has no value
-                "FiscalYearEnd" => GetApplicantFiscalYearEnd(application) is { } fiscalYearEnd
+                FiscalYearEnd => GetApplicantFiscalYearEnd(application) is { } fiscalYearEnd
                     ? fiscalYearEnd.ToDateTime(TimeOnly.MinValue)
                     : null,
                 _ => null
@@ -363,17 +364,21 @@ namespace Unity.GrantManager.Events
             return triggerDate.HasValue && triggerDate.Value.Date <= today.Date;
         }
 
-        // Applicant navigation throws if not eager-loaded, so guard access rather than returning null via ?.
+        // Applicant is a required relationship (non-nullable ApplicantId), so it is never legitimately null;
+        // the getter only throws InvalidOperationException when the navigation was not eager-loaded.
         private static DateOnly? GetApplicantFiscalYearEnd(Application application)
         {
+            Applicant? applicant;
             try
             {
-                return application.Applicant.FiscalYearEnd;
+                applicant = application.Applicant;
             }
             catch (InvalidOperationException)
             {
                 return null;
             }
+
+            return applicant?.FiscalYearEnd;
         }
 
         private async Task<ScheduledNotificationTracking?> ProcessApplicationForNotificationAsync(

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Events/DateBasedScheduledNotificationJob.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Events/DateBasedScheduledNotificationJob.cs
@@ -204,21 +204,11 @@ namespace Unity.GrantManager.Events
                 }
 
                 var today = DateTime.UtcNow.Date;
-                var todayDateOnly = DateOnly.FromDateTime(today);
 
                 // OPTIMIZATION: Single query to get all applications for all forms with past dates
                 // Only queries applications where FormId exists in ScheduledNotifications with Date trigger type
-                // includeDetails: true is required to eager-load Applicant (needed for FiscalYearEnd matching)
-                var allApplications = (await _applicationRepository.GetListAsync(
-                    a => formIds.Contains(a.ApplicationFormId)
-                      && ((a.DueDate != null && a.DueDate <= today) ||
-                          (a.ProjectStartDate != null && a.ProjectStartDate <= today) ||
-                          (a.ProjectEndDate != null && a.ProjectEndDate <= today) ||
-                          (a.NotificationDate != null && a.NotificationDate <= today) ||
-                          (a.ContractExecutionDate != null && a.ContractExecutionDate <= today) ||
-                          (a.Applicant != null && a.Applicant.FiscalYearEnd != null && a.Applicant.FiscalYearEnd <= todayDateOnly)),
-                    includeDetails: true))
-                    .ToList();
+                // Only eager-loads Applicant (needed for FiscalYearEnd matching), not the full details graph
+                var allApplications = await _applicationRepository.GetListForDateBasedNotificationsAsync(formIds, today);
 
                 if (allApplications.Count == 0)
                 {

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Events/ScheduledNotificationHelper.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/Events/ScheduledNotificationHelper.cs
@@ -7,12 +7,9 @@ using System.Threading.Tasks;
 using Unity.GrantManager.Applications;
 using Unity.GrantManager.Notifications;
 using Unity.Notifications.EmailGroups;
-using Unity.Notifications.Emails;
 using Unity.Notifications.Events;
-using Unity.Notifications.Templates;
 using Volo.Abp.EventBus.Local;
 using Volo.Abp.Identity.Integration;
-using Volo.Abp.MultiTenancy;
 
 namespace Unity.GrantManager.Events
 {
@@ -63,6 +60,7 @@ namespace Unity.GrantManager.Events
                 ["project_summary"]             = application.ProjectSummary ?? string.Empty,
                 ["project_start_date"]          = application.ProjectStartDate?.ToString("yyyy-MM-dd") ?? string.Empty,
                 ["project_end_date"]            = application.ProjectEndDate?.ToString("yyyy-MM-dd") ?? string.Empty,
+                ["fiscal_year_end"]             = applicant?.FiscalYearEnd?.ToString("yyyy-MM-dd") ?? string.Empty,
                 ["signing_authority_full_name"] = application.SigningAuthorityFullName ?? string.Empty,
                 ["signing_authority_title"]     = application.SigningAuthorityTitle ?? string.Empty,
                 ["contact_full_name"]           = applicantAgent?.Name ?? string.Empty,

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/GrantApplicationAppService.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Application/GrantApplications/GrantApplicationAppService.cs
@@ -206,7 +206,8 @@ public class GrantApplicationAppService(
                     IndigenousOrgInd = rec.ApplicantIndigenousOrgInd ?? string.Empty,
                     UnityApplicantId = rec.ApplicantUnityApplicantId ?? string.Empty,
                     FiscalDay = rec.ApplicantFiscalDay?.ToString() ?? string.Empty,
-                    FiscalMonth = rec.ApplicantFiscalMonth ?? string.Empty
+                    FiscalMonth = rec.ApplicantFiscalMonth ?? string.Empty,
+                    FiscalYearEnd = rec.ApplicantFiscalYearEnd
                 },
                 OrganizationName = rec.ApplicantOrgName ?? string.Empty,
                 NonRegOrgName = rec.ApplicantNonRegOrgName ?? string.Empty,

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/ApplicationListRecord.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/ApplicationListRecord.cs
@@ -85,6 +85,7 @@ public class ApplicationListRecord
     public string? ApplicantIndigenousOrgInd { get; init; }
     public int? ApplicantFiscalDay { get; init; }
     public string? ApplicantFiscalMonth { get; init; }
+    public DateOnly? ApplicantFiscalYearEnd { get; init; }
     public string? ApplicantUnityApplicantId { get; init; }
 
     // ApplicantAgent (left-joined when present)

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/IApplicationRepository.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Applications/IApplicationRepository.cs
@@ -46,5 +46,9 @@ namespace Unity.GrantManager.Applications
 
         // Check whether any applications exist for the given applicant
         Task<bool> HasApplicationsByApplicantIdAsync(Guid applicantId);
+
+        // Lean list for the date-based notification job: only eager-loads Applicant (for FiscalYearEnd),
+        // avoiding the full details graph pulled in by includeDetails: true.
+        Task<List<Application>> GetListForDateBasedNotificationsAsync(List<Guid> formIds, DateTime today);
     }
 }

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Notifications/NotificationDateFields.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Domain/Notifications/NotificationDateFields.cs
@@ -1,0 +1,12 @@
+namespace Unity.GrantManager.Notifications;
+
+// Centralizes the DateField string identifiers shared by the scheduling job, the UI dropdown, and tests
+public static class NotificationDateFields
+{
+    public const string NotificationDate = "NotificationDate";
+    public const string DueDate = "DueDate";
+    public const string ProjectStartDate = "ProjectStartDate";
+    public const string ProjectEndDate = "ProjectEndDate";
+    public const string ContractExecutionDate = "ContractExecutionDate";
+    public const string FiscalYearEnd = "FiscalYearEnd";
+}

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/ApplicationRepository.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/ApplicationRepository.cs
@@ -344,6 +344,7 @@ public class ApplicationRepository
                 ApplicantIndigenousOrgInd = a.Applicant.IndigenousOrgInd,
                 ApplicantFiscalDay = a.Applicant.FiscalDay,
                 ApplicantFiscalMonth = a.Applicant.FiscalMonth,
+                ApplicantFiscalYearEnd = a.Applicant.FiscalYearEnd,
                 ApplicantUnityApplicantId = a.Applicant.UnityApplicantId,
             })
             .ToListAsync();
@@ -534,6 +535,7 @@ public class ApplicationRepository
                     ApplicantIndigenousOrgInd = a.ApplicantIndigenousOrgInd,
                     ApplicantFiscalDay = a.ApplicantFiscalDay,
                     ApplicantFiscalMonth = a.ApplicantFiscalMonth,
+                    ApplicantFiscalYearEnd = a.ApplicantFiscalYearEnd,
                     ApplicantUnityApplicantId = a.ApplicantUnityApplicantId,
                     ContactFullName = includeApplicantAgent ? agent.Name : null,
                     ContactTitle = includeApplicantAgent ? agent.Title : null,

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/ApplicationRepository.cs
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.EntityFrameworkCore/Repositories/ApplicationRepository.cs
@@ -230,6 +230,25 @@ public class ApplicationRepository
         return await query.AnyAsync(a => a.ApplicantId == applicantId);
     }
 
+    public async Task<List<Application>> GetListForDateBasedNotificationsAsync(List<Guid> formIds, DateTime today)
+    {
+        var todayDateOnly = DateOnly.FromDateTime(today);
+
+        var query = (await GetQueryableAsync())
+            .AsNoTracking()
+            .Include(a => a.Applicant);
+
+        return await query
+            .Where(a => formIds.Contains(a.ApplicationFormId)
+                && ((a.DueDate != null && a.DueDate <= today) ||
+                    (a.ProjectStartDate != null && a.ProjectStartDate <= today) ||
+                    (a.ProjectEndDate != null && a.ProjectEndDate <= today) ||
+                    (a.NotificationDate != null && a.NotificationDate <= today) ||
+                    (a.ContractExecutionDate != null && a.ContractExecutionDate <= today) ||
+                    (a.Applicant != null && a.Applicant.FiscalYearEnd != null && a.Applicant.FiscalYearEnd <= todayDateOnly)))
+            .ToListAsync();
+    }
+
     public async Task<List<ApplicationListRecord>> GetApplicationListRecordsAsync(
         int skipCount,
         int maxResultCount,

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/Notifications/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/Notifications/Default.cshtml
@@ -79,6 +79,7 @@
                                             <option value="ProjectStartDate">Project Start Date</option>
                                             <option value="ProjectEndDate">Project End Date</option>
                                             <option value="ContractExecutionDate">Contract Execution Date</option>
+                                            <option value="FiscalYearEnd">Fiscal Year End</option>
                                         </select>
                                         <div class="invalid-feedback">Please select a date type.</div>
                                     </div>

--- a/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/Notifications/Default.cshtml
+++ b/applications/Unity.GrantManager/src/Unity.GrantManager.Web/Views/Shared/Components/Notifications/Default.cshtml
@@ -1,6 +1,7 @@
 @model Unity.GrantManager.Web.Views.Shared.Components.Notifications.NotificationsViewModel
 @using Volo.Abp.Authorization.Permissions
 @using Unity.Notifications.Permissions;
+@using static Unity.GrantManager.Notifications.NotificationDateFields
 @inject IPermissionChecker PermissionChecker
 
 <link rel="stylesheet" href="/libs/select2/dist/css/select2.min.css" />
@@ -74,12 +75,12 @@
                                         <label for="dateType" class="form-label">Notification Date Type <span class="text-danger" aria-hidden="true">*</span></label>
                                         <select id="dateType" class="form-select" required>
                                             <option value=""></option>
-                                            <option value="NotificationDate">Notification Date</option>
-                                            <option value="DueDate">Due Date</option>
-                                            <option value="ProjectStartDate">Project Start Date</option>
-                                            <option value="ProjectEndDate">Project End Date</option>
-                                            <option value="ContractExecutionDate">Contract Execution Date</option>
-                                            <option value="FiscalYearEnd">Fiscal Year End</option>
+                                            <option value="@NotificationDate">Notification Date</option>
+                                            <option value="@DueDate">Due Date</option>
+                                            <option value="@ProjectStartDate">Project Start Date</option>
+                                            <option value="@ProjectEndDate">Project End Date</option>
+                                            <option value="@ContractExecutionDate">Contract Execution Date</option>
+                                            <option value="@FiscalYearEnd">Fiscal Year End</option>
                                         </select>
                                         <div class="invalid-feedback">Please select a date type.</div>
                                     </div>

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/Events/DateBasedScheduledNotificationJobTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/Events/DateBasedScheduledNotificationJobTests.cs
@@ -1,6 +1,6 @@
-using System;
 using Shouldly;
-using Unity.GrantManager.Events;
+using System;
+using Unity.GrantManager.Applications;
 using Xunit;
 using GrantApplication = Unity.GrantManager.Applications.Application;
 
@@ -104,6 +104,43 @@ public class DateBasedScheduledNotificationJobTests
         DateBasedScheduledNotificationJob.MatchesDateField(
             application,
             "UnknownDateField",
+            new DateTime(2026, 9, 10)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void MatchesDateField_WhenApplicantFiscalYearEndIsTodayOrPast_ReturnsTrue()
+    {
+        var today = new DateTime(2026, 9, 10);
+        var application = CreateApplication(Guid.NewGuid());
+
+        application.Applicant = new Applicant { FiscalYearEnd = DateOnly.FromDateTime(today).AddDays(-1) };
+        DateBasedScheduledNotificationJob.MatchesDateField(application, "FiscalYearEnd", today).ShouldBeTrue();
+
+        application.Applicant = new Applicant { FiscalYearEnd = DateOnly.FromDateTime(today) };
+        DateBasedScheduledNotificationJob.MatchesDateField(application, "FiscalYearEnd", today).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void MatchesDateField_WhenApplicantFiscalYearEndIsFutureOrMissing_ReturnsFalse()
+    {
+        var today = new DateTime(2026, 9, 10);
+        var application = CreateApplication(Guid.NewGuid());
+
+        application.Applicant = new Applicant { FiscalYearEnd = DateOnly.FromDateTime(today).AddDays(1) };
+        DateBasedScheduledNotificationJob.MatchesDateField(application, "FiscalYearEnd", today).ShouldBeFalse();
+
+        application.Applicant = new Applicant { FiscalYearEnd = null };
+        DateBasedScheduledNotificationJob.MatchesDateField(application, "FiscalYearEnd", today).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void MatchesDateField_WhenApplicantNavigationNotLoaded_ReturnsFalseForFiscalYearEnd()
+    {
+        var application = CreateApplication(Guid.NewGuid());
+
+        DateBasedScheduledNotificationJob.MatchesDateField(
+            application,
+            "FiscalYearEnd",
             new DateTime(2026, 9, 10)).ShouldBeFalse();
     }
 

--- a/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/Events/DateBasedScheduledNotificationJobTests.cs
+++ b/applications/Unity.GrantManager/test/Unity.GrantManager.Application.Tests/Events/DateBasedScheduledNotificationJobTests.cs
@@ -3,6 +3,7 @@ using System;
 using Unity.GrantManager.Applications;
 using Xunit;
 using GrantApplication = Unity.GrantManager.Applications.Application;
+using static Unity.GrantManager.Notifications.NotificationDateFields;
 
 namespace Unity.GrantManager.Events;
 
@@ -55,16 +56,16 @@ public class DateBasedScheduledNotificationJobTests
         application.DueDate = today.AddDays(-1);
         application.ProjectEndDate = today.AddDays(30);
 
-        DateBasedScheduledNotificationJob.MatchesDateField(application, "DueDate", today).ShouldBeTrue();
-        DateBasedScheduledNotificationJob.MatchesDateField(application, "ProjectEndDate", today).ShouldBeFalse();
+        DateBasedScheduledNotificationJob.MatchesDateField(application, DueDate, today).ShouldBeTrue();
+        DateBasedScheduledNotificationJob.MatchesDateField(application, ProjectEndDate, today).ShouldBeFalse();
     }
 
     [Theory]
-    [InlineData("NotificationDate")]
-    [InlineData("DueDate")]
-    [InlineData("ProjectStartDate")]
-    [InlineData("ProjectEndDate")]
-    [InlineData("ContractExecutionDate")]
+    [InlineData(NotificationDate)]
+    [InlineData(DueDate)]
+    [InlineData(ProjectStartDate)]
+    [InlineData(ProjectEndDate)]
+    [InlineData(ContractExecutionDate)]
     public void MatchesDateField_WhenConfiguredDateIsTodayOrPast_ReturnsTrue(string dateField)
     {
         var today = new DateTime(2026, 9, 10);
@@ -78,11 +79,11 @@ public class DateBasedScheduledNotificationJobTests
     }
 
     [Theory]
-    [InlineData("NotificationDate")]
-    [InlineData("DueDate")]
-    [InlineData("ProjectStartDate")]
-    [InlineData("ProjectEndDate")]
-    [InlineData("ContractExecutionDate")]
+    [InlineData(NotificationDate)]
+    [InlineData(DueDate)]
+    [InlineData(ProjectStartDate)]
+    [InlineData(ProjectEndDate)]
+    [InlineData(ContractExecutionDate)]
     public void MatchesDateField_WhenConfiguredDateIsFutureOrMissing_ReturnsFalse(string dateField)
     {
         var today = new DateTime(2026, 9, 10);
@@ -114,10 +115,10 @@ public class DateBasedScheduledNotificationJobTests
         var application = CreateApplication(Guid.NewGuid());
 
         application.Applicant = new Applicant { FiscalYearEnd = DateOnly.FromDateTime(today).AddDays(-1) };
-        DateBasedScheduledNotificationJob.MatchesDateField(application, "FiscalYearEnd", today).ShouldBeTrue();
+        DateBasedScheduledNotificationJob.MatchesDateField(application, FiscalYearEnd, today).ShouldBeTrue();
 
         application.Applicant = new Applicant { FiscalYearEnd = DateOnly.FromDateTime(today) };
-        DateBasedScheduledNotificationJob.MatchesDateField(application, "FiscalYearEnd", today).ShouldBeTrue();
+        DateBasedScheduledNotificationJob.MatchesDateField(application, FiscalYearEnd, today).ShouldBeTrue();
     }
 
     [Fact]
@@ -127,10 +128,10 @@ public class DateBasedScheduledNotificationJobTests
         var application = CreateApplication(Guid.NewGuid());
 
         application.Applicant = new Applicant { FiscalYearEnd = DateOnly.FromDateTime(today).AddDays(1) };
-        DateBasedScheduledNotificationJob.MatchesDateField(application, "FiscalYearEnd", today).ShouldBeFalse();
+        DateBasedScheduledNotificationJob.MatchesDateField(application, FiscalYearEnd, today).ShouldBeFalse();
 
         application.Applicant = new Applicant { FiscalYearEnd = null };
-        DateBasedScheduledNotificationJob.MatchesDateField(application, "FiscalYearEnd", today).ShouldBeFalse();
+        DateBasedScheduledNotificationJob.MatchesDateField(application, FiscalYearEnd, today).ShouldBeFalse();
     }
 
     [Fact]
@@ -140,7 +141,7 @@ public class DateBasedScheduledNotificationJobTests
 
         DateBasedScheduledNotificationJob.MatchesDateField(
             application,
-            "FiscalYearEnd",
+            FiscalYearEnd,
             new DateTime(2026, 9, 10)).ShouldBeFalse();
     }
 
@@ -156,19 +157,19 @@ public class DateBasedScheduledNotificationJobTests
     {
         switch (dateField)
         {
-            case "NotificationDate":
+            case NotificationDate:
                 application.NotificationDate = value;
                 break;
-            case "DueDate":
+            case DueDate:
                 application.DueDate = value;
                 break;
-            case "ProjectStartDate":
+            case ProjectStartDate:
                 application.ProjectStartDate = value;
                 break;
-            case "ProjectEndDate":
+            case ProjectEndDate:
                 application.ProjectEndDate = value;
                 break;
-            case "ContractExecutionDate":
+            case ContractExecutionDate:
                 application.ContractExecutionDate = value;
                 break;
         }

--- a/documentation/notifications/notifications-scheduled-notifications.md
+++ b/documentation/notifications/notifications-scheduled-notifications.md
@@ -120,6 +120,7 @@ The tokens produced:
 |`category`|`ApplicationForm.Category`|
 |`today_date`|`DateTime.Today` as `MMMM d, yyyy`|
 |`unity_application_id`|`UnityApplicationId`|
+|`fiscal_year_end`| `applicant.fiscalYearEnd` |
 
 These must stay in sync with the `TemplateVariable` rows seeded by `NotificationsDataSeedContributor`, which is what the template editor offers the user. The seed's `MapTo` column is documentation of intent — the actual resolution is this hand-written dictionary, not reflection over `MapTo`. Adding a variable therefore takes **two** edits: a seed row and a dictionary entry.
 


### PR DESCRIPTION
# Pull request overview

Adds fiscal-year-end support to scheduled notifications and email template tokens.

**Changes:**
- Adds centralized notification date-field constants.
- Supports applicant fiscal year end in matching, querying, UI, and templates.
- Adds focused fiscal-year-end matching tests.
</details>

<details>
<summary>File summaries</summary>

| File | Description |
| ---- | ----------- |
| `DateBasedScheduledNotificationJobTests.cs` | Tests fiscal-year-end matching. |
| `Default.cshtml` | Adds the FYE trigger option. |
| `NotificationDateFields.cs` | Centralizes date-field identifiers. |
| `ScheduledNotificationHelper.cs` | Adds the FYE template token. |
| `DateBasedScheduledNotificationJob.cs` | Queries and matches applicant FYE dates. |
| `NotificationsDataSeedContributor.cs` | Seeds the FYE template variable. |
</details>